### PR TITLE
add CLAUDE.md sections: comments, don't test upstream

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -89,6 +89,24 @@ reliable enough.
   rather than picking a side. A confident wrong answer costs more than
   one round of "let me confirm".
 
+## Comments
+
+- Default to no comment. Earn each one by asking "would this be true
+  and useful 18 months from now to a stranger?" Drop procedural
+  restatements, parentheticals describing what standard tools do,
+  commit-message framing ("we used to test X but stopped"), and
+  versions/dates that rot. Keep timeless WHY, non-obvious patterns,
+  and protocol details not visible in code. Match the precedent in
+  the surrounding file.
+
+## Don't test upstream
+
+- If the language, library, or tool is responsible for a behaviour,
+  don't add a check for it — upstream's tests cover that better than
+  yours can. Project tests cover project-specific logic only: your
+  code's invariants, your config's cross-references, your wrappers'
+  added behaviour.
+
 ## Growing this file
 
 Add a rule here once the same friction shows up in more than one project.


### PR DESCRIPTION
## Context

Two universal principles surfaced through repeated correction across
PRs #43-#45. Both apply to any codebase, not just this one, so they
belong in the cross-machine guide rather than as project memory.

The "show up in more than one project" rule from \`Growing this file\`
is technically not yet met — both came from this repo's review cycle —
but the principles are clear enough that waiting for a second project
to re-establish them would just be friction.

## Gotchas

A separate tightening pass on the existing sections is worth
considering as a follow-up — several have grown verbose enough
that the new \`Comments\` section's bar would tighten them too. Held
off here to keep this diff focused on additions only.

## Verification

Reviewed both new sections against the bar each one establishes:
- "Comments" passes its own test (timeless principle, no
  procedural restatement, no rotting versions).
- "Don't test upstream" is a single direct rule with one example
  paragraph for application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)