### PR TITLE
add cli.github.com apt repo so gh upgrades past 2.23

### DIFF
--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -16,6 +16,21 @@ if [ ! -f /usr/share/keyrings/hashicorp-archive-keyring.gpg ]; then
     "$(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
 fi
 
+# ---------------------------------------------------------------- github cli
+# Debian's gh package is too stale (2.23, Feb 2023) — `gh pr edit` errors
+# on the deprecated `projectCards` GraphQL field. Pull from the official
+# cli.github.com repo so fresh installs get a current version. Existing
+# hosts need a one-time `sudo apt-get install --only-upgrade -y gh` after
+# this repo is in place; the APT_PACKAGES block below only installs
+# missing packages, not upgrades.
+if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
+  log "github-cli: adding apt repository"
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+    sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+  printf 'deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+    "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+fi
+
 # -------------------------------------------------------------------- apt pkgs
 APT_PACKAGES=(gh zsh ripgrep fd-find fzf jq unzip age terraform)
 missing=()

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -17,12 +17,6 @@ if [ ! -f /usr/share/keyrings/hashicorp-archive-keyring.gpg ]; then
 fi
 
 # ---------------------------------------------------------------- github cli
-# Debian's gh package is too stale (2.23, Feb 2023) — `gh pr edit` errors
-# on the deprecated `projectCards` GraphQL field. Pull from the official
-# cli.github.com repo so fresh installs get a current version. Existing
-# hosts need a one-time `sudo apt-get install --only-upgrade -y gh` after
-# this repo is in place; the APT_PACKAGES block below only installs
-# missing packages, not upgrades.
 if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
   log "github-cli: adding apt repository"
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |


### PR DESCRIPTION
## Context

Debian's apt-installed `gh` package is 2.23 (Feb 2023), which queries
the deprecated `projectCards` GraphQL field as part of `pr edit`'s
default response. GitHub now returns that field as a hard error rather
than a soft warning, so `gh pr edit` fails on stale gh — regardless of
whether the PR or repo has any projects attached. Surfaced while
trying to update the body of #44.

Mirrors the existing hashicorp-repo block exactly: add the vendor's
signing key + sources.list entry, leave the actual install to the
existing APT_PACKAGES loop.

## Gotchas

Existing hosts already on `gh` 2.23 need a one-time manual upgrade
after this lands — the APT_PACKAGES loop only installs missing
packages, not upgrades. The fix is one command:

```
sudo apt-get update && sudo apt-get install --only-upgrade -y gh
```

Could have added that as a forced step in the bootstrap, but that
would deviate from the hashicorp pattern (which has the same
characteristic for terraform updates) without strong justification.

## Verification

- `pre-commit run --files run_once_before_01-install-system-packages.sh.tmpl`
  → shellcheck and shfmt pass.
- Bootstrap script not exercised end-to-end (it modifies /etc/apt
  and requires sudo); will validate by running `chezmoi apply`
  after merge and confirming `gh --version` shows >2.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)