### PR TITLE
rename zellij workflow steps to match check- pattern

### DIFF
--- a/.github/workflows/zellij.yml
+++ b/.github/workflows/zellij.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install
+      - name: Install zellij
         env:
           ZELLIJ_VERSION: v0.44.1
         run: |
@@ -30,5 +30,5 @@ jobs:
           tar -xzf /tmp/zellij.tar.gz -C /tmp
           sudo install -m 0755 /tmp/zellij /usr/local/bin/zellij
 
-      - name: Config
+      - name: Check config
         run: script/check-zellij-config


### PR DESCRIPTION
## Context

Renames the two steps in \`.github/workflows/zellij.yml\` (\`Install\` → \`Install zellij\`, \`Config\` → \`Check config\`) to match the pattern from #38: named install step, and a validation step that mirrors the \`check-\` verb of \`script/check-zellij-config\`. No behavioural change.

## Verification

Ran \`script/check-zellij-config\` locally — passed. Diff is rename-only; no logic touched.