### PR TITLE
add readwise CLI to bootstrap script

### DIFF
--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -98,6 +98,14 @@ else
   log "claude-code: already installed"
 fi
 
+# ----------------------------------------------------------- Readwise CLI
+if ! command -v readwise >/dev/null 2>&1; then
+  log "readwise-cli: npm install -g @readwise/cli"
+  npm install -g @readwise/cli
+else
+  log "readwise-cli: already installed"
+fi
+
 # ---------------------------------------------------------- rustup + claustre
 if ! command -v cargo >/dev/null 2>&1; then
   log "rustup: installing stable toolchain"


### PR DESCRIPTION
## Summary

- Adds `@readwise/cli` (npm) to the bootstrap install script, placed after Claude Code since both require Node/npm
- Follows the same idempotent pattern: skip if `readwise` is already on PATH, install otherwise

## Test plan

- Verified shellcheck passes on the rendered bootstrap script
- Verified JSON syntax check passes on settings.json