### PR TITLE
move lychee options to lychee.toml for local/CI parity

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,6 +1,7 @@
 CLAUDE.md
 LICENSE
 README.md
+lychee.toml
 renovate.json
 script
 test

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,3 +1,4 @@
+.lycheecache
 CLAUDE.md
 LICENSE
 README.md

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: .lycheecache
-          key: lychee-cache-${{ hashFiles('README.md', 'dot_config/zellij/config.kdl') }}
+          key: lychee-cache-${{ hashFiles('lychee.toml', 'README.md', 'dot_config/zellij/config.kdl') }}
           restore-keys: lychee-cache-
       - uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: '--cache --retry-wait-time 5 README.md dot_config/zellij/config.kdl'
+          args: 'README.md dot_config/zellij/config.kdl'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,2 @@
+cache = true
+retry_wait_time = 5


### PR DESCRIPTION
## Context

Moves \`--cache\` and \`--retry-wait-time 5\` out of \`.github/workflows/lychee.yml\` into a repo-root \`lychee.toml\` so local invocations (\`lychee README.md dot_config/zellij/config.kdl\`) pick up the same options CI uses. Inputs stay as positional args in the workflow because lychee's TOML has no \`inputs\` key (only \`files_from\`, which is extra indirection for two files).

## Gotchas

\`lychee.toml\` is added to \`.chezmoiignore\` so chezmoi does not deploy it to \`\$HOME\`. The \`actions/cache\` key now also hashes \`lychee.toml\` so config edits bust the cache.

## Verification

Ran \`script/check-chezmoi-apply\` against the working tree — passed. Spot-checked \`chezmoi apply --destination=<tmp>\` and confirmed \`lychee.toml\` is not deployed. Pre-commit had no hooks applicable to the touched files.