### PR TITLE
fix check-zellij-config to validate source files, not deployed config

### DIFF
--- a/script/check-zellij-config
+++ b/script/check-zellij-config
@@ -8,4 +8,4 @@ mkdir -p "$config_dir/zellij/layouts"
 cp dot_config/zellij/config.kdl "$config_dir/zellij/config.kdl"
 cp dot_config/zellij/layouts/*.kdl "$config_dir/zellij/layouts/"
 
-XDG_CONFIG_HOME="$config_dir" zellij setup --check
+ZELLIJ_CONFIG_DIR="$config_dir/zellij" zellij setup --check


### PR DESCRIPTION
Closes #29

## Context

`script/check-zellij-config` used `XDG_CONFIG_HOME` to override zellij's
config directory, but zellij ignores that variable — it reads
`ZELLIJ_CONFIG_DIR` instead. The script was therefore always validating
whatever was deployed at `~/.config/zellij/`, not the source files in
this repo.

Switched the env var to `ZELLIJ_CONFIG_DIR` so `zellij setup --check`
reads from the tempdir populated with the source `.kdl` files.

## Verification

Ran `pre-commit run --all-files` (shellcheck, shfmt, check-json) and
`bats test/` — all passed.