### PR TITLE
rephrase Fowler framing as actionable Where-rules-live

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,13 +1,7 @@
 # Claude Code -- user-level guide
 
-Cross-machine defaults for every Claude Code session on this host. A per-repo
-`CLAUDE.md` overrides anything here.
-
-Framed on Martin Fowler's harness-engineering model: this file is a *guide*
-(feedforward -- steers behaviour before an action). Deterministic *sensors*
-(tests, linters, type-checkers) live per-project, not here. Hooks in
-`settings.json` enforce the rules below for the cases where text alone is not
-reliable enough.
+Cross-machine defaults for every Claude Code session on this host.
+A per-repo `CLAUDE.md` overrides anything here.
 
 ## Pull requests
 
@@ -107,9 +101,17 @@ reliable enough.
   code's invariants, your config's cross-references, your wrappers'
   added behaviour.
 
-## Growing this file
+## Where rules live
 
-Add a rule here once the same friction shows up in more than one project.
-If a rule needs to be deterministic (Claude must not be able to forget it),
-pair it with a hook in `settings.json` instead of -- or in addition to --
-a bullet here.
+When a new rule is needed, choose the mechanism by how it must
+behave:
+
+- **CLAUDE.md text** — for behaviour Claude can be trusted to follow
+  consistently after reading. Default choice. Add here once friction
+  shows up in more than one project.
+- **`settings.json` hooks** — for behaviour Claude must not be able
+  to forget. Pair with text in CLAUDE.md when both reinforcement and
+  enforcement are wanted.
+- **Per-project sensors** (tests, linters, type-checkers) — for
+  detecting violations after the fact. Live with the project, not
+  here.


### PR DESCRIPTION
## Context

The Martin Fowler harness-engineering paragraph in the preamble was
meta-context for the human reader, not directive for Claude. Replaced
with a tighter preamble (just "what is this file") and folded the
substance into a new "Where rules live" section that turns Fowler's
distinction into a decision framework Claude can apply.

The new section subsumes the old "Growing this file" section. The
previous version only covered guide-vs-hook; the new one adds
sensors as a third option.

## Gotchas

The "show up in more than one project" guideline is preserved, just
moved into the bullet for CLAUDE.md text rather than living in its
own section.

## Verification

Reviewed the new section against the existing \`Comments\` bar — no
procedural restatement, no rotting versions, decision-framework
substance is timeless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)