### PR TITLE
add zjstatus PR widget to pair layout

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -4,19 +4,15 @@
 //
 // Plugins are pinned by release tag -- Zellij fetches and caches them in
 // ~/.cache/zellij/ on first use. Aliases (below) keep references short.
-// Per-tab UI (zellaude top strip, tab-bar, status-bar) lives in the layouts
-// (layouts/default.kdl, layouts/pair.kdl); a default_tab_template here
-// would not propagate into layout-spawned tabs anyway.
+// Per-tab UI lives in the layouts (layouts/default.kdl, layouts/pair.kdl);
+// a default_tab_template here would not propagate into layout-spawned tabs
+// anyway. The pair layout adds a zjstatus line for PR-aware status; default
+// stays minimal.
 
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
     ghost    location="https://github.com/vdbulcke/ghost/releases/download/v0.7.1/ghost.wasm"
-    notepad  location="https://github.com/0xble/zellij-notepad/releases/download/v0.2.1/notepad.wasm"
-}
-
-// notepad uses MessagePlugin "toggle" semantics, so it must be preloaded.
-load_plugins {
-    "notepad"
+    zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm"
 }
 
 keybinds {
@@ -35,10 +31,6 @@ keybinds {
                 shell "bash"
                 shell_flag "-ic"
             }
-        }
-        // Floating timestamped notepad in $EDITOR.
-        bind "Alt m" {
-            MessagePlugin "notepad" { name "toggle"; }
         }
     }
 }

--- a/dot_config/zellij/layouts/default.kdl
+++ b/dot_config/zellij/layouts/default.kdl
@@ -3,7 +3,7 @@
 // bundled tab-bar/status-bar but not zellaude — so the initial tab would be
 // missing the per-tab Claude Code activity strip.
 //
-// Template shape mirrors pair.kdl. Keep them in sync:
+// Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
 //   children   (the panes)
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -3,10 +3,9 @@
 // changes, drive Claude" side of pairing. On-demand shells come from ghost
 // (Alt+g) so no fixed terminal strip is reserved.
 //
-// Template shape mirrors default.kdl — zellij does not propagate config-level
-// templates into layout-spawned tabs, so each layout carries its own copy.
-// Keep this in sync with ../layouts/default.kdl:
+// Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
+//   zjstatus   (1 line) — open-PR list (gh pr list, refreshed every 60s)
 //   children   (the panes)
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
@@ -21,6 +20,15 @@ layout {
     default_tab_template {
         pane size=1 borderless=true {
             plugin location="zellaude"
+        }
+        pane size=1 borderless=true {
+            plugin location="zjstatus" {
+                format_left  ""
+                format_right "{command_prs}"
+                command_prs_command  "bash -lc zellij-pr-status"
+                command_prs_format   "#[fg=green]{stdout}"
+                command_prs_interval "60"
+            }
         }
         children
         pane size=1 borderless=true {

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Emit "PRs: #123  #456" where each #N is an OSC 8 hyperlink to the PR. The
+# zjstatus command_prs widget in ~/.config/zellij/layouts/pair.kdl invokes
+# this every 60s and renders {stdout} in the status line. Output is empty
+# when there are no open PRs or when gh fails (offline, rate-limited, not
+# authed) -- zjstatus then renders an empty segment, which is the right
+# silent-failure behaviour for a status widget.
+
+set -euo pipefail
+
+prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
+        | jq -r '.[] | "\(.number)\t\(.url)"') || exit 0
+
+[ -z "$prs" ] && exit 0
+
+printf 'PRs:'
+while IFS=$'\t' read -r number url; do
+  # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
+  printf '  \033]8;;%s\033\\#%s\033]8;;\033\\' "$url" "$number"
+done <<<"$prs"


### PR DESCRIPTION
## Summary

- Surface my own open PRs while pairing in zellij. A `zjstatus` pane sits under `zellaude` in `pair.kdl`, calling a small `~/.local/bin/zellij-pr-status` helper every 60s. The helper emits OSC 8 hyperlinks, so each `#N` is clickable in terminals that render them.
- Drops the unused `notepad` plugin (alias, `load_plugins`, `Alt+m` keybind) in the same change — the slot is more useful free.

## Gotchas

- **Pair-only change.** `default.kdl` is untouched; the third row is only worth the vertical real estate during deep pairing. Comment trims in both layouts removed the "keep in sync" framing now that the templates intentionally differ.
- **Silent-on-failure is intentional.** `zellij-pr-status` exits empty when `gh` errors (offline, rate-limited, not authed) or returns no PRs. zjstatus then renders an empty segment, which is the right behaviour for a status widget.
- **Command invocation.** `command_prs_command` is `bash -lc zellij-pr-status` to avoid hardcoding `/home/alunduil/` in the layout file (the alternative would be templating `pair.kdl` via chezmoi). If zjstatus's command runner doesn't propagate PATH through a login shell, the widget will be empty and we'll switch to a templated absolute path — focus review on this line.
- **No `renovate.json` change.** The existing generic regex manager on `dot_config/zellij/config.kdl` already catches the new `zjstatus` alias; no extra entry needed.

## Verification

- Ran `script/checks/zellij-config`: `[CONFIG FILE]: Well defined.`
- Ran `pre-commit run --files ...` on the new helper and changed layouts: shellcheck and shfmt passed (one `# shellcheck disable=SC1003` directive on the intentional `\\` in the OSC 8 printf format).
- Smoke-tested `zellij-pr-status` with synthetic PR data piped through `cat -v` — confirmed the byte sequence is correct OSC 8 (`ESC]8;;<URL>ESC\#N ESC]8;;ESC\`).
- Confirmed OSC 8 hyperlinks render as clickable in the host's Crostini terminal both inside and outside zellij (printf test).
- **Not yet verified at runtime.** Needs `chezmoi apply` + zellij restart to confirm the widget renders in a live pair session and the bash-lc PATH inheritance works as expected.