### PR TITLE
broaden lychee scope to all markdown and KDL files

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: .lycheecache
-          key: lychee-cache-${{ hashFiles('lychee.toml', 'README.md', 'dot_config/zellij/config.kdl') }}
+          key: lychee-cache-${{ hashFiles('lychee.toml', '**/*.md', '**/*.kdl') }}
           restore-keys: lychee-cache-
       - uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: 'README.md dot_config/zellij/config.kdl'
+          args: '**/*.md **/*.kdl'


### PR DESCRIPTION
## Context

`.github/workflows/lychee.yml` listed `README.md` and `dot_config/zellij/config.kdl` explicitly, which means new doc-style files would silently miss link checking until someone remembered to edit the workflow. Switch to `**/*.md **/*.kdl` so coverage extends automatically.

## Gotchas

Focus on why the globs stop at markdown/KDL rather than scanning everything: a quick `grep -lE 'https?://'` across tracked files turns up `run_once_before_*.sh.tmpl`, `renovate.json`, and `dot_claude/settings.json.tmpl`, all of which embed URLs that aren't meant for fetching — shell variable interpolation (`.../releases/download/${ZELLIJ_VERSION}`), regex patterns in renovate config (`https://github\\.com/...`), schema refs. Including those would generate false-positive failures. The doc-format globs match the convention any future link-bearing file will follow.

## Verification

Inspected the URL surface across the tree before deciding scope; confirmed the only files currently containing plain http(s) URLs in clickable form are `README.md` and `dot_config/zellij/config.kdl`, so this PR is no-op against current content but future-proofs the workflow. CI will re-run lychee with the new globs.