### PR TITLE
split zellij layout into default + pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell + git config.
 - `dot_claude/` — user-level Claude Code harness: `CLAUDE.md` rules, `settings.json` hook wiring, `hooks/pr-draft-guard.sh` blocking non-draft PRs over the GitHub MCP tools. Per-project sensors (tests/linters/types) stay with the project.
 - `dot_claustre/config.toml` — Claustre user config (`sync.auto_push = true`).
-- `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus, ghost, notepad — all pinned to release tags), status bars, and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
+- `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, ghost, notepad — all pinned to release tags) and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
+- `dot_config/zellij/layouts/default.kdl` — initial-tab layout: zellaude top strip + built-in `tab-bar` + `status-bar`.
 - `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
 - `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -4,10 +4,12 @@
 //
 // Plugins are pinned by release tag -- Zellij fetches and caches them in
 // ~/.cache/zellij/ on first use. Aliases (below) keep references short.
+// Per-tab UI (zellaude top strip, tab-bar, status-bar) lives in the layouts
+// (layouts/default.kdl, layouts/pair.kdl); a default_tab_template here
+// would not propagate into layout-spawned tabs anyway.
 
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
-    zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm"
     ghost    location="https://github.com/vdbulcke/ghost/releases/download/v0.7.1/ghost.wasm"
     notepad  location="https://github.com/0xble/zellij-notepad/releases/download/v0.2.1/notepad.wasm"
 }
@@ -15,24 +17,6 @@ plugins {
 // notepad uses MessagePlugin "toggle" semantics, so it must be preloaded.
 load_plugins {
     "notepad"
-}
-
-// zellaude on top (per-tab Claude Code activity), zjstatus on the bottom
-// (mode, session, tabs, clock). Applies to every tab, including those opened
-// from layouts like pair.kdl.
-default_tab_template {
-    pane size=1 borderless=true {
-        plugin location="zellaude"
-    }
-    children
-    pane size=2 borderless=true {
-        plugin location="zjstatus" {
-            format_left   "#[fg=green,bold]{mode} #[fg=white]{session}"
-            format_center "{tabs}"
-            format_right  "#[fg=cyan]{datetime}"
-            datetime_format "%Y-%m-%d %H:%M"
-        }
-    }
 }
 
 keybinds {

--- a/dot_config/zellij/layouts/default.kdl
+++ b/dot_config/zellij/layouts/default.kdl
@@ -1,0 +1,25 @@
+// Default layout: applied when zellij starts without --layout. Without this
+// file, zellij falls back to its built-in default layout, which uses the
+// bundled tab-bar/status-bar but not zellaude — so the initial tab would be
+// missing the per-tab Claude Code activity strip.
+//
+// Template shape mirrors pair.kdl. Keep them in sync:
+//   zellaude   (1 line) — per-tab Claude Code activity
+//   tab-bar    (1 line) — tab list
+//   children   (the panes)
+//   status-bar (2 lines) — mode indicator + keybinding hints
+
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellaude"
+        }
+        pane size=1 borderless=true {
+            plugin location="tab-bar"
+        }
+        children
+        pane size=2 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+}

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -1,8 +1,13 @@
 // Deep-pairing layout: Claude Code (40%) alongside lazygit (60%). The editing
 // surface is VS Code in its own window; this layout is for the "watch the
 // changes, drive Claude" side of pairing. On-demand shells come from ghost
-// (Alt+g) so no fixed terminal strip is reserved. The global
-// default_tab_template in ../config.kdl wraps this with zellaude + zjstatus.
+// (Alt+g) so no fixed terminal strip is reserved.
+//
+// The default_tab_template below mirrors the one in ../config.kdl. Zellij
+// does not apply config-level templates to layout-spawned tabs, so without
+// this duplication, tabs created via `--layout pair` lose the zellaude top
+// bar and the zjstatus bottom bar (and with them the mode indicator that
+// makes zellij controllable). Keep this template in sync with ../config.kdl.
 //
 // Invoke:
 //   zellij --layout pair                         # fresh session
@@ -10,6 +15,20 @@
 //   Alt+p                                        # keybind, same as above
 
 layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellaude"
+        }
+        children
+        pane size=2 borderless=true {
+            plugin location="zjstatus" {
+                format_left   "#[fg=green,bold]{mode} #[fg=white]{session}"
+                format_center "{tabs}"
+                format_right  "#[fg=cyan]{datetime}"
+                datetime_format "%Y-%m-%d %H:%M"
+            }
+        }
+    }
     tab name="pair" focus=true {
         pane split_direction="vertical" {
             pane size="40%" name="claude" command="claude"

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -3,30 +3,32 @@
 // changes, drive Claude" side of pairing. On-demand shells come from ghost
 // (Alt+g) so no fixed terminal strip is reserved.
 //
-// The default_tab_template below mirrors the one in ../config.kdl. Zellij
-// does not apply config-level templates to layout-spawned tabs, so without
-// this duplication, tabs created via `--layout pair` lose the zellaude top
-// bar and the zjstatus bottom bar (and with them the mode indicator that
-// makes zellij controllable). Keep this template in sync with ../config.kdl.
+// Template shape mirrors default.kdl — zellij does not propagate config-level
+// templates into layout-spawned tabs, so each layout carries its own copy.
+// Keep this in sync with ../layouts/default.kdl:
+//   zellaude   (1 line) — per-tab Claude Code activity
+//   tab-bar    (1 line) — tab list
+//   children   (the panes)
+//   status-bar (2 lines) — mode indicator + keybinding hints
 //
 // Invoke:
 //   zellij --layout pair                         # fresh session
 //   zellij action new-tab --layout pair          # new tab in current session
 //   Alt+p                                        # keybind, same as above
+//                                                # (git-repo-picker renames the
+//                                                # spawned tab to the repo name)
 
 layout {
     default_tab_template {
         pane size=1 borderless=true {
             plugin location="zellaude"
         }
+        pane size=1 borderless=true {
+            plugin location="tab-bar"
+        }
         children
         pane size=2 borderless=true {
-            plugin location="zjstatus" {
-                format_left   "#[fg=green,bold]{mode} #[fg=white]{session}"
-                format_center "{tabs}"
-                format_right  "#[fg=cyan]{datetime}"
-                datetime_format "%Y-%m-%d %H:%M"
-            }
+            plugin location="status-bar"
         }
     }
     tab name="pair" focus=true {

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -55,3 +55,6 @@ else
 fi
 
 zellij action new-tab --layout pair --cwd "$dir"
+# pair.kdl hardcodes the tab name to "pair"; rename to the repo basename so
+# the tab-bar reflects which repo this pairing session is for.
+zellij action rename-tab "$(basename "$dir")"


### PR DESCRIPTION
## Context

The initial tab (no `--layout`) was missing zellaude and showing built-in status-bar controls, while pair tabs showed zjstatus -- because zellij's built-in default layout supplies its own bars and `default_tab_template` in `config.kdl` doesn't propagate into layout-spawned tabs (which is what `1e0057e` was already a workaround for). Net effect: that template was dead code, and the initial tab had no way to pick up the project's UI choices.

This PR makes the two contexts symmetric. A new `layouts/default.kdl` mirrors `layouts/pair.kdl`'s shape -- zellaude + `tab-bar` + children + `status-bar` -- so both kinds of tabs get the same strips. zjstatus is dropped in favour of the built-in `status-bar`: it shows keybinding hints automatically and stays correct as keybindings evolve, which is more useful for a deep-pairing workflow than session/clock/tabs text. The unused `default_tab_template` and `zjstatus` alias come out of `config.kdl` with it.

`git-repo-picker` now renames the spawned pair tab to the repo basename, so the new tab-bar reflects which repo the session is for instead of the hardcoded `pair`.

## Gotchas

- The two layouts duplicate the same `default_tab_template`. That's deliberate -- zellij does not propagate config-level templates into layout-spawned tabs, so each layout has to carry its own copy. Comments in both files point at the other.
- `script/check-zellij-config` sets `XDG_CONFIG_HOME`, but zellij actually honours `ZELLIJ_CONFIG_DIR` -- so the script silently validates the deployed config rather than the source. Out of scope here, but worth a follow-up issue.

## Verification

- pre-commit clean (shellcheck, shfmt, check-json).
- bats: 14/14 pass.
- `zellij setup --check` against the source config (via `ZELLIJ_CONFIG_DIR` on a temp copy) reports `[CONFIG FILE]: Well defined.` and resolves both layouts.
- `script/check-chezmoi-apply` clean.