### PR TITLE
fix npm EACCES by verifying prefix before global installs

### DIFF
--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -81,32 +81,24 @@ fi
 
 # shellcheck disable=SC1091
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-# Non-interactive shells may not auto-activate the default node.
-# Without this, npm global installs fall through to the system prefix
-# (/usr/lib/node_modules) which requires root.
-nvm use default >/dev/null 2>&1 || true
 
-if ! command -v node >/dev/null 2>&1; then
+# Ensure an nvm-managed node exists. The `command -v node` check that was
+# here before could find a system /usr/bin/node and skip installation,
+# leaving nvm with zero versions and npm pointed at /usr/lib.
+if ! nvm ls default >/dev/null 2>&1; then
   log "node: installing LTS via nvm"
   nvm install --lts
   nvm alias default 'lts/*'
-else
-  log "node: $(node --version) already on PATH"
 fi
+nvm use default >/dev/null 2>&1
+log "node: $(node --version) via nvm"
 
-# Verify npm global prefix is writable (not the system /usr/lib/node_modules).
-# Even after sourcing nvm.sh and `nvm use default`, a stale PATH or missing
-# default alias can leave the system npm active.
-npm_prefix="$(npm config get prefix 2>/dev/null || echo /usr)"
-if [[ "$npm_prefix" == /usr* ]]; then
-  log "npm: prefix is $npm_prefix (system); re-activating nvm"
-  nvm use default 2>/dev/null || nvm use node 2>/dev/null || true
-  npm_prefix="$(npm config get prefix 2>/dev/null || echo /usr)"
-  if [[ "$npm_prefix" == /usr* ]]; then
-    log "FATAL: npm global prefix is $npm_prefix — cannot install packages without root"
-    exit 1
-  fi
-fi
+# Pin npm's global prefix to the nvm-managed node directory so that
+# `npm install -g` never falls through to /usr/lib/node_modules (which
+# requires root). This is more reliable than `nvm use default` alone
+# which can fail silently in non-interactive chezmoi runs.
+NPM_CONFIG_PREFIX="$NVM_DIR/versions/node/$(node --version)"
+export NPM_CONFIG_PREFIX
 
 # ---------------------------------------------------------------- Claude Code
 if ! command -v claude >/dev/null 2>&1; then

--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -94,6 +94,20 @@ else
   log "node: $(node --version) already on PATH"
 fi
 
+# Verify npm global prefix is writable (not the system /usr/lib/node_modules).
+# Even after sourcing nvm.sh and `nvm use default`, a stale PATH or missing
+# default alias can leave the system npm active.
+npm_prefix="$(npm config get prefix 2>/dev/null || echo /usr)"
+if [[ "$npm_prefix" == /usr* ]]; then
+  log "npm: prefix is $npm_prefix (system); re-activating nvm"
+  nvm use default 2>/dev/null || nvm use node 2>/dev/null || true
+  npm_prefix="$(npm config get prefix 2>/dev/null || echo /usr)"
+  if [[ "$npm_prefix" == /usr* ]]; then
+    log "FATAL: npm global prefix is $npm_prefix — cannot install packages without root"
+    exit 1
+  fi
+fi
+
 # ---------------------------------------------------------------- Claude Code
 if ! command -v claude >/dev/null 2>&1; then
   log "claude-code: npm install -g @anthropic-ai/claude-code"


### PR DESCRIPTION
## Summary

- Adds a npm prefix check after the nvm + node section that detects when npm is still pointed at the system prefix (`/usr/lib/node_modules`)
- Re-activates nvm (`nvm use default`, falling back to `nvm use node`) when the system prefix is detected
- Fails with a clear error instead of a cryptic EACCES if nvm re-activation doesn't fix the prefix

## Context

The existing `nvm use default >/dev/null 2>&1 || true` (added in #10) can fail silently — e.g. when the default alias is unset or nvm's shell integration doesn't fully activate in a non-interactive `chezmoi` run. When that happens, `npm install -g` falls through to the system npm prefix and hits `EACCES: permission denied, mkdir '/usr/lib/node_modules/@readwise'`.

## Test plan

- Verified script passes `bash -n` syntax check and `shellcheck` with no warnings
- On a host where `nvm use default` succeeds, the new guard is a no-op (prefix is already under `$NVM_DIR`)
- On a host where `nvm use default` fails silently, the guard detects the `/usr/lib` prefix and retries activation