### PR TITLE
Alt+p: floating picker over local clones, gh repos, and create-new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
             < run_once_before_install-packages.sh.tmpl > /tmp/bootstrap.sh
           shellcheck /tmp/bootstrap.sh
           shellcheck dot_local/bin/executable_gh
+          shellcheck dot_local/bin/executable_pair-start
           shellcheck dot_claude/hooks/executable_pr-draft-guard.sh
 
       - name: chezmoi dry-run

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus, ghost, notepad — all pinned to release tags), status bars, and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
 - `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
-- `dot_local/bin/pair-start` — floating fzf picker bound to `Alt+p`. Unifies git checkouts in `~/*`, `gh repo list`, and a "create new" fallback (typed name, or `owner/repo` to clone — both placed in `~`), then opens the pair layout in a new tab with the chosen cwd.
+- `dot_local/bin/pair-start` — floating fzf picker bound to `Alt+p`. Unifies git checkouts in `~/*` and `gh repo list`; a no-match query creates `~/<query>` (the list already covers everything cloneable, so a miss means "new directory"). Then opens the pair layout in a new tab with the chosen cwd.
 - `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap (apt packages, Tailscale, Zellij, lazygit, nvm/Node, `@anthropic-ai/claude-code`, rustup/Claustre).
 
 ## Never in the repo

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus, ghost, notepad — all pinned to release tags), status bars, and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
 - `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
-- `dot_local/bin/pair-start` — floating fzf picker bound to `Alt+p`. Unifies `~/pair/*` clones, `gh repo list`, and a "create new" fallback (typed name, or `owner/repo` to clone), then opens the pair layout in a new tab with the chosen cwd.
+- `dot_local/bin/pair-start` — floating fzf picker bound to `Alt+p`. Unifies git checkouts in `~/*`, `gh repo list`, and a "create new" fallback (typed name, or `owner/repo` to clone — both placed in `~`), then opens the pair layout in a new tab with the chosen cwd.
 - `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap (apt packages, Tailscale, Zellij, lazygit, nvm/Node, `@anthropic-ai/claude-code`, rustup/Claustre).
 
 ## Never in the repo

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus, ghost, notepad — all pinned to release tags), status bars, and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
 - `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
+- `dot_local/bin/pair-start` — floating fzf picker bound to `Alt+p`. Unifies `~/pair/*` clones, `gh repo list`, and a "create new" fallback (typed name, or `owner/repo` to clone), then opens the pair layout in a new tab with the chosen cwd.
 - `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap (apt packages, Tailscale, Zellij, lazygit, nvm/Node, `@anthropic-ai/claude-code`, rustup/Claustre).
 
 ## Never in the repo

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -37,9 +37,15 @@ default_tab_template {
 
 keybinds {
     shared_except "locked" {
-        // Deep-pairing layout in a new tab.
+        // Deep-pairing picker: floating fzf chooser over local clones,
+        // GitHub repos, and "create new" -- it then opens the pair layout
+        // in a new tab with the chosen cwd. See ~/.local/bin/pair-start.
         bind "Alt p" {
-            NewTab { layout "pair"; }
+            Run "pair-start" {
+                floating true
+                close_on_exit true
+                name "pair-picker"
+            }
         }
         // Floating ad-hoc terminal (gh, chezmoi diff, rg, etc.).
         bind "Alt g" {

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -7,7 +7,8 @@
 // Invoke:
 //   zellij --layout pair                         # fresh session
 //   zellij action new-tab --layout pair          # new tab in current session
-//   Alt+p                                        # keybind, same as above
+//   Alt+p                                        # floating picker (pair-start)
+//                                                # then `new-tab --layout pair --cwd <chosen>`
 
 layout {
     tab name="pair" focus=true {

--- a/dot_local/bin/executable_pair-start
+++ b/dot_local/bin/executable_pair-start
@@ -11,9 +11,9 @@
 #                 entry. $XDG_RUNTIME_DIR is deliberately not used -- it is
 #                 tmpfs and wiped on logout, which would lose uncommitted work.
 #   2. github     repos visible to `gh repo list`
-#   3. (no match) the typed query, treated as $PAIR_BASE_DIR/<name>; if it
-#                 contains "/" it is treated as `owner/repo` and cloned via
-#                 `gh repo clone` into $PAIR_BASE_DIR/<repo>
+#   3. (no match) the typed query, created as $PAIR_BASE_DIR/<query>. The
+#                 list already enumerates every repo you can clone, so a
+#                 miss means "new directory" -- no foreign-clone heuristic.
 #
 # After resolving the cwd, opens the pair layout in a new tab there.
 
@@ -63,7 +63,7 @@ output=$(
   printf '%s\n' "$list" \
   | fzf --print-query \
         --prompt='pair> ' \
-        --header='Enter to open; type a name (no match) to create; owner/repo to clone' \
+        --header='Enter to open; type a name with no match + Enter to create' \
         --delimiter=$'\t' \
         --with-nth=1,2 \
         --no-sort \
@@ -93,14 +93,8 @@ elif [ -n "$query" ]; then
   if [ -z "$trimmed" ]; then
     exit 0
   fi
-  if [[ "$trimmed" == */* ]]; then
-    target="$PAIR_BASE_DIR/$(basename "$trimmed")"
-    [ -d "$target/.git" ] || gh repo clone "$trimmed" "$target"
-    cwd="$target"
-  else
-    cwd="$PAIR_BASE_DIR/$trimmed"
-    mkdir -p "$cwd"
-  fi
+  cwd="$PAIR_BASE_DIR/$trimmed"
+  mkdir -p "$cwd"
 else
   exit 0
 fi

--- a/dot_local/bin/executable_pair-start
+++ b/dot_local/bin/executable_pair-start
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# pair-start: pick the working directory for the Zellij `pair` layout.
+#
+# Bound to Alt+p (~/.config/zellij/config.kdl) so the picker pops up
+# regardless of zellij's current cwd -- typical entry is from claustre
+# in $HOME, where the bare layout would otherwise open in $HOME.
+#
+# Three sources, unified into one fzf prompt:
+#   1. local      directories directly under $PAIR_BASE_DIR (default ~/pair)
+#   2. github     repos visible to `gh repo list`
+#   3. (no match) the typed query, treated as $PAIR_BASE_DIR/<name>; if it
+#                 contains "/" it is treated as `owner/repo` and cloned via
+#                 `gh repo clone` into $PAIR_BASE_DIR/<repo>
+#
+# After resolving the cwd, opens the pair layout in a new tab there.
+
+set -euo pipefail
+
+PAIR_BASE_DIR="${PAIR_BASE_DIR:-$HOME/pair}"
+mkdir -p "$PAIR_BASE_DIR"
+
+# Floating panes auto-close on exit, so a silent failure would vanish before
+# it could be read. Pause on error so the human can see what happened.
+on_error() {
+  local code=$?
+  printf '\n[pair-start] aborted (exit %d). Press Enter to close...\n' "$code" >&2
+  read -r _ || true
+  exit "$code"
+}
+trap on_error ERR
+
+# --- collect entries -------------------------------------------------------
+# Tab-separated:  <kind>\t<label>\t<value>
+# fzf shows columns 1,2 (--with-nth) and matches across all of them.
+entries=()
+
+while IFS= read -r -d '' dir; do
+  entries+=("$(printf 'local\t%s\t%s' "$(basename "$dir")" "$dir")")
+done < <(find "$PAIR_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
+
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    entries+=("$(printf 'github\t%s\t%s' "$repo" "$repo")")
+  done < <(gh repo list --limit 200 --json nameWithOwner -q '.[].nameWithOwner' 2>/dev/null || true)
+fi
+
+# --- pick ------------------------------------------------------------------
+if (( ${#entries[@]} > 0 )); then
+  list=$(printf '%s\n' "${entries[@]}")
+else
+  list=""
+fi
+
+output=$(
+  printf '%s\n' "$list" \
+  | fzf --print-query \
+        --prompt='pair> ' \
+        --header='Enter to open; type a name (no match) to create; owner/repo to clone' \
+        --delimiter=$'\t' \
+        --with-nth=1,2 \
+        --no-sort \
+        --tiebreak=begin \
+  || true
+)
+
+query=$(printf '%s' "$output" | sed -n '1p')
+selected=$(printf '%s' "$output" | sed -n '2p')
+
+cwd=""
+
+if [ -n "$selected" ]; then
+  IFS=$'\t' read -r kind _label value <<<"$selected"
+  case "$kind" in
+    local)
+      cwd="$value"
+      ;;
+    github)
+      target="$PAIR_BASE_DIR/$(basename "$value")"
+      [ -d "$target/.git" ] || gh repo clone "$value" "$target"
+      cwd="$target"
+      ;;
+  esac
+elif [ -n "$query" ]; then
+  trimmed=$(printf '%s' "$query" | awk '{$1=$1};1')
+  if [ -z "$trimmed" ]; then
+    exit 0
+  fi
+  if [[ "$trimmed" == */* ]]; then
+    target="$PAIR_BASE_DIR/$(basename "$trimmed")"
+    [ -d "$target/.git" ] || gh repo clone "$trimmed" "$target"
+    cwd="$target"
+  else
+    cwd="$PAIR_BASE_DIR/$trimmed"
+    mkdir -p "$cwd"
+  fi
+else
+  exit 0
+fi
+
+[ -n "$cwd" ] || exit 0
+
+zellij action new-tab --layout pair --cwd "$cwd"

--- a/dot_local/bin/executable_pair-start
+++ b/dot_local/bin/executable_pair-start
@@ -6,7 +6,10 @@
 # in $HOME, where the bare layout would otherwise open in $HOME.
 #
 # Three sources, unified into one fzf prompt:
-#   1. local      directories directly under $PAIR_BASE_DIR (default ~/pair)
+#   1. local      git checkouts directly under $PAIR_BASE_DIR (default $HOME):
+#                 visible (non-dot) top-level dirs that contain a `.git`
+#                 entry. $XDG_RUNTIME_DIR is deliberately not used -- it is
+#                 tmpfs and wiped on logout, which would lose uncommitted work.
 #   2. github     repos visible to `gh repo list`
 #   3. (no match) the typed query, treated as $PAIR_BASE_DIR/<name>; if it
 #                 contains "/" it is treated as `owner/repo` and cloned via
@@ -16,7 +19,7 @@
 
 set -euo pipefail
 
-PAIR_BASE_DIR="${PAIR_BASE_DIR:-$HOME/pair}"
+PAIR_BASE_DIR="${PAIR_BASE_DIR:-$HOME}"
 mkdir -p "$PAIR_BASE_DIR"
 
 # Floating panes auto-close on exit, so a silent failure would vanish before
@@ -35,8 +38,12 @@ trap on_error ERR
 entries=()
 
 while IFS= read -r -d '' dir; do
+  # `.git` is a directory in normal clones and a file in worktrees; -e covers
+  # both. Filtering to actual checkouts keeps $HOME's many non-repo dirs out
+  # of the picker.
+  [ -e "$dir/.git" ] || continue
   entries+=("$(printf 'local\t%s\t%s' "$(basename "$dir")" "$dir")")
-done < <(find "$PAIR_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
+done < <(find "$PAIR_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -print0 2>/dev/null | sort -z)
 
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   while IFS= read -r repo; do

--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -13,7 +13,7 @@ log() { printf '==> %s\n' "$*" >&2; }
 # -------------------------------------------------------------------- apt pkgs
 # zellij is intentionally not here: not in Debian bookworm. Installed below
 # from GitHub releases (pre-built musl binary).
-APT_PACKAGES=(gh zsh ripgrep fd-find jq unzip age)
+APT_PACKAGES=(gh zsh ripgrep fd-find jq unzip age fzf)
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do
   dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")


### PR DESCRIPTION
Previously Alt+p just opened the pair layout in zellij's current cwd —
which, when launched from claustre in $HOME, meant the panes opened in
$HOME. Replace the bind with a floating fzf picker (pair-start) that
unifies three sources: directories under ~/pair, `gh repo list`, and a
"no-match" fallback that either creates ~/pair/<name> or, when the query
contains "/", clones owner/repo via gh. Then it dispatches the layout
with `zellij action new-tab --layout pair --cwd <chosen>`.

Adds fzf to the apt bootstrap and shellchecks the new script in CI.