### PR TITLE
split chezmoi workflow into named install steps

### DIFF
--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -20,13 +20,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+
+      - name: Install age
         run: |
-          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
           sudo apt-get update -qq
           sudo apt-get install -y -qq age
-          mkdir -p ~/.config/chezmoi
-          age-keygen -o ~/.config/chezmoi/key.txt 2>/dev/null
 
-      - name: Apply
+      - name: Generate ephemeral age key
+        run: |
+          mkdir -p ~/.config/chezmoi
+          age-keygen -o ~/.config/chezmoi/key.txt
+
+      - name: Check apply
         run: script/check-chezmoi-apply


### PR DESCRIPTION
## Context

Splits the monolithic Install step in `.github/workflows/chezmoi.yml` into three named steps (chezmoi, age, ephemeral key) so a CI failure points at a specific concern. Renames the validation step from \`Apply\` to \`Check apply\` to match the \`check-\` verb of \`script/check-chezmoi-apply\` (the script doesn't apply to \$HOME — it validates a temp-dir apply).

## Verification

Ran pre-commit against the changed workflow (no YAML hooks fire, but file was inspected). Reviewed the diff visually; behaviour is unchanged. CI itself exercises the new step layout.