### PR TITLE
rework CI workflows: bats-action swap and hardened defaults

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -18,5 +18,5 @@ jobs:
           file-install: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run
+      - name: Test
         run: bats test/

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -2,6 +2,7 @@ name: Bats
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -16,6 +16,7 @@ jobs:
           assert-install: false
           detik-install: false
           file-install: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run
         run: bats test/

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -10,10 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install bats
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq bats
+      - uses: bats-core/bats-action@4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
 
       - name: Run
         run: bats test/

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -21,10 +22,12 @@ jobs:
 
       - uses: bats-core/bats-action@4.0.0
         with:
+          # Override defaults of true; tests in test/ don't load helper libs.
           support-install: false
           assert-install: false
           detik-install: false
           file-install: false
+          # bats-action curls api.github.com; auth raises the anonymous rate limit.
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -2,6 +2,7 @@ name: Chezmoi
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -2,6 +2,7 @@ name: Lychee
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,7 @@ name: Pre-commit
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/zellij.yml
+++ b/.github/workflows/zellij.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/zellij.yml
+++ b/.github/workflows/zellij.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/zellij.yml
+++ b/.github/workflows/zellij.yml
@@ -2,6 +2,7 @@ name: Zellij
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Context

Started as swapping `apt-get install bats` for `bats-core/bats-action`. Grew into a holistic review of the CI workflows — once the bats one was clean, applying the same shape across the other four was cheap and removes the same classes of issue everywhere.

Net changes:
- Bats: `bats-core/bats-action@4.0.0` replaces apt install; `github-token` passed to avoid GitHub API rate limits; bats-helper installs (support/assert/detik/file) disabled since tests don't load any; step renamed from `Run` to `Test` to match the verb-of-purpose pattern (`Install`/`Apply`/`Config`).
- All five workflows: `push:` branch-pinned to `main` so a PR push doesn't fire both `push` and `pull_request`; `permissions: contents: read` for least-privilege `GITHUB_TOKEN`; `concurrency:` with `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` so PR branches cancel themselves but main always queues; `timeout-minutes: 10` as runaway insurance; `runs-on: ubuntu-24.04` pinned (Renovate's `github-runners` manager — included in `config:recommended` — handles the bump).

Future-editor warnings (don't drop the install overrides, the github-token, or the cancel-in-progress conditional) live as inline comments at the lines they protect rather than here.

## Verification

- Confirmed all four bats-action `*-install` defaults are `true` by reading `action.yaml` at tag `4.0.0`.
- Confirmed `test/` doesn't `bats_load_library` or `load` any helper libs (`grep -r 'bats_load_library\|^load ' test/` returns nothing).
- First CI run failed on a 403 from the anonymous GitHub API; adding `github-token` resolved it and all subsequent runs were green.
