### PR TITLE
fix npm EACCES error for readwise-cli install

### DIFF
--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -81,6 +81,10 @@ fi
 
 # shellcheck disable=SC1091
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+# Non-interactive shells may not auto-activate the default node.
+# Without this, npm global installs fall through to the system prefix
+# (/usr/lib/node_modules) which requires root.
+nvm use default >/dev/null 2>&1 || true
 
 if ! command -v node >/dev/null 2>&1; then
   log "node: installing LTS via nvm"


### PR DESCRIPTION
## Summary

- `chezmoi update` runs the bootstrap script non-interactively, and sourcing `nvm.sh` in that context may not auto-activate the default node version
- Without the active nvm node, `npm install -g` falls through to the system prefix (`/usr/lib/node_modules`) which requires root and fails with `EACCES: permission denied`
- Added explicit `nvm use default` after sourcing nvm to ensure the nvm-managed node/npm is active before global installs

## Test plan

- Verified shellcheck passes on the expanded template
- Confirmed the `|| true` guard handles the first-run case where no default alias exists yet