### PR TITLE
add Renovate configuration for automated dependency updates

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,2 +1,3 @@
 LICENSE
 README.md
+renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["run_once_before_install-packages\\.sh\\.tmpl$"],
+      "matchStrings": ["ZELLIJ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "zellij-org/zellij",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["run_once_before_install-packages\\.sh\\.tmpl$"],
+      "matchStrings": ["NVM_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "nvm-sh/nvm",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["run_once_before_install-packages\\.sh\\.tmpl$"],
+      "matchStrings": ["LAZYGIT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "jesseduffield/lazygit",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["dot_config/zellij/config\\.kdl$"],
+      "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Added `renovate.json` with `config:recommended` base and custom regex managers
- Regex managers cover the three bootstrap script version pins (zellij, nvm, lazygit) and the four Zellij plugin download URLs in `config.kdl`
- GitHub Actions versions (e.g., `actions/checkout@v4`) are handled by Renovate's built-in manager
- Added `renovate.json` to `.chezmoiignore` so chezmoi does not deploy it to `~`

## Test plan

- Validated `renovate.json` syntax with `jq empty`
- Verified regex patterns match the expected version strings in the bootstrap script and KDL config
- Confirmed `.chezmoiignore` correctly lists `renovate.json`