### PR TITLE
fix npm global install EACCES by using nvm-managed node

### DIFF
--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -82,13 +82,14 @@ fi
 # shellcheck disable=SC1091
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-if ! command -v node >/dev/null 2>&1; then
+if nvm which default >/dev/null 2>&1; then
+  log "node: $(nvm version default) already managed by nvm"
+else
   log "node: installing LTS via nvm"
   nvm install --lts
   nvm alias default 'lts/*'
-else
-  log "node: $(node --version) already on PATH"
 fi
+nvm use default >/dev/null 2>&1
 
 # ---------------------------------------------------------------- Claude Code
 if ! command -v claude >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- `chezmoi update` failed with `EACCES: permission denied, mkdir '/usr/lib/node_modules/@readwise'` when the bootstrap script ran `npm install -g @readwise/cli`
- Root cause: the script checked `command -v node` which found the system node at `/usr/bin/node`, skipping `nvm install`. The system npm's global prefix is `/usr/lib/node_modules` — requires root
- Fix: check `nvm which default` instead (detects nvm-managed node specifically) and always run `nvm use default` before npm commands

## Test plan

- Verified shellcheck passes on the modified bootstrap script
- The fix ensures `npm install -g` uses nvm's user-local prefix (`~/.config/nvm/versions/node/<version>/lib/node_modules/`) which doesn't require root