### PR TITLE
document and wire claustre Linux notifications

### DIFF
--- a/dot_claustre/config.toml
+++ b/dot_claustre/config.toml
@@ -1,2 +1,14 @@
+# Schema: https://github.com/pmbrull/claustre/blob/main/src/config/mod.rs
+# `claustre init` rewrites this file; expect drift after running the wizard.
+
+[claude]
+# Alias tracks latest Opus; otherwise claustre's pinned default (claude-opus-4-6) wins.
+model = "opus"
+
 [sync]
 auto_push = true
+
+[notifications]
+command = "notify-send"
+system  = false  # macOS-only path
+# Linux templates only see {task}; pr_url is system-path-only.

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -26,7 +26,7 @@ if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
 fi
 
 # -------------------------------------------------------------------- apt pkgs
-APT_PACKAGES=(gh zsh ripgrep fd-find fzf jq unzip age terraform)
+APT_PACKAGES=(gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin)
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do
   dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")


### PR DESCRIPTION
## Summary

Annotate `dot_claustre/config.toml` with rationale (schema source link, `claustre init` drift warning, the `{task}`-only template substitution on Linux), pin `[claude].model` to the `opus` alias so it tracks the latest release instead of claustre's stale pinned default, and wire `notify-send` as the notification command with the macOS-only system path disabled. Add `libnotify-bin` to the system-packages bootstrap so `notify-send` is available on fresh Crostini installs.

Related: #55 covers the larger upstream-dependent enrichment (project name in the toast, clickable PR URL) — this PR delivers only what's reachable without an upstream change.

## Gotchas

`~/.claustre/config.toml` is also written by `claustre init`, so re-running the wizard creates chezmoi drift. The in-file comment surfaces this risk where someone editing the file will see it; `chezmoi diff` remains the canonical signal that the source has fallen out of step with the deployed copy.

## Verification

- pre-commit (shellcheck, shfmt) passed on both modified files.
- ChromeOS notification bridge verified live before relying on `notify-send` — `gdbus call` against `org.freedesktop.Notifications` produced a visible toast, confirming the daemon owns the well-known name and surfaces messages even with empty introspection.
- Did not exercise the new config end-to-end via `claustre` itself (would require a task transition in a session); deferred to first real run post-merge.