### PR TITLE
factor binary installs into per-tool scripts shared with CI

### DIFF
--- a/.github/workflows/zellij.yml
+++ b/.github/workflows/zellij.yml
@@ -21,14 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install zellij
-        env:
-          ZELLIJ_VERSION: v0.44.1
         run: |
-          arch="x86_64-unknown-linux-musl"
-          base="https://github.com/zellij-org/zellij/releases/download/${ZELLIJ_VERSION}"
-          curl -fsSL -o /tmp/zellij.tar.gz "$base/zellij-${arch}.tar.gz"
-          tar -xzf /tmp/zellij.tar.gz -C /tmp
-          sudo install -m 0755 /tmp/zellij /usr/local/bin/zellij
+          script/install-zellij --bin-dir "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check config
         run: script/check-zellij-config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ software project — naming conventions and file structure follow chezmoi rules.
 - `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:
   01 system packages, 02 binary tools, 03 Node ecosystem, 04 Rust ecosystem,
   05 standalone tools
+- `script/install-{zellij,lazygit,act}` — per-tool installers (version pinned
+  inside, `--bin-dir DIR` required, SHA256-verified). Invoked by the 02
+  bootstrap script and reused by CI workflows so versions live in one place.
 
 ## Previewing and testing changes
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["run_once_before_.*\\.sh\\.tmpl$"],
+      "fileMatch": ["^script/install-zellij$"],
       "matchStrings": ["ZELLIJ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "zellij-org/zellij",
       "datasourceTemplate": "github-releases"
@@ -18,23 +18,16 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["run_once_before_.*\\.sh\\.tmpl$"],
+      "fileMatch": ["^script/install-lazygit$"],
       "matchStrings": ["LAZYGIT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "jesseduffield/lazygit",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["run_once_before_.*\\.sh\\.tmpl$"],
+      "fileMatch": ["^script/install-act$"],
       "matchStrings": ["ACT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "nektos/act",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["\\.github/workflows/zellij\\.yml$"],
-      "matchStrings": ["ZELLIJ_VERSION: (?<currentValue>v[\\d.]+)"],
-      "depNameTemplate": "zellij-org/zellij",
       "datasourceTemplate": "github-releases"
     },
     {

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -1,97 +1,16 @@
 #!/usr/bin/env bash
-# Installs pre-built binaries from GitHub releases into ~/.local/bin.
-# Each binary is pinned to an exact version and verified against upstream
-# checksums.
+# install-zellij content:  {{ include "script/install-zellij" | sha256sum }}
+# install-lazygit content: {{ include "script/install-lazygit" | sha256sum }}
+# install-act content:     {{ include "script/install-act" | sha256sum }}
+# The hashes above embed the install scripts' content into this file's
+# rendered output so chezmoi re-runs this script when any of them change
+# (e.g. version bumps). Without them, run_once would not re-fire.
 
 set -euo pipefail
 
-log() { printf '==> %s\n' "$*" >&2; }
+SCRIPT_DIR="{{ .chezmoi.sourceDir }}/script"
+"$SCRIPT_DIR/install-zellij" --bin-dir "$HOME/.local/bin"
+"$SCRIPT_DIR/install-lazygit" --bin-dir "$HOME/.local/bin"
+"$SCRIPT_DIR/install-act" --bin-dir "$HOME/.local/bin"
 
-# ------------------------------------------------------------------- zellij
-ZELLIJ_VERSION="v0.44.1"
-ZELLIJ_BIN="$HOME/.local/bin/zellij"
-if [ -x "$ZELLIJ_BIN" ] && "$ZELLIJ_BIN" --version 2>/dev/null | grep -qF "${ZELLIJ_VERSION#v}"; then
-  log "zellij: $ZELLIJ_VERSION already installed"
-else
-  log "zellij: downloading $ZELLIJ_VERSION"
-  tmp="$(mktemp -d)"
-  arch="x86_64-unknown-linux-musl"
-  base="https://github.com/zellij-org/zellij/releases/download/${ZELLIJ_VERSION}"
-  curl -fsSL -o "$tmp/zellij.tar.gz" "$base/zellij-${arch}.tar.gz"
-  curl -fsSL -o "$tmp/zellij.sha256sum" "$base/zellij-${arch}.sha256sum"
-  # The published .sha256sum file labels the binary by its CI build path
-  # (target/.../zellij), not the tarball name -- so `sha256sum -c` on it
-  # fails. Extract the expected hash and verify the extracted binary
-  # against it explicitly.
-  expected="$(awk '{print $1}' "$tmp/zellij.sha256sum")"
-  tar -xzf "$tmp/zellij.tar.gz" -C "$tmp"
-  actual="$(sha256sum "$tmp/zellij" | awk '{print $1}')"
-  if [ "$expected" != "$actual" ]; then
-    printf 'zellij: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-    exit 1
-  fi
-  mkdir -p "$HOME/.local/bin"
-  install -m 0755 "$tmp/zellij" "$ZELLIJ_BIN"
-  rm -rf "$tmp"
-fi
-
-# ------------------------------------------------------------------- lazygit
-LAZYGIT_VERSION="v0.61.1"
-LAZYGIT_BIN="$HOME/.local/bin/lazygit"
-if [ -x "$LAZYGIT_BIN" ] && "$LAZYGIT_BIN" --version 2>/dev/null | grep -qF "${LAZYGIT_VERSION#v}"; then
-  log "lazygit: $LAZYGIT_VERSION already installed"
-else
-  log "lazygit: downloading $LAZYGIT_VERSION"
-  tmp="$(mktemp -d)"
-  base="https://github.com/jesseduffield/lazygit/releases/download/${LAZYGIT_VERSION}"
-  asset="lazygit_${LAZYGIT_VERSION#v}_linux_x86_64.tar.gz"
-  curl -fsSL -o "$tmp/$asset" "$base/$asset"
-  curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
-  expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
-  if [ -z "$expected" ]; then
-    printf 'lazygit: no checksum entry for %s in checksums.txt\n' "$asset" >&2
-    exit 1
-  fi
-  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
-  if [ "$expected" != "$actual" ]; then
-    printf 'lazygit: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-    exit 1
-  fi
-  tar -xzf "$tmp/$asset" -C "$tmp" lazygit
-  mkdir -p "$HOME/.local/bin"
-  install -m 0755 "$tmp/lazygit" "$LAZYGIT_BIN"
-  rm -rf "$tmp"
-fi
-
-# ----------------------------------------------------------------------- act
-ACT_VERSION="v0.2.87"
-ACT_BIN="$HOME/.local/bin/act"
-if [ -x "$ACT_BIN" ] && "$ACT_BIN" --version 2>/dev/null | grep -qF "${ACT_VERSION#v}"; then
-  log "act: $ACT_VERSION already installed"
-else
-  log "act: downloading $ACT_VERSION"
-  tmp="$(mktemp -d)"
-  base="https://github.com/nektos/act/releases/download/${ACT_VERSION}"
-  asset="act_Linux_x86_64.tar.gz"
-  curl -fsSL -o "$tmp/$asset" "$base/$asset"
-  curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
-  expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
-  if [ -z "$expected" ]; then
-    printf 'act: no checksum entry for %s in checksums.txt\n' "$asset" >&2
-    exit 1
-  fi
-  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
-  if [ "$expected" != "$actual" ]; then
-    printf 'act: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-    exit 1
-  fi
-  tar -xzf "$tmp/$asset" -C "$tmp" act
-  mkdir -p "$HOME/.local/bin"
-  install -m 0755 "$tmp/act" "$ACT_BIN"
-  rm -rf "$tmp"
-fi
-
-# ---------------------------------------------------------------- zellij dirs
 mkdir -p "$HOME/.config/zellij/plugins"
-
-log "binary tools complete"

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -2,6 +2,7 @@
 # install-zellij content:  {{ include "script/install-zellij" | sha256sum }}
 # install-lazygit content: {{ include "script/install-lazygit" | sha256sum }}
 # install-act content:     {{ include "script/install-act" | sha256sum }}
+# lib.sh content:          {{ include "script/lib.sh" | sha256sum }}
 # The hashes above embed the install scripts' content into this file's
 # rendered output so chezmoi re-runs this script when any of them change
 # (e.g. version bumps). Without them, run_once would not re-fire.

--- a/script/install-act
+++ b/script/install-act
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACT_VERSION="v0.2.87"
+ARCH="Linux_x86_64"
+
+bin_dir=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bin-dir)
+      [ $# -ge 2 ] || {
+        echo "install-act: --bin-dir requires an argument" >&2
+        exit 2
+      }
+      bin_dir="$2"
+      shift 2
+      ;;
+    *)
+      echo "install-act: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+[ -n "$bin_dir" ] || {
+  echo "install-act: --bin-dir DIR required" >&2
+  exit 2
+}
+
+bin="$bin_dir/act"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${ACT_VERSION#v}"; then
+  printf '==> act: %s already installed at %s\n' "$ACT_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> act: downloading %s\n' "$ACT_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/nektos/act/releases/download/${ACT_VERSION}"
+asset="act_${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
+
+expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
+if [ -z "$expected" ]; then
+  printf 'install-act: no checksum entry for %s in checksums.txt\n' "$asset" >&2
+  exit 1
+fi
+actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  printf 'install-act: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp/$asset" -C "$tmp" act
+mkdir -p "$bin_dir"
+install -m 0755 "$tmp/act" "$bin"

--- a/script/install-act
+++ b/script/install-act
@@ -4,29 +4,12 @@ set -euo pipefail
 ACT_VERSION="v0.2.87"
 ARCH="Linux_x86_64"
 
-bin_dir=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --bin-dir)
-      [ $# -ge 2 ] || {
-        echo "install-act: --bin-dir requires an argument" >&2
-        exit 2
-      }
-      bin_dir="$2"
-      shift 2
-      ;;
-    *)
-      echo "install-act: unknown argument: $1" >&2
-      exit 2
-      ;;
-  esac
-done
-[ -n "$bin_dir" ] || {
-  echo "install-act: --bin-dir DIR required" >&2
-  exit 2
-}
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
 
-bin="$bin_dir/act"
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/act"
 if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${ACT_VERSION#v}"; then
   printf '==> act: %s already installed at %s\n' "$ACT_VERSION" "$bin" >&2
   exit 0
@@ -41,17 +24,9 @@ asset="act_${ARCH}.tar.gz"
 curl -fsSL -o "$tmp/$asset" "$base/$asset"
 curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
 
-expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
-if [ -z "$expected" ]; then
-  printf 'install-act: no checksum entry for %s in checksums.txt\n' "$asset" >&2
-  exit 1
-fi
-actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
-if [ "$expected" != "$actual" ]; then
-  printf 'install-act: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-  exit 1
-fi
+expected="$(expected_from_checksums "$tmp/checksums.txt" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
 
 tar -xzf "$tmp/$asset" -C "$tmp" act
-mkdir -p "$bin_dir"
+mkdir -p "$BIN_DIR"
 install -m 0755 "$tmp/act" "$bin"

--- a/script/install-lazygit
+++ b/script/install-lazygit
@@ -4,29 +4,12 @@ set -euo pipefail
 LAZYGIT_VERSION="v0.61.1"
 ARCH="linux_x86_64"
 
-bin_dir=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --bin-dir)
-      [ $# -ge 2 ] || {
-        echo "install-lazygit: --bin-dir requires an argument" >&2
-        exit 2
-      }
-      bin_dir="$2"
-      shift 2
-      ;;
-    *)
-      echo "install-lazygit: unknown argument: $1" >&2
-      exit 2
-      ;;
-  esac
-done
-[ -n "$bin_dir" ] || {
-  echo "install-lazygit: --bin-dir DIR required" >&2
-  exit 2
-}
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
 
-bin="$bin_dir/lazygit"
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/lazygit"
 if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${LAZYGIT_VERSION#v}"; then
   printf '==> lazygit: %s already installed at %s\n' "$LAZYGIT_VERSION" "$bin" >&2
   exit 0
@@ -41,17 +24,9 @@ asset="lazygit_${LAZYGIT_VERSION#v}_${ARCH}.tar.gz"
 curl -fsSL -o "$tmp/$asset" "$base/$asset"
 curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
 
-expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
-if [ -z "$expected" ]; then
-  printf 'install-lazygit: no checksum entry for %s in checksums.txt\n' "$asset" >&2
-  exit 1
-fi
-actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
-if [ "$expected" != "$actual" ]; then
-  printf 'install-lazygit: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-  exit 1
-fi
+expected="$(expected_from_checksums "$tmp/checksums.txt" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
 
 tar -xzf "$tmp/$asset" -C "$tmp" lazygit
-mkdir -p "$bin_dir"
+mkdir -p "$BIN_DIR"
 install -m 0755 "$tmp/lazygit" "$bin"

--- a/script/install-lazygit
+++ b/script/install-lazygit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LAZYGIT_VERSION="v0.61.1"
+ARCH="linux_x86_64"
+
+bin_dir=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bin-dir)
+      [ $# -ge 2 ] || {
+        echo "install-lazygit: --bin-dir requires an argument" >&2
+        exit 2
+      }
+      bin_dir="$2"
+      shift 2
+      ;;
+    *)
+      echo "install-lazygit: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+[ -n "$bin_dir" ] || {
+  echo "install-lazygit: --bin-dir DIR required" >&2
+  exit 2
+}
+
+bin="$bin_dir/lazygit"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${LAZYGIT_VERSION#v}"; then
+  printf '==> lazygit: %s already installed at %s\n' "$LAZYGIT_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> lazygit: downloading %s\n' "$LAZYGIT_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/jesseduffield/lazygit/releases/download/${LAZYGIT_VERSION}"
+asset="lazygit_${LAZYGIT_VERSION#v}_${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
+
+expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")"
+if [ -z "$expected" ]; then
+  printf 'install-lazygit: no checksum entry for %s in checksums.txt\n' "$asset" >&2
+  exit 1
+fi
+actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  printf 'install-lazygit: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp/$asset" -C "$tmp" lazygit
+mkdir -p "$bin_dir"
+install -m 0755 "$tmp/lazygit" "$bin"

--- a/script/install-zellij
+++ b/script/install-zellij
@@ -4,29 +4,12 @@ set -euo pipefail
 ZELLIJ_VERSION="v0.44.1"
 ARCH="x86_64-unknown-linux-musl"
 
-bin_dir=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --bin-dir)
-      [ $# -ge 2 ] || {
-        echo "install-zellij: --bin-dir requires an argument" >&2
-        exit 2
-      }
-      bin_dir="$2"
-      shift 2
-      ;;
-    *)
-      echo "install-zellij: unknown argument: $1" >&2
-      exit 2
-      ;;
-  esac
-done
-[ -n "$bin_dir" ] || {
-  echo "install-zellij: --bin-dir DIR required" >&2
-  exit 2
-}
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
 
-bin="$bin_dir/zellij"
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/zellij"
 if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${ZELLIJ_VERSION#v}"; then
   printf '==> zellij: %s already installed at %s\n' "$ZELLIJ_VERSION" "$bin" >&2
   exit 0
@@ -45,11 +28,7 @@ curl -fsSL -o "$tmp/zellij.sha256sum" "$base/zellij-${ARCH}.sha256sum"
 # Extract the expected hash and verify the unpacked binary explicitly.
 expected="$(awk '{print $1}' "$tmp/zellij.sha256sum")"
 tar -xzf "$tmp/zellij.tar.gz" -C "$tmp"
-actual="$(sha256sum "$tmp/zellij" | awk '{print $1}')"
-if [ "$expected" != "$actual" ]; then
-  printf 'install-zellij: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
-  exit 1
-fi
+verify_sha256 "$tmp/zellij" "$expected"
 
-mkdir -p "$bin_dir"
+mkdir -p "$BIN_DIR"
 install -m 0755 "$tmp/zellij" "$bin"

--- a/script/install-zellij
+++ b/script/install-zellij
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZELLIJ_VERSION="v0.44.1"
+ARCH="x86_64-unknown-linux-musl"
+
+bin_dir=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bin-dir)
+      [ $# -ge 2 ] || {
+        echo "install-zellij: --bin-dir requires an argument" >&2
+        exit 2
+      }
+      bin_dir="$2"
+      shift 2
+      ;;
+    *)
+      echo "install-zellij: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+[ -n "$bin_dir" ] || {
+  echo "install-zellij: --bin-dir DIR required" >&2
+  exit 2
+}
+
+bin="$bin_dir/zellij"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${ZELLIJ_VERSION#v}"; then
+  printf '==> zellij: %s already installed at %s\n' "$ZELLIJ_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> zellij: downloading %s\n' "$ZELLIJ_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/zellij-org/zellij/releases/download/${ZELLIJ_VERSION}"
+curl -fsSL -o "$tmp/zellij.tar.gz" "$base/zellij-${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/zellij.sha256sum" "$base/zellij-${ARCH}.sha256sum"
+
+# zellij's published .sha256sum labels the binary by its CI build path
+# (target/.../zellij), not the tarball name -- so `sha256sum -c` fails.
+# Extract the expected hash and verify the unpacked binary explicitly.
+expected="$(awk '{print $1}' "$tmp/zellij.sha256sum")"
+tar -xzf "$tmp/zellij.tar.gz" -C "$tmp"
+actual="$(sha256sum "$tmp/zellij" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  printf 'install-zellij: sha256 mismatch -- expected %s, got %s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+mkdir -p "$bin_dir"
+install -m 0755 "$tmp/zellij" "$bin"

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -1,0 +1,55 @@
+# shellcheck shell=bash
+# Shared helpers for script/install-* scripts. Source from the same dir.
+
+# Parse --bin-dir DIR from the install script's arguments. Sets BIN_DIR.
+# Errors (return 2) on missing or unknown arguments.
+parse_bin_dir() {
+  BIN_DIR=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --bin-dir)
+        [ $# -ge 2 ] || {
+          echo "${0##*/}: --bin-dir requires an argument" >&2
+          return 2
+        }
+        BIN_DIR="$2"
+        shift 2
+        ;;
+      *)
+        echo "${0##*/}: unknown argument: $1" >&2
+        return 2
+        ;;
+    esac
+  done
+  [ -n "$BIN_DIR" ] || {
+    echo "${0##*/}: --bin-dir DIR required" >&2
+    return 2
+  }
+}
+
+# Look up the SHA256 of ASSET in a `<hash>  <filename>` style checksums
+# file. Prints the hash on stdout. Returns 1 if no entry is found.
+expected_from_checksums() {
+  local file="$1" asset="$2"
+  local hash
+  hash="$(awk -v f="$asset" '$2 == f {print $1}' "$file")"
+  if [ -z "$hash" ]; then
+    printf '%s: no checksum entry for %s in %s\n' \
+      "${0##*/}" "$asset" "${file##*/}" >&2
+    return 1
+  fi
+  printf '%s' "$hash"
+}
+
+# Compare sha256(FILE) against EXPECTED. Returns 1 with a diagnostic on
+# mismatch, 0 on match. Caller's set -e propagates the failure.
+verify_sha256() {
+  local file="$1" expected="$2"
+  local actual
+  actual="$(sha256sum "$file" | awk '{print $1}')"
+  if [ "$expected" != "$actual" ]; then
+    printf '%s: sha256 mismatch on %s -- expected %s, got %s\n' \
+      "${0##*/}" "${file##*/}" "$expected" "$actual" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## Context

Today the zellij CI workflow re-implements the same install logic as the
chezmoi `run_once_before_02-install-binary-tools.sh.tmpl` (same version
pin, no checksum verification), so the two can drift and CI is weaker
on supply-chain hygiene than the local install. This PR pulls the
zellij/lazygit/act installers into `script/install-{zellij,lazygit,act}`
and has both chezmoi and the zellij workflow call them.

## Gotchas

Focus on `run_once_before_02-install-binary-tools.sh.tmpl` because the
three `{{ include … | sha256sum }}` comment lines do real work:
without them the run_once script's rendered output never changes when
an install script is updated, so chezmoi would not re-fire on a
version bump. Worth confirming you're happy with that mechanism vs.
e.g. switching to `run_onchange_before_`.

The zellij workflow now installs into `~/.local/bin` and prepends to
`$GITHUB_PATH` (no sudo) — preserves the spirit of the previous
"sudo only on the final move" while removing sudo entirely.

## Verification

- ran each `script/install-*` into a tmpdir end-to-end on Linux x86_64
  and confirmed the SHA256 path passes; re-running `install-zellij`
  hit the idempotent skip
- rendered the bootstrap with `chezmoi execute-template
  --source=…/alunduil-chezmoi` and shellchecked the rendered output
- `pre-commit run --all-files`, `bats test/`,
  `script/check-zellij-config`, `script/check-chezmoi-apply` all green