### PR TITLE
exclude hidden directories from repo picker search

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -30,7 +30,7 @@ cache=$(mktemp)
 trap 'rm -f "$cache"' EXIT
 export GIT_REPO_PICKER_CACHE="$cache"
 
-find "$HOME" -maxdepth 4 -name .git -type d 2>/dev/null \
+find "$HOME" -maxdepth 4 \( -name '.*' ! -name '.git' -prune \) -o \( -name .git -type d -print \) 2>/dev/null \
     | sed 's|/\.git$||' \
     | sed "s|^$HOME/||" \
     | sort > "$cache"


### PR DESCRIPTION
Closes #25.

## Context

The `find` in `git-repo-picker` descends into hidden directories
(`.cache`, `.local`, etc.), which adds noise to the list and slows down
the search. This change prunes hidden directories at the `find` level
while still matching `.git` itself.

## Verification

Ran `pre-commit run --all-files` — shellcheck, shfmt, and check-json
all pass. Verified the new `find` expression locally: repos under
visible paths still appear, repos inside hidden directories do not.