### PR TITLE
Add Claude Code harness and gh wrapper for draft PR enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Follows Martin Fowler's [harness-engineering](https://martinfowler.com/articles/
 
 - `dot_claude/CLAUDE.md` — cross-machine guide (PR defaults, feedback preference, scope discipline). Per-project `CLAUDE.md` overrides.
 - `dot_claude/settings.json` — hook wiring. No permission allowlist yet; add entries with the `fewer-permission-prompts` skill once prompts become repetitive.
-- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking `mcp__github__create_pull_request` calls that omit `draft=true`. Deterministic backstop for the CLAUDE.md rule.
+- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking PR-creation calls that don't request a draft. Covers `mcp__github__create_pull_request` (and the copilot variant) when `draft` isn't `true`, and `gh pr create` via `Bash` when `--draft`/`-d` isn't passed.
 
 Prefer a hook over a CLAUDE.md bullet when the rule must not be forgotten mid-session; prefer the bullet when the rule is preference, not policy.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Only projects, tasks, and subtasks are synced — sessions, worktrees, PIDs, and
 - `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — managed shell + git config.
 - `dot_claude/` — user-level Claude Code harness (see below). Runtime state (`.credentials.json`, session history, project scratch) stays machine-local.
 - `dot_claustre/config.toml` — Claustre's user config. Currently sets `sync.auto_push = true` so task/project state pushes to the companion `alunduil-claustre-state` repo automatically. Runtime state (DB, sockets, worktrees) stays machine-local.
+- `dot_local/bin/gh` — wrapper that shadows apt's `/usr/bin/gh` to enforce `--draft` on `gh pr create`. See below.
 
 ## Claude Code harness
 
@@ -71,9 +72,10 @@ Follows Martin Fowler's [harness-engineering](https://martinfowler.com/articles/
 
 - `dot_claude/CLAUDE.md` — cross-machine guide (PR defaults, feedback preference, scope discipline). Per-project `CLAUDE.md` overrides.
 - `dot_claude/settings.json` — hook wiring. No permission allowlist yet; add entries with the `fewer-permission-prompts` skill once prompts become repetitive.
-- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking PR-creation calls that don't request a draft. Covers `mcp__github__create_pull_request` (and the copilot variant) when `draft` isn't `true`, and `gh pr create` via `Bash` when `--draft`/`-d` isn't passed.
+- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking `mcp__github__create_pull_request` (and the copilot variant) when `draft=true` is missing. Pure JSON-field check; no shell-string parsing.
+- `dot_local/bin/gh` — PATH shim covering the `gh pr create` path. Intercepts the actual invocation, so nothing reaches the real binary without `--draft` unless `GH_DRAFT_GUARD=off` is set. The wrapper approach sidesteps the false-positive risk of string-matching `Bash` commands in a hook.
 
-Prefer a hook over a CLAUDE.md bullet when the rule must not be forgotten mid-session; prefer the bullet when the rule is preference, not policy.
+Prefer a hook over a CLAUDE.md bullet when the rule must not be forgotten mid-session; prefer the bullet when the rule is preference, not policy. Prefer a PATH shim over a hook when the rule can be enforced by intercepting the binary itself — it covers any way the model reaches for the tool.
 
 ## Bootstrap script
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,50 @@
 # alunduil-chezmoi
 
-Dotfiles for Alex Brandt's Crostini / Chromebook workstation, managed by [chezmoi](https://chezmoi.io). Bootstraps a Claude Code + [Claustre](https://github.com/pmbrull/claustre) + [Zellij](https://zellij.dev) multi-session workflow on a fresh Debian/Crostini host.
+Personal dotfiles for [@alunduil](https://github.com/alunduil), managed by [chezmoi](https://chezmoi.io). Bootstraps a Claude Code + [Claustre](https://github.com/pmbrull/claustre) + [Zellij](https://zellij.dev) workflow on a fresh Debian/Crostini host. Source: <https://github.com/alunduil/alunduil-chezmoi>.
 
-## Disaster recovery — fresh machine bootstrap
+Personal config — no warranty, no support, fork freely.
 
-The whole setup must rebuild from this repo plus the age key stored in a password manager. On a fresh Crostini container:
+## Bootstrap
+
+Requires a Debian/Crostini host and the age key from a password manager.
 
 ```bash
-# 1. Install chezmoi itself (no apt package — canonical installer to ~/.local/bin)
 sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
 
-# 2. Restore the age key from the password manager
 mkdir -p ~/.config/chezmoi
-$EDITOR ~/.config/chezmoi/key.txt     # paste key contents
+$EDITOR ~/.config/chezmoi/key.txt          # paste age key contents
 chmod 600 ~/.config/chezmoi/key.txt
 
-# 3. Initialize + apply. Clones the source, runs the install script, writes
-#    managed files. The install script needs sudo for apt.
 ~/.local/bin/chezmoi init --apply git@github.com:alunduil/alunduil-chezmoi.git
 
-# 4. Log in to remote services (interactive — not managed by chezmoi)
-gh auth login
-claude                 # first launch prompts for the Anthropic login
-sudo tailscale up      # opens a browser to join the tailnet
-claustre configure     # checks prereqs, wires up Claude Code permissions
+# Interactive logins (per-machine, never managed):
+gh auth login                              # ~/.config/gh/
+claude                                     # ~/.claude/.credentials.json
+sudo tailscale up                          # tailnet auth
+claustre configure                         # wires up Claude Code permissions
 ```
 
-If SSH auth to GitHub isn't set up yet, clone over HTTPS first (`https://github.com/alunduil/alunduil-chezmoi.git`) and swap the remote once keys are in place.
-
-## Manual steps (not automated by this repo)
-
-By design — none of these should ever enter the repo:
-
-- **Anthropic / Claude Code login** — lives in `~/.claude/.credentials.json`
-- **GitHub CLI login** — `gh auth login`, stored under `~/.config/gh/`
-- **age key** — `~/.config/chezmoi/key.txt`, restored from password manager. The key that decrypts this repo cannot live inside it.
-- **SSH keys** — generated per machine, public half uploaded to GitHub
-- **Tailscale auth** — `sudo tailscale up` opens a browser for tailnet auth. Per-machine, not syncable (auth keys are bound to the node identity).
+If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.
 
 ## Companion repo
 
-`alunduil-claustre-state` (planned, private): holds Claustre's cross-machine task/project state. Claustre syncs into `~/.claustre/sync/`. Bootstrap on a new machine with:
+`alunduil-claustre-state` (planned, private) holds Claustre's cross-machine task/project state:
 
 ```bash
 claustre sync init git@github.com:alunduil/alunduil-claustre-state.git
 claustre sync pull
 ```
 
-Only projects, tasks, and subtasks are synced — sessions, worktrees, PIDs, and rate-limit state stay local.
-
-## Intentionally NOT in this repo
-
-- Plaintext API keys, session tokens, or credentials of any kind
-- `~/.claude/.credentials.json`, Claude Code session history, or any runtime state
-- `~/.claustre/db/` or other Claustre runtime state
-- The age private key (password manager only)
-- Node, Rust, or chezmoi binaries (install script uses canonical installers)
-- Project-level Claude Code state (`projects/`, `todos/`, `shell-snapshots/`, `statsig/`, `.credentials.json`, session history) — only the user-level harness files under `dot_claude/` are synced
-- `~/.claustre/` runtime state (`claustre.db`, `sockets/`, `pids/`, `worktrees/`, `tmp/`, `hooks/`, `sync/`) — machine-local by design; only `config.toml` is managed
+Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-limit state stay local.
 
 ## Layout
 
-- `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — managed shell + git config.
-- `dot_claude/` — user-level Claude Code harness (see below). Runtime state (`.credentials.json`, session history, project scratch) stays machine-local.
-- `dot_claustre/config.toml` — Claustre's user config. Currently sets `sync.auto_push = true` so task/project state pushes to the companion `alunduil-claustre-state` repo automatically. Runtime state (DB, sockets, worktrees) stays machine-local.
-- `dot_local/bin/gh` — wrapper that shadows apt's `/usr/bin/gh` to enforce `--draft` on `gh pr create`. See below.
+- `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell + git config.
+- `dot_claude/` — user-level Claude Code harness: `CLAUDE.md` rules, `settings.json` hook wiring, `hooks/pr-draft-guard.sh` blocking non-draft PRs over the GitHub MCP tools. Per-project sensors (tests/linters/types) stay with the project.
+- `dot_claustre/config.toml` — Claustre user config (`sync.auto_push = true`).
+- `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
+- `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap (apt packages, Tailscale, Zellij, nvm/Node, `@anthropic-ai/claude-code`, rustup/Claustre).
 
-## Claude Code harness
+## Never in the repo
 
-Follows Martin Fowler's [harness-engineering](https://martinfowler.com/articles/harness-engineering.html) split: *guides* (feedforward — shape behaviour before the model acts) sync across machines; *sensors* (feedback — tests, linters, type-checkers) belong to each project and are not in this repo. Intentionally lean; grow a rule only when the same friction shows up in more than one project.
-
-- `dot_claude/CLAUDE.md` — cross-machine guide (PR defaults, feedback preference, scope discipline). Per-project `CLAUDE.md` overrides.
-- `dot_claude/settings.json` — hook wiring. No permission allowlist yet; add entries with the `fewer-permission-prompts` skill once prompts become repetitive.
-- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking `mcp__github__create_pull_request` (and the copilot variant) when `draft=true` is missing. Pure JSON-field check; no shell-string parsing.
-- `dot_local/bin/gh` — PATH shim covering the `gh pr create` path. Intercepts the actual invocation, so nothing reaches the real binary without `--draft` unless `GH_DRAFT_GUARD=off` is set. The wrapper approach sidesteps the false-positive risk of string-matching `Bash` commands in a hook.
-
-Prefer a hook over a CLAUDE.md bullet when the rule must not be forgotten mid-session; prefer the bullet when the rule is preference, not policy. Prefer a PATH shim over a hook when the rule can be enforced by intercepting the binary itself — it covers any way the model reaches for the tool.
-
-## Bootstrap script
-
-- `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap: apt packages (`gh zsh ripgrep fd-find jq unzip age`), Tailscale via its official installer (system daemon, enables `tailscaled.service`), zellij from the upstream GitHub release (pinned, sha256-verified; Debian bookworm doesn't package it), nvm + Node LTS, `@anthropic-ai/claude-code`, rustup + `claustre` from git, and the `~/.config/zellij/plugins/` directory that zellaude auto-populates on first Zellij load. Re-runs whenever its content hash changes.
+Credentials of any kind, runtime state (`.credentials.json`, session history, `~/.claustre/db/`), the age private key, SSH private keys, and toolchain binaries (chezmoi/Node/Rust install via canonical installers).

--- a/README.md
+++ b/README.md
@@ -56,11 +56,25 @@ Only projects, tasks, and subtasks are synced — sessions, worktrees, PIDs, and
 - `~/.claustre/db/` or other Claustre runtime state
 - The age private key (password manager only)
 - Node, Rust, or chezmoi binaries (install script uses canonical installers)
-- `~/.claude/` configs (deferred — will be added once real usage informs what's worth syncing)
+- Project-level Claude Code state (`projects/`, `todos/`, `shell-snapshots/`, `statsig/`, `.credentials.json`, session history) — only the user-level harness files under `dot_claude/` are synced
 - `~/.claustre/` runtime state (`claustre.db`, `sockets/`, `pids/`, `worktrees/`, `tmp/`, `hooks/`, `sync/`) — machine-local by design; only `config.toml` is managed
 
 ## Layout
 
 - `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — managed shell + git config.
+- `dot_claude/` — user-level Claude Code harness (see below). Runtime state (`.credentials.json`, session history, project scratch) stays machine-local.
 - `dot_claustre/config.toml` — Claustre's user config. Currently sets `sync.auto_push = true` so task/project state pushes to the companion `alunduil-claustre-state` repo automatically. Runtime state (DB, sockets, worktrees) stays machine-local.
+
+## Claude Code harness
+
+Follows Martin Fowler's [harness-engineering](https://martinfowler.com/articles/harness-engineering.html) split: *guides* (feedforward — shape behaviour before the model acts) sync across machines; *sensors* (feedback — tests, linters, type-checkers) belong to each project and are not in this repo. Intentionally lean; grow a rule only when the same friction shows up in more than one project.
+
+- `dot_claude/CLAUDE.md` — cross-machine guide (PR defaults, feedback preference, scope discipline). Per-project `CLAUDE.md` overrides.
+- `dot_claude/settings.json` — hook wiring. No permission allowlist yet; add entries with the `fewer-permission-prompts` skill once prompts become repetitive.
+- `dot_claude/hooks/pr-draft-guard.sh` — `PreToolUse` hook blocking `mcp__github__create_pull_request` calls that omit `draft=true`. Deterministic backstop for the CLAUDE.md rule.
+
+Prefer a hook over a CLAUDE.md bullet when the rule must not be forgotten mid-session; prefer the bullet when the rule is preference, not policy.
+
+## Bootstrap script
+
 - `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap: apt packages (`gh zsh ripgrep fd-find jq unzip age`), Tailscale via its official installer (system daemon, enables `tailscaled.service`), zellij from the upstream GitHub release (pinned, sha256-verified; Debian bookworm doesn't package it), nvm + Node LTS, `@anthropic-ai/claude-code`, rustup + `claustre` from git, and the `~/.config/zellij/plugins/` directory that zellaude auto-populates on first Zellij load. Re-runs whenever its content hash changes.

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -12,9 +12,9 @@ reliable enough.
 ## Pull requests
 
 - Open every PR as a draft. The user promotes to ready after reviewing.
-  Enforced by `~/.claude/hooks/pr-draft-guard.sh`; this bullet is the
-  backup for code paths the hook does not cover (e.g. `gh pr create`
-  invoked through Bash).
+  Enforced by `~/.claude/hooks/pr-draft-guard.sh` for both the GitHub
+  MCP tools and `gh pr create` via Bash. This bullet stays as the
+  reminder for any future path the hook doesn't yet cover.
 
 ## Feedback preference
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,0 +1,36 @@
+# Claude Code -- user-level guide
+
+Cross-machine defaults for every Claude Code session on this host. A per-repo
+`CLAUDE.md` overrides anything here.
+
+Framed on Martin Fowler's harness-engineering model: this file is a *guide*
+(feedforward -- steers behaviour before an action). Deterministic *sensors*
+(tests, linters, type-checkers) live per-project, not here. Hooks in
+`settings.json` enforce the rules below for the cases where text alone is not
+reliable enough.
+
+## Pull requests
+
+- Open every PR as a draft. The user promotes to ready after reviewing.
+  Enforced by `~/.claude/hooks/pr-draft-guard.sh`; this bullet is the
+  backup for code paths the hook does not cover (e.g. `gh pr create`
+  invoked through Bash).
+
+## Feedback preference
+
+- Run the project's computational sensors (tests, linters, type checker,
+  formatter) before claiming a task is done. Use inferential review
+  (another LLM reading the diff) to catch what those miss, not as a
+  substitute for them.
+
+## Scope
+
+- Fix the task that was asked. Don't refactor, rename, or tidy adjacent
+  code in the same change unless explicitly requested.
+
+## Growing this file
+
+Add a rule here once the same friction shows up in more than one project.
+If a rule needs to be deterministic (Claude must not be able to forget it),
+pair it with a hook in `settings.json` instead of -- or in addition to --
+a bullet here.

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -12,9 +12,12 @@ reliable enough.
 ## Pull requests
 
 - Open every PR as a draft. The user promotes to ready after reviewing.
-  Enforced by `~/.claude/hooks/pr-draft-guard.sh` for both the GitHub
-  MCP tools and `gh pr create` via Bash. This bullet stays as the
-  reminder for any future path the hook doesn't yet cover.
+  Two deterministic enforcers cover the paths the model can take:
+  `~/.claude/hooks/pr-draft-guard.sh` blocks the GitHub MCP tools
+  (`mcp__github__create_pull_request` and its copilot variant) when
+  `draft=true` is missing, and `~/.local/bin/gh` shadows the apt `gh`
+  binary to require `--draft`/`-d` on `gh pr create`. Override
+  intentionally with `GH_DRAFT_GUARD=off gh pr create ...`.
 
 ## Feedback preference
 

--- a/dot_claude/hooks/executable_pr-draft-guard.sh
+++ b/dot_claude/hooks/executable_pr-draft-guard.sh
@@ -24,5 +24,23 @@ EOF
       exit 2
     fi
     ;;
+  Bash)
+    command="$(jq -r '.tool_input.command // empty' <<<"$input")"
+    # `gh pr create` as a standalone invocation -- word-ish boundaries so
+    # quoted/echoed forms and unrelated gh subcommands (gh pr view, gh
+    # pr-create-foo) don't match.
+    if printf '%s' "$command" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+create([^[:alnum:]_]|$)'; then
+      # Allow `--draft` or `-d` as a whole token (not a substring of another
+      # flag). gh's `-d` is the short form for `--draft`; no conflict on
+      # `gh pr create`.
+      if ! printf '%s' "$command" | grep -qE '(^|[[:space:]])(--draft|-d)([[:space:]=]|$)'; then
+        cat >&2 <<'EOF'
+Blocked by ~/.claude/hooks/pr-draft-guard.sh: `gh pr create` must include --draft.
+Retry the command with --draft (or -d). The user will mark it ready after reviewing.
+EOF
+        exit 2
+      fi
+    fi
+    ;;
 esac
 exit 0

--- a/dot_claude/hooks/executable_pr-draft-guard.sh
+++ b/dot_claude/hooks/executable_pr-draft-guard.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# PreToolUse hook: require PRs to be opened as drafts.
+# PreToolUse hook: require PRs from the GitHub MCP tools to be drafts.
 #
-# User-level harness rule: every PR starts as a draft so the human can
-# review before it advertises itself as ready. Deterministic enforcement
-# because a CLAUDE.md bullet is easy to forget mid-session.
+# The `gh pr create` path is enforced separately by ~/.local/bin/gh
+# (a PATH shim), so this hook only has to cover the MCP tools that
+# call GitHub's API directly and never touch the gh binary.
 #
 # Input: Claude Code PreToolUse JSON on stdin.
-# Exit 0 = allow; exit 2 = block and send stderr back to Claude as feedback.
+# Exit 0 = allow; exit 2 = block and send stderr back to Claude.
 
 set -euo pipefail
 
@@ -22,24 +22,6 @@ Blocked by ~/.claude/hooks/pr-draft-guard.sh: PRs must be opened as drafts.
 Retry the same call with draft=true. The user will mark it ready after reviewing.
 EOF
       exit 2
-    fi
-    ;;
-  Bash)
-    command="$(jq -r '.tool_input.command // empty' <<<"$input")"
-    # `gh pr create` as a standalone invocation -- word-ish boundaries so
-    # quoted/echoed forms and unrelated gh subcommands (gh pr view, gh
-    # pr-create-foo) don't match.
-    if printf '%s' "$command" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+create([^[:alnum:]_]|$)'; then
-      # Allow `--draft` or `-d` as a whole token (not a substring of another
-      # flag). gh's `-d` is the short form for `--draft`; no conflict on
-      # `gh pr create`.
-      if ! printf '%s' "$command" | grep -qE '(^|[[:space:]])(--draft|-d)([[:space:]=]|$)'; then
-        cat >&2 <<'EOF'
-Blocked by ~/.claude/hooks/pr-draft-guard.sh: `gh pr create` must include --draft.
-Retry the command with --draft (or -d). The user will mark it ready after reviewing.
-EOF
-        exit 2
-      fi
     fi
     ;;
 esac

--- a/dot_claude/hooks/executable_pr-draft-guard.sh
+++ b/dot_claude/hooks/executable_pr-draft-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PreToolUse hook: require PRs to be opened as drafts.
+#
+# User-level harness rule: every PR starts as a draft so the human can
+# review before it advertises itself as ready. Deterministic enforcement
+# because a CLAUDE.md bullet is easy to forget mid-session.
+#
+# Input: Claude Code PreToolUse JSON on stdin.
+# Exit 0 = allow; exit 2 = block and send stderr back to Claude as feedback.
+
+set -euo pipefail
+
+input="$(cat)"
+tool_name="$(jq -r '.tool_name // empty' <<<"$input")"
+
+case "$tool_name" in
+  mcp__github__create_pull_request|mcp__github__create_pull_request_with_copilot)
+    draft="$(jq -r '.tool_input.draft // false' <<<"$input")"
+    if [ "$draft" != "true" ]; then
+      cat >&2 <<'EOF'
+Blocked by ~/.claude/hooks/pr-draft-guard.sh: PRs must be opened as drafts.
+Retry the same call with draft=true. The user will mark it ready after reviewing.
+EOF
+      exit 2
+    fi
+    ;;
+esac
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "mcp__github__create_pull_request(_with_copilot)?",
+        "matcher": "mcp__github__create_pull_request(_with_copilot)?|Bash",
         "hooks": [
           {
             "type": "command",

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__create_pull_request(_with_copilot)?",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/pr-draft-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "mcp__github__create_pull_request(_with_copilot)?|Bash",
+        "matcher": "mcp__github__create_pull_request(_with_copilot)?",
         "hooks": [
           {
             "type": "command",

--- a/dot_local/bin/executable_gh
+++ b/dot_local/bin/executable_gh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shim for `gh` that enforces --draft on `gh pr create`. Shadows the apt-
+# installed /usr/bin/gh because ~/.local/bin sits ahead of /usr/bin on PATH
+# (see ~/.profile). Everything other than `gh pr create` is a plain exec
+# passthrough, so there is no behavioural surprise for other subcommands.
+#
+# Bypass (for when the human genuinely wants a ready PR):
+#   GH_DRAFT_GUARD=off gh pr create ...
+# or invoke the real binary directly:
+#   /usr/bin/gh pr create ...
+#   command -p gh pr create ...
+#
+# Intentional limitation: the draft-detector is a whole-token scan, not a
+# full parse of gh's flag grammar. If someone passes `-d` as the *value* of
+# another flag (e.g. `--title -d`) the wrapper would mistake it for --draft.
+# Nobody writes that; correctness here isn't worth embedding a gh parser.
+
+set -euo pipefail
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ] && [ "${GH_DRAFT_GUARD:-}" != "off" ]; then
+  has_draft=0
+  for arg in "${@:3}"; do
+    case "$arg" in
+      --draft|-d) has_draft=1; break ;;
+    esac
+  done
+  if [ "$has_draft" -eq 0 ]; then
+    cat >&2 <<'EOF'
+gh wrapper (~/.local/bin/gh): `gh pr create` must include --draft (or -d).
+Retry with the flag, or, to open a ready PR on purpose:
+  GH_DRAFT_GUARD=off gh pr create ...
+EOF
+    exit 1
+  fi
+fi
+
+# Find the real gh: first executable `gh` in PATH that isn't this script.
+self="$(readlink -f "$0")"
+IFS=':' read -r -a path_dirs <<<"${PATH:-}"
+for dir in "${path_dirs[@]}"; do
+  [ -n "$dir" ] || continue
+  candidate="$dir/gh"
+  [ -x "$candidate" ] || continue
+  [ "$(readlink -f "$candidate" 2>/dev/null)" = "$self" ] && continue
+  exec "$candidate" "$@"
+done
+
+printf 'gh wrapper: real gh not found on PATH\n' >&2
+exit 127


### PR DESCRIPTION
## Summary

Adds user-level Claude Code configuration and tooling to enforce draft-first PR workflows, plus comprehensive documentation updates to clarify the repository's purpose and bootstrap process.

## Key Changes

- **Claude Code harness** (`dot_claude/`):
  - `CLAUDE.md`: User-level guide documenting cross-machine defaults (draft PRs, feedback preferences, scope discipline)
  - `settings.json`: Wires up PreToolUse hooks to enforce draft requirement on GitHub MCP tools
  - `hooks/pr-draft-guard.sh`: Bash hook that blocks `mcp__github__create_pull_request` calls when `draft=true` is missing

- **gh CLI wrapper** (`dot_local/bin/executable_gh`):
  - Shadows the apt-installed `/usr/bin/gh` to require `--draft`/`-d` on `gh pr create`
  - Passes through all other subcommands unchanged
  - Provides bypass mechanism via `GH_DRAFT_GUARD=off` environment variable or direct invocation of `/usr/bin/gh`

- **Documentation overhaul** (README.md):
  - Simplified opening to clarify this is personal dotfiles with no warranty
  - Condensed bootstrap instructions into a single focused code block
  - Reorganized manual steps and layout sections for clarity
  - Explicitly lists what is never stored in the repo (credentials, runtime state, keys)

## Implementation Details

The draft enforcement uses a two-layer approach:
1. **MCP tools** (GitHub API calls): Blocked by the PreToolUse hook in `settings.json`
2. **gh CLI**: Blocked by the PATH shim that scans arguments for `--draft`/`-d` flags

The gh wrapper uses a simple whole-token scan rather than full flag parsing, accepting the limitation that flag values cannot be mistaken for the draft flag itself (an edge case that doesn't occur in practice).

https://claude.ai/code/session_01SHznU4iSQijkfYEiUTRvmp