### PR TITLE
enable globstar option in bashrc

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -25,7 +25,7 @@ shopt -s checkwinsize
 
 # If set, the pattern "**" used in a pathname expansion context will
 # match all files and zero or more directories and subdirectories.
-#shopt -s globstar
+shopt -s globstar
 
 # make less more friendly for non-text input files, see lesspipe(1)
 #[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"


### PR DESCRIPTION
## Summary
- Uncomment `shopt -s globstar` in `dot_bashrc` to enable `**` glob pattern matching for recursive directory traversal in pathname expansion.

## Test plan
- Verified the diff contains only the intended uncomment of the globstar shopt line.