### PR TITLE
add searchable git-repo picker to zellij Alt+p keybind

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -37,9 +37,12 @@ default_tab_template {
 
 keybinds {
     shared_except "locked" {
-        // Deep-pairing layout in a new tab.
+        // Searchable git-repo picker → pair layout in the chosen repo.
         bind "Alt p" {
-            NewTab { layout "pair"; }
+            Run "git-repo-picker" {
+                floating true
+                close_on_exit true
+            }
         }
         // Floating ad-hoc terminal (gh, chezmoi diff, rg, etc.).
         bind "Alt g" {

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--list" ]]; then
+    query="${2:-}"
+    if [[ -n "${GIT_REPO_PICKER_CACHE:-}" && -f "$GIT_REPO_PICKER_CACHE" ]]; then
+        cat "$GIT_REPO_PICKER_CACHE"
+    fi
+    if [[ "$query" == */* ]]; then
+        gh search repos "$query" --limit 30 --json fullName -q '.[].fullName' 2>/dev/null \
+            | while IFS= read -r repo; do
+                if [[ -n "${GIT_REPO_PICKER_CACHE:-}" ]] \
+                    && grep -qxF "$repo" "$GIT_REPO_PICKER_CACHE" 2>/dev/null; then
+                    continue
+                fi
+                printf 'remote:%s\n' "$repo"
+            done
+    fi
+    exit 0
+fi
+
+for cmd in fzf zellij; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        printf 'git-repo-picker: %s required but not found\n' "$cmd" >&2
+        exit 1
+    fi
+done
+
+cache=$(mktemp)
+trap 'rm -f "$cache"' EXIT
+export GIT_REPO_PICKER_CACHE="$cache"
+
+find "$HOME" -maxdepth 4 -name .git -type d 2>/dev/null \
+    | sed 's|/\.git$||' \
+    | sed "s|^$HOME/||" \
+    | sort > "$cache"
+
+selection=$(fzf \
+    --bind "change:reload:$0 --list {q}" \
+    --prompt "repo> " \
+    --header "type to search local repos · include / for GitHub" \
+    < "$cache") || exit 0
+
+[[ -z "$selection" ]] && exit 0
+
+if [[ "$selection" == remote:* ]]; then
+    repo="${selection#remote:}"
+    repo_name="${repo##*/}"
+    dir="$HOME/$repo_name"
+    if [[ ! -d "$dir" ]]; then
+        gh repo clone "$repo" "$dir"
+    fi
+else
+    dir="$HOME/$selection"
+fi
+
+zellij action new-tab --layout pair --cwd "$dir"

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -17,7 +17,7 @@ if [ ! -f /usr/share/keyrings/hashicorp-archive-keyring.gpg ]; then
 fi
 
 # -------------------------------------------------------------------- apt pkgs
-APT_PACKAGES=(gh zsh ripgrep fd-find jq unzip age terraform)
+APT_PACKAGES=(gh zsh ripgrep fd-find fzf jq unzip age terraform)
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do
   dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")


### PR DESCRIPTION
## Summary
- **Alt+p** now opens a floating fzf picker listing local git repos (found via `find ~ -maxdepth 4 -name .git`). Typing a query containing `/` augments the list with GitHub search results via `gh search repos`, prefixed with `remote:` to distinguish them.
- Selecting a local repo opens the pair layout (`claude` + `lazygit`) with cwd set to that directory. Selecting a remote repo clones it to `~` first, then opens the pair layout there.
- Adds `fzf` to the apt packages in the system-packages bootstrap script.

## Test plan
- Verified zellij config validates cleanly via `script/check-zellij-config`
- Verified `shellcheck` passes on the new `git-repo-picker` script
- Verified `pre-commit run --all-files` passes (shellcheck, shfmt, check-json)
- Verified `bats test/` passes (14 existing tests unaffected)