### PR TITLE
trim zellij chrome: drop tab-bar, shrink status-bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_claude/` — user-level Claude Code harness: `CLAUDE.md` rules, `settings.json` hook wiring, `hooks/pr-draft-guard.sh` blocking non-draft PRs over the GitHub MCP tools. Per-project sensors (tests/linters/types) stay with the project.
 - `dot_claustre/config.toml` — Claustre user config (`sync.auto_push = true`).
 - `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, ghost, notepad — all pinned to release tags) and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
-- `dot_config/zellij/layouts/default.kdl` — initial-tab layout: zellaude top strip + built-in `tab-bar` + `status-bar`.
+- `dot_config/zellij/layouts/default.kdl` — initial-tab layout: zellaude top strip + 1-line `status-bar` (mode only, tips clipped).
 - `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
 - `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:

--- a/dot_config/zellij/layouts/default.kdl
+++ b/dot_config/zellij/layouts/default.kdl
@@ -4,21 +4,17 @@
 // missing the per-tab Claude Code activity strip.
 //
 // Template shape mirrors pair.kdl. Keep them in sync:
-//   zellaude   (1 line) — per-tab Claude Code activity
-//   tab-bar    (1 line) — tab list
+//   zellaude   (1 line) — per-tab Claude Code activity + tab list
 //   children   (the panes)
-//   status-bar (2 lines) — mode indicator + keybinding hints
+//   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 
 layout {
     default_tab_template {
         pane size=1 borderless=true {
             plugin location="zellaude"
         }
-        pane size=1 borderless=true {
-            plugin location="tab-bar"
-        }
         children
-        pane size=2 borderless=true {
+        pane size=1 borderless=true {
             plugin location="status-bar"
         }
     }

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -6,10 +6,9 @@
 // Template shape mirrors default.kdl — zellij does not propagate config-level
 // templates into layout-spawned tabs, so each layout carries its own copy.
 // Keep this in sync with ../layouts/default.kdl:
-//   zellaude   (1 line) — per-tab Claude Code activity
-//   tab-bar    (1 line) — tab list
+//   zellaude   (1 line) — per-tab Claude Code activity + tab list
 //   children   (the panes)
-//   status-bar (2 lines) — mode indicator + keybinding hints
+//   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
 // Invoke:
 //   zellij --layout pair                         # fresh session
@@ -23,11 +22,8 @@ layout {
         pane size=1 borderless=true {
             plugin location="zellaude"
         }
-        pane size=1 borderless=true {
-            plugin location="tab-bar"
-        }
         children
-        pane size=2 borderless=true {
+        pane size=1 borderless=true {
             plugin location="status-bar"
         }
     }


### PR DESCRIPTION
## Context

zellaude v0.5.0 renders the tab list in its top strip, so the dedicated `tab-bar` pane was just duplicating it. The bottom `status-bar` at `size=2` was rendering a second line of keybinding tips that added noise without value. Trimming both is the natural follow-on to the layout split in #28.

## Gotchas

- Focus on `dot_config/zellij/layouts/pair.kdl` — verify nothing in the pair workflow depended on the tab-bar pane being present (the `tab name="pair"` block is unaffected; only the template chrome shrinks).
- `status-bar` at `size=1` clips the plugin's second line. zellij renders the mode indicator on line 1 and tips on line 2, so clipping yields mode-only. If a future zellij/status-bar release reorders these, this would silently flip.
- Both layout files carry a mirrored doc-comment block. Updated in lockstep — please confirm they still agree.

## Verification

- `script/check-zellij-config` clean.
- `script/check-chezmoi-apply` clean.
- `bats test/` 14/14 ok.
- `pre-commit run` on the changed files clean (no shell/json files in the diff).