### PR TITLE
validate README against ddbeck checklist and add project CLAUDE.md

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,2 +1,3 @@
+CLAUDE.md
 LICENSE
 README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# alunduil-chezmoi
+
+Chezmoi-managed dotfiles. Source files in this repo deploy to `$HOME` via
+`chezmoi apply`. This is the *chezmoi source directory*, not a conventional
+software project — naming conventions and file structure follow chezmoi rules.
+
+## Chezmoi naming conventions
+
+- `dot_` prefix → deployed as `.` (e.g. `dot_bashrc` → `~/.bashrc`)
+- `executable_` prefix → deployed with mode +x
+- `.tmpl` suffix → expanded as a Go template before deployment
+- `run_once_before_` prefix → script executed once on `chezmoi apply`; re-runs
+  only when the file's content hash changes
+- `.chezmoiignore` → lists source files excluded from deployment (README.md,
+  LICENSE)
+
+## Layout
+
+- `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell and
+  git config
+- `dot_claude/` — user-level Claude Code harness deployed to `~/.claude/`:
+  `CLAUDE.md` (guide), `settings.json` (hook wiring), `hooks/` (pr-draft-guard)
+- `dot_claustre/config.toml` — Claustre user config
+- `dot_config/zellij/` — Zellij config and layouts (pair.kdl for deep-pairing)
+- `dot_local/bin/executable_gh` — wrapper shadowing system `gh` to enforce
+  `--draft` on PR creation
+- `run_once_before_install-packages.sh.tmpl` — idempotent bootstrap script
+  (apt packages, Tailscale, Zellij, lazygit, nvm/Node, Claude Code, Readwise
+  CLI, rtk, rustup/Claustre)
+
+## Previewing and testing changes
+
+```bash
+chezmoi diff          # show what chezmoi apply would change on the host
+chezmoi apply -n      # dry-run: same as diff but in apply format
+chezmoi apply -v      # apply with verbose output
+```
+
+No test suite or linter — verification is `chezmoi diff` and manual review.
+The bootstrap script is idempotent; re-running it is safe.
+
+## Never commit
+
+Credentials, private keys (`key.txt`, `.credentials.json`), runtime state
+(`~/.claustre/db/`), SSH private keys, or toolchain binaries. See README
+"Never in the repo" for the full list.
+
+## Two CLAUDE.md files
+
+- **This file** (`CLAUDE.md` at repo root): instructions for AI tools working
+  on the chezmoi source — naming conventions, layout, testing.
+- **`dot_claude/CLAUDE.md`**: the deployed user-level Claude Code guide
+  (`~/.claude/CLAUDE.md`). It governs Claude Code behaviour on the host, not
+  contributions to this repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/alunduil/alunduil-chezmoi/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/alunduil-chezmoi/actions/workflows/ci.yml)
 
-Personal dotfiles for [@alunduil](https://github.com/alunduil), managed by [chezmoi](https://chezmoi.io). One command on a fresh Debian/Crostini host sets up a complete AI-assisted development environment: [Claude Code](https://claude.com/claude-code) for coding, [Claustre](https://github.com/pmbrull/claustre) for task orchestration, [Zellij](https://zellij.dev) for terminal multiplexing, and [lazygit](https://github.com/jesseduffield/lazygit) for git — all pre-wired with layouts, keybinds, and guardrails. Source: <https://github.com/alunduil/alunduil-chezmoi>.
+Personal [chezmoi](https://chezmoi.io)-managed dotfiles for [@alunduil](https://github.com/alunduil). Run one command on a fresh Debian/Crostini host to go from bare OS to a fully configured development environment with AI pair programming, terminal multiplexing, and git integration — layouts, keybinds, and guardrails included. Source: <https://github.com/alunduil/alunduil-chezmoi>.
 
 Personal config — no warranty, no support. [0BSD licensed](LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/alunduil/alunduil-chezmoi/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/alunduil-chezmoi/actions/workflows/ci.yml)
 
-Personal dotfiles for [@alunduil](https://github.com/alunduil), managed by [chezmoi](https://chezmoi.io). Bootstraps a Claude Code + [Claustre](https://github.com/pmbrull/claustre) + [Zellij](https://zellij.dev) workflow on a fresh Debian/Crostini host. Source: <https://github.com/alunduil/alunduil-chezmoi>.
+Personal dotfiles for [@alunduil](https://github.com/alunduil), managed by [chezmoi](https://chezmoi.io). One command on a fresh Debian/Crostini host sets up a complete AI-assisted development environment: [Claude Code](https://claude.com/claude-code) for coding, [Claustre](https://github.com/pmbrull/claustre) for task orchestration, [Zellij](https://zellij.dev) for terminal multiplexing, and [lazygit](https://github.com/jesseduffield/lazygit) for git — all pre-wired with layouts, keybinds, and guardrails. Source: <https://github.com/alunduil/alunduil-chezmoi>.
 
 Personal config — no warranty, no support. [0BSD licensed](LICENSE).
 
@@ -28,6 +28,14 @@ claustre configure                         # wires up Claude Code permissions
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.
 
+### Verify
+
+After bootstrap, confirm the key tools are on PATH:
+
+```bash
+claude --version && claustre --version && zellij --version && lazygit --version
+```
+
 ## Companion repo
 
 `alunduil-claustre-state` (planned, private) holds Claustre's cross-machine task/project state:
@@ -52,3 +60,7 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 ## Never in the repo
 
 Credentials of any kind, runtime state (`.credentials.json`, session history, `~/.claustre/db/`), the age private key, SSH private keys, and toolchain binaries (chezmoi/Node/Rust install via canonical installers).
+
+## Contributing
+
+Personal configuration — not accepting contributions. Fork freely under [0BSD](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrote README description to be outcome-oriented (what environment you get) rather than tool-list-oriented, per ddbeck's "describe what the project achieves" checklist item
- Added a post-bootstrap verification step (`claude --version && claustre --version && ...`) to close the "test your setup steps" gap
- Added explicit Contributing section ("not accepting contributions, fork freely") to satisfy the engagement checklist item
- Created project-root `CLAUDE.md` with chezmoi naming conventions, layout overview, preview/test commands, and clarification of the two CLAUDE.md files in the repo
- Added `CLAUDE.md` to `.chezmoiignore` so it stays in the source repo only

## Test plan

- Verified the README renders correctly with all links intact
- Confirmed `.chezmoiignore` now lists CLAUDE.md alongside LICENSE and README.md
- Verified project-root CLAUDE.md accurately reflects current repo layout and naming conventions