### PR TITLE
sync settings.json to runtime-emitted state

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -3,14 +3,36 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "mcp__github__create_pull_request(_with_copilot)?",
         "hooks": [
           {
-            "type": "command",
-            "command": "$HOME/.claude/hooks/pr-draft-guard.sh"
+            "command": "$HOME/.claude/hooks/pr-draft-guard.sh",
+            "type": "command"
           }
-        ]
+        ],
+        "matcher": "mcp__github__create_pull_request(_with_copilot)?"
       }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash",
+      "BashOutput(*)",
+      "Edit(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "MultiEdit(*)",
+      "NotebookEdit(*)",
+      "Read(*)",
+      "TodoWrite(*)",
+      "Write(*)"
+    ],
+    "ask": [
+      "Bash(rm:*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push*--force*)",
+      "Bash(git push*main*)"
     ]
   }
 }


### PR DESCRIPTION
## Context

The Claude Code runtime had been mutating \`~/.local/share/chezmoi/dot_claude/settings.json\` in-place on every session — adding a \`permissions\` block (allow / ask / deny rules) and reordering hook keys cosmetically. Without this sync, that drift reappears after each session and \`chezmoi diff\` keeps flagging it. Adopting the runtime-emitted state into the chezmoi source resolves the drift loop. Notably, the new \`deny\` rules (\`git push --force*\`, \`git push*--force*\`, \`git push*main*\`) are exactly the deterministic enforcers \`dot_claude/CLAUDE.md\` prescribes for "don't force-push, don't push to main".

## Gotchas

The diff is +26/-4: net-additive on the permissions block, with 4 lines reordered (\`hooks\` before \`matcher\`, \`command\` before \`type\`) to match the runtime's preferred key order. Semantically identical to before — only formatting changed in those 4 lines.

## Verification

Confirmed the new \`dot_claude/settings.json\` matches \`~/.local/share/chezmoi/dot_claude/settings.json\` byte-for-byte after the change.