### PR TITLE
expand and tighten user-level CLAUDE.md

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -3,115 +3,185 @@
 Cross-machine defaults for every Claude Code session on this host.
 A per-repo `CLAUDE.md` overrides anything here.
 
+## Communication
+
+- Ambiguous request: ask clarifying questions AND propose options
+  with trade-offs and a single recommendation. Don't silently pick.
+- Unambiguous request: state intent in a sentence and proceed.
+- Surface disagreement early. If your model of the problem differs
+  from the user's, settle it before investing in a solution that may
+  not match.
+- Mark uncertainty plainly ("I think", "haven't checked, but..."). When
+  confident and pushed back on, cite proof — file path, command
+  output, source.
+
 ## Pull requests
 
-- Open every PR as a draft. The user promotes to ready after reviewing.
-  Two deterministic enforcers cover the paths the model can take:
-  `~/.claude/hooks/pr-draft-guard.sh` blocks the GitHub MCP tools
-  (`mcp__github__create_pull_request` and its copilot variant) when
-  `draft=true` is missing, and `~/.local/bin/gh` shadows the apt `gh`
-  binary to require `--draft`/`-d` on `gh pr create`. Override
-  intentionally with `GH_DRAFT_GUARD=off gh pr create ...`.
-- PR body structure (assumes the PR will be squash-merged, so the body
-  is the surviving commit context):
-  - **Context** — one or two sentences on why this change exists. If an
-    issue exists, link it and state the PR's approach to it; do not
-    re-explain the issue.
-  - **Gotchas** — direct the reviewer: "focus on X because Y." Tell
-    them where to spend time, not just what is risky. Omit the heading
-    when there is nothing to flag.
-  - **Verification** — what was checked beyond CI (which is already
-    visible in the PR). Describe manual or exploratory testing that was
-    performed, using past tense ("ran X, confirmed Y"). Do not
-    re-list automated checks that CI covers.
+- Open every PR as a draft; the user promotes to ready after review.
+  Enforced by `~/.claude/hooks/pr-draft-guard.sh` (blocks GitHub MCP
+  `create_pull_request` and its copilot variant when `draft=true` is
+  missing) and `~/.local/bin/gh` (shadows `gh`, requires
+  `--draft`/`-d` on `gh pr create`). Override with
+  `GH_DRAFT_GUARD=off gh pr create ...`.
+- Use the repo's PR template when one exists. Otherwise, structure
+  the body (squash-merged, so this becomes the commit context):
+  - **Summary** — 1-2 sentences on what this PR delivers. Surface
+    the approach if the choice isn't obvious from the diff. Link the
+    issue if any; don't re-explain it.
+  - **Gotchas** — direct the reviewer: "focus on X because Y." Where
+    to spend time, not just what's risky. Omit when nothing to flag.
+  - **Verification** — what was checked beyond CI. Manual or
+    exploratory testing in past tense ("ran X, confirmed Y"). Don't
+    re-list CI checks.
+
+## Commits
+
+- [Seven rules of a great commit message](https://cbea.ms/git-commit/):
+  imperative subject ≤50 chars, blank line, wrapped body explaining
+  why and anything confusing.
+- Never force-push. If history needs cleanup, add commits; squash
+  merge collapses noise. Merge style and intermediate-commit
+  preservation are repo-specific; defer to the repo when stated.
 
 ## Issues
 
-- When a repo provides issue templates, use the matching template.
-  When no template exists, structure the issue body as follows:
-  - **Why** — the motivation: what problem exists, what opportunity is
-    being missed, or what user need is unmet. Lead with outcomes, not
-    implementation.
-  - **Done when** — one or two concrete acceptance criteria that define
-    the exit condition. State the desired end state without prescribing
-    the implementation path.
-- Before filing, check the repo's milestones and labels. Assign the
-  issue to the most relevant milestone (or leave it unset if none fits)
-  and apply labels that match the issue's type and area.
+- Use the repo's issue template when one exists. Otherwise:
+  - **Title** — statement true when done. Active voice, outcome
+    ("Profile writes persist across API restarts in Firestore",
+    not "Fix profile persistence").
+  - **Summary** — 1-2 sentences on what this delivers.
+  - **Motivation** — what problem, dependency, or opportunity drives
+    this.
+  - **Scope** — concrete changes required, specific enough to start
+    without ambiguity.
+  - **Acceptance criteria** — measurable conditions true when done.
+    Task-list syntax (`- [ ]`).
+  - **Additional context** — links, screenshots, related issues, when
+    they help.
+- Before filing, check milestones and labels. Assign to the most
+  relevant milestone (unset if none fits) and apply matching labels.
 
 ## Issue workflow
 
-- Before implementing a GitHub issue, read its comments and scan recent
-  commits in the relevant area to confirm the work is still relevant
-  given the current state of the repo. Surface a go/no-go before
-  writing code if anything looks stale (e.g., the tooling the issue
-  assumes has since been replaced).
-- For multi-step tasks, commit incrementally rather than batching all
-  changes for the end. Usage limits or interruptions then leave a
-  recoverable branch instead of lost work.
+- Before implementing an issue, read its comments and scan recent
+  commits in the area to confirm relevance. Surface a go/no-go before
+  writing code if anything looks stale (e.g. tooling the issue assumes
+  has been replaced).
+- Multi-step tasks: commit incrementally rather than batching.
+  Interruptions leave a recoverable branch, not lost work.
 
 ## Feedback preference
 
-- Run the project's computational sensors (tests, linters, type checker,
-  formatter) before claiming a task is done. Use inferential review
-  (another LLM reading the diff) to catch what those miss, not as a
-  substitute for them.
+- Run the project's computational sensors (tests, linters, type
+  checker, formatter) before claiming done. Use inferential review
+  (another LLM reading the diff) to catch what they miss, not as a
+  substitute.
 
 ## Approach
 
-- Prefer the simplest solution that meets the requirement. Before
-  writing custom scripts, guards, or wrappers, check whether a standard
-  mechanism (env var, official package repo, existing repo pattern)
-  already covers it. When the proposed change is more complex than
-  precedent in the repo, justify the divergence in one sentence or
-  pick the precedent.
-- Propose the minimal fix first. Add complexity only when the minimal
-  version is shown to be insufficient -- not pre-emptively.
+- Prefer the simplest solution that meets the requirement. Check for
+  a standard mechanism (env var, official package, existing repo
+  pattern) before writing custom scripts, guards, or wrappers. When
+  the change exceeds repo precedent, justify the divergence in one
+  sentence or pick the precedent.
+- Minimal fix first. Add complexity only when the minimal version
+  proves insufficient, not pre-emptively.
+- Rule of three before extracting an abstraction. Exception: when a
+  clean semantic concept is obvious upfront, name it early — shared
+  vocabulary beats loose duplicates that resist extraction.
 
 ## Scope
 
-- Fix the task that was asked. Don't refactor, rename, or tidy adjacent
+- Fix only what was asked. Don't refactor, rename, or tidy adjacent
   code in the same change unless explicitly requested.
+- Unrelated issues found mid-task: file separately by default.
+  Piggyback only when the inclusion is small, defensible, and called
+  out in the PR body.
 
 ## Verify before claiming
 
-- Don't assert behaviour you haven't checked. Claims like "this script
-  isn't bundled in the WASM", "the schema doesn't include this field",
-  "tests can't run in this environment", or "the issue is obsolete" need
-  a quick `grep`/`find`/`unzip -l`/WebFetch/devcontainer-exec first. When
-  verifying is too expensive, say "I haven't checked, but I think..."
-  rather than picking a side. A confident wrong answer costs more than
-  one round of "let me confirm".
+- Don't assert behaviour you haven't checked. Claims about bundled
+  contents, schema fields, environment capability, or issue staleness
+  need a quick `grep`/`find`/`unzip -l`/WebFetch/devcontainer-exec
+  first. When verifying is too expensive, say "I haven't checked, but
+  I think..." rather than picking a side.
 
 ## Comments
 
-- Default to no comment. Earn each one by asking "would this be true
-  and useful 18 months from now to a stranger?" Drop procedural
-  restatements, parentheticals describing what standard tools do,
+- Default to no comment. Earn each one with: "would this be true and
+  useful 18 months from now to a stranger?" Drop procedural
+  restatements, parentheticals describing standard tools,
   commit-message framing ("we used to test X but stopped"), and
   versions/dates that rot. Keep timeless WHY, non-obvious patterns,
-  and protocol details not visible in code. Match the precedent in
-  the surrounding file.
+  and protocol details not in code. Match the surrounding file's
+  precedent.
 
-## Don't test upstream
+## Documentation
 
-- If the language, library, or tool is responsible for a behaviour,
-  don't add a check for it — upstream's tests cover that better than
-  yours can. Project tests cover project-specific logic only: your
+Choose the cheapest layer that adds value; escalate only when the
+audience needs more:
+
+- Inline comment for non-obvious why.
+- Docstring on functions, modules, packages — interfaces future
+  readers land on.
+- Project documentation organised by [Diátaxis](https://diataxis.fr)
+  (tutorials / how-to / reference / explanation) for knowledge
+  shared across the project.
+- Repo-local `CLAUDE.md` when the audience is Claude, not a human.
+- Promote to `~/.claude/CLAUDE.md` when the same friction shows up
+  in more than one project.
+
+Human-read docs should be skimmable and earn their place.
+AI-targeted text (this file, repo-local `CLAUDE.md`, hooks, prompt
+templates) is loaded every relevant turn. Optimise for tokens, not
+readability: cut filler, decorative connectors, restated headings,
+and examples that don't disambiguate.
+
+## Tests
+
+- Don't test upstream. If a behaviour belongs to the language,
+  library, or tool, don't test it — upstream's tests cover that
+  better. Project tests cover project-specific logic only: your
   code's invariants, your config's cross-references, your wrappers'
   added behaviour.
+- Avoid test theatre. If a test would still pass after deleting the
+  code it claims to verify, it's decoration — delete or rewrite.
+  Assertions must exercise the claimed logic or requirement.
+
+## Before acting on shared or external state
+
+Local, reversible work (file edits, tests, builds) needs no
+confirmation — narrate, proceed. Pause and ask before anything hard
+to undo or touching state outside this checkout.
+
+- Hard-to-undo: force-pushing, modifying remote history, deleting
+  branches, deployments, dropping data, edits to host-wide config
+  that takes effect on next apply (e.g. `alunduil-chezmoi` source,
+  `~/.claude/settings.json`).
+- Installing tools: ask first. Prefer isolation (devcontainer, then
+  language-native venv). When a new tool earns its place, decide
+  whether it lives in the repo (isolated) or in `alunduil-chezmoi`
+  (host-wide) — surface the choice, don't pick silently.
+- Permission allowlists in `settings.json`: read-only fine to
+  propose; mutating local needs review; remote/external stays manual.
+
+## Subagents
+
+- Use subagents when they help control context or parallelise work,
+  provided their actions and findings remain recoverable. Prefer
+  agents that report concrete file paths, line numbers, and command
+  output over vague summaries.
 
 ## Where rules live
 
-When a new rule is needed, choose the mechanism by how it must
-behave:
+When a new rule is needed, choose the mechanism by required
+behaviour:
 
-- **CLAUDE.md text** — for behaviour Claude can be trusted to follow
-  consistently after reading. Default choice. Add here once friction
-  shows up in more than one project.
-- **`settings.json` hooks** — for behaviour Claude must not be able
-  to forget. Pair with text in CLAUDE.md when both reinforcement and
-  enforcement are wanted.
-- **Per-project sensors** (tests, linters, type-checkers) — for
-  detecting violations after the fact. Live with the project, not
-  here.
+- **CLAUDE.md text** — Claude can be trusted to follow it after
+  reading. Default choice. Add here once friction shows up in more
+  than one project.
+- **`settings.json` hooks** — Claude must not be able to forget.
+  Pair with CLAUDE.md text when reinforcement and enforcement are
+  both wanted.
+- **Per-project sensors** (tests, linters, type-checkers) — detect
+  violations after the fact. Live with the project.


### PR DESCRIPTION
## Summary

Adds Communication, Commits, Documentation, Before-acting, and Subagents sections; extends Approach, Scope, and Tests; restructures Issues to mirror the work-item template (matching the structure used in genshin.dungeon.studio) and parallels the template-first rule for PRs. Applies a token-optimisation pass across the file under the new "AI-targeted text optimises for tokens, not readability" rule (Documentation section).

The principles came from a structured Q&A. No logic affected — documentation only.

## Gotchas

Focus on whether each new principle's phrasing carries the intent correctly. Particularly worth a careful read:

- **Communication** — options-with-recommendation pattern; "surface disagreement early."
- **Documentation** — Diátaxis-based escalation hierarchy (inline → docstring → project docs → repo CLAUDE.md → user CLAUDE.md).
- **Before acting on shared or external state** — permission-allowlist tiering (read-only fine to propose, mutating local needs review, remote/external stays manual).
- **Tests** — "test theatre" definition (assertion would still pass after deleting the code it claims to verify).

Token pass on existing sections is semantics-preserving but worth a sanity check, especially Verify-before-claiming where concrete claim examples got abstracted into category names.

## Verification

Cross-checked CLAUDE.md's references against the actual files:

- `~/.claude/hooks/pr-draft-guard.sh` (`dot_claude/hooks/executable_pr-draft-guard.sh`) handles `mcp__github__create_pull_request` and the `_with_copilot` variant; blocks when `draft=true` is missing.
- `~/.local/bin/gh` (`dot_local/bin/executable_gh`) enforces `--draft`/`-d` on `gh pr create` and honours `GH_DRAFT_GUARD=off`.
- `settings.json.tmpl` matcher regex aligns with the hook's case statement.

All paths and behaviours described in CLAUDE.md match the source. CI handles markdown/link validation (lychee) and chezmoi-apply.