### PR TITLE
tighten Claude settings: ask gates, MCP reads

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -36,6 +36,14 @@
       "TodoWrite(*)",
       "Write(*)",
 
+      "mcp__claude_ai_Readwise__reader_get_*",
+      "mcp__claude_ai_Readwise__reader_list_*",
+      "mcp__claude_ai_Readwise__reader_search_*",
+      "mcp__claude_ai_Readwise__reader_export_*",
+      "mcp__claude_ai_Readwise__readwise_get_*",
+      "mcp__claude_ai_Readwise__readwise_list_*",
+      "mcp__claude_ai_Readwise__readwise_search_*",
+
       "Bash(awk:*)",
       "Bash(basename:*)",
       "Bash(bats:*)",
@@ -102,12 +110,26 @@
       "Bash(zellij:*)"
     ],
     "ask": [
+      "Bash(chezmoi apply*)",
+      "Bash(docker system prune*)",
+      "Bash(docker volume rm*)",
+      "Bash(find* -delete*)",
+      "Bash(find* -exec*)",
+      "Bash(find* -ok*)",
       "Bash(rm:*)",
-      "Bash(sudo:*)"
+      "Bash(sudo:*)",
+      "Bash(terraform apply*)",
+      "Bash(terraform destroy*)",
+      "Bash(xargs rm*)",
+      "Bash(xargs* rm*)",
+      "Bash(xargs sudo*)",
+      "Bash(xargs* sudo*)"
     ],
     "deny": [
       "Bash(git push --force*)",
-      "Bash(git push*--force*)"
+      "Bash(git push*--force*)",
+      "Bash(git push -f*)",
+      "Bash(git push* -f*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Tightens `dot_claude/settings.json.tmpl` permissions in three directions: allowlists read-only Readwise MCP tools so they stop prompting per session; adds ask gates for hard-to-undo or remote-affecting commands that were auto-allowed under broader patterns (`chezmoi apply`, `terraform apply`/`destroy`, `docker system prune`, `docker volume rm`); and closes find/xargs bypass paths plus the `git push -f` shorthand gap.

The "remote/external stays manual" rule from #51's CLAUDE.md was the trigger; this PR brings the actual settings file in line with the rule.

## Gotchas

- **Friction check.** The new ask gates will prompt on every `chezmoi apply`, `terraform apply`, `find -exec`, etc. If any of these are routine enough that prompting will get tiresome, easy to revert specific entries to `allow`.
- **Bypass coverage is targeted, not exhaustive.** xargs gates only catch `xargs rm` and `xargs sudo` (the realistic destructive verbs); other compositions like `xargs sed -i` are not gated. Same trade-off as the find approach — denying the construct entirely would block legitimate use.
- **`-uf` reverse-combined gap on git push.** Patterns that catch `git push -uf origin main` create false positives on branch names containing `-f`. The CLAUDE.md "never force-push" rule remains the primary defense; deny is a safety net.
- **Notion MCP deferred.** Server is configured but its tool list isn't accessible from this session; replicating the Readwise pattern needs the Notion tool list visible. Easy follow-up.

## Verification

- Template renders to valid JSON: `chezmoi execute-template < dot_claude/settings.json.tmpl | jq .` exits 0.
- Inspected rendered `.permissions.{allow, ask, deny}` via `jq` and confirmed every new entry lands in the right list (counts: allow 73→80, ask 2→14, deny 2→4).
- Pattern semantics traced manually for the non-trivial globs (`find* -exec*`, `xargs* rm*`, `git push* -f*`) against representative invocations and likely false-positive cases.