### PR TITLE
add approach and issue-workflow guidance to user-level Claude config

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -45,12 +45,34 @@ reliable enough.
   issue to the most relevant milestone (or leave it unset if none fits)
   and apply labels that match the issue's type and area.
 
+## Issue workflow
+
+- Before implementing a GitHub issue, read its comments and scan recent
+  commits in the relevant area to confirm the work is still relevant
+  given the current state of the repo. Surface a go/no-go before
+  writing code if anything looks stale (e.g., the tooling the issue
+  assumes has since been replaced).
+- For multi-step tasks, commit incrementally rather than batching all
+  changes for the end. Usage limits or interruptions then leave a
+  recoverable branch instead of lost work.
+
 ## Feedback preference
 
 - Run the project's computational sensors (tests, linters, type checker,
   formatter) before claiming a task is done. Use inferential review
   (another LLM reading the diff) to catch what those miss, not as a
   substitute for them.
+
+## Approach
+
+- Prefer the simplest solution that meets the requirement. Before
+  writing custom scripts, guards, or wrappers, check whether a standard
+  mechanism (env var, official package repo, existing repo pattern)
+  already covers it. When the proposed change is more complex than
+  precedent in the repo, justify the divergence in one sentence or
+  pick the precedent.
+- Propose the minimal fix first. Add complexity only when the minimal
+  version is shown to be insufficient -- not pre-emptively.
 
 ## Scope
 


### PR DESCRIPTION
## Context

The `/insights` pass on 2026-04-29 surfaced two recurring frictions across recent Claude Code sessions: Claude reaching for complex solutions before checking idiomatic ones (e.g., a 14-line npm guard where `NPM_CONFIG_PREFIX` would do; manual Terraform binary download instead of the HashiCorp apt repo), and starting work on issues without verifying current relevance (e.g., implementing a Dependabot task after the project had migrated to Renovate). This PR encodes both as new sections in the global user-level guide so they apply across every repo, not just whichever one last hit the friction.

## Verification

Spot-checked the rendered section order (Issues → Issue workflow → Feedback preference → Approach → Scope) and confirmed the diff is purely additive (+22 lines, no edits to existing content).