### PR TITLE
redesign zjstatus PR widget: header + per-PR segments + null state

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -26,7 +26,7 @@ layout {
                 format_left  "{command_prs}"
                 format_right ""
                 command_prs_command  "bash -lc zellij-pr-status"
-                command_prs_format   "#[fg=green]{stdout}"
+                command_prs_format   "#[bg=green,fg=black] {stdout} #[bg=default,fg=green]\u{E0B0}"
                 command_prs_interval "60"
             }
         }

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -23,8 +23,8 @@ layout {
         }
         pane size=1 borderless=true {
             plugin location="zjstatus" {
-                format_left  ""
-                format_right "{command_prs}"
+                format_left  "{command_prs}"
+                format_right ""
                 command_prs_command  "bash -lc zellij-pr-status"
                 command_prs_format   "#[fg=green]{stdout}"
                 command_prs_interval "60"

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -25,9 +25,10 @@ layout {
             plugin location="zjstatus" {
                 format_left  "{command_prs}"
                 format_right ""
-                command_prs_command  "bash -lc zellij-pr-status"
-                command_prs_format   "#[bg=green,fg=black] {stdout} #[bg=default,fg=green]\u{E0B0}"
-                command_prs_interval "60"
+                command_prs_command    "bash -lc zellij-pr-status"
+                command_prs_format     "{stdout}"
+                command_prs_rendermode "dynamic"
+                command_prs_interval   "60"
             }
         }
         children

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -1,51 +1,42 @@
 #!/usr/bin/env bash
-# Render the zjstatus PR widget for ~/.config/zellij/layouts/pair.kdl. The
-# script emits zjstatus `#[...]` style directives interleaved with OSC 8
-# hyperlinks, so the pair.kdl entry must set `command_prs_rendermode
-# "dynamic"` -- otherwise the directives render as literal text.
+# Render the zjstatus PR widget for ~/.config/zellij/layouts/pair.kdl. Emits
+# zjstatus `#[...]` style directives interleaved with OSC 8 hyperlinks, so
+# the pair.kdl entry must set `command_prs_rendermode "dynamic"`.
+#
+# Each segment mirrors zellij's status-bar mode-indicator pattern: a coloured
+# block tapering to default via a right-pointing powerline arrow (U+E0B0).
+# Colours are named (blue/green/black) so they track the user's zellij theme
+# palette rather than being hard-coded RGB.
 #
 # Layout:
-#   [bg=blue]   PR        (header, always shown)
-#   [bg=green]  #N #N #N  (one segment, PRs separated by thin powerline
-#                          arrows; each #N is an OSC 8 link to the PR url)
-#   [bg=black]  ∅         (shown only when there are no open PRs or gh
-#                          fails -- offline, rate-limited, not authed)
+#   [bg=blue]   PR     (header, always shown)
+#   [bg=green]  #N     (one segment per open PR; #N is an OSC 8 link)
+#   [bg=black]  ∅      (shown only when there are no open PRs or gh fails
+#                       -- offline, rate-limited, not authed)
 #
-# Outer boundaries use a solid powerline arrow (U+E0B0); inter-PR separators
-# inside the green block use the thin powerline arrow (U+E0B1).
+# Rendered shape:
+#   PR ▶ #42 ▶ #57 ▶ #58 ▶    (with PRs)
+#   PR ▶ ∅ ▶                  (empty)
 
 set -euo pipefail
 
-ARROW=$'\uE0B0' # powerline right arrow -- segment boundary
-THIN=$'\uE0B1'  # powerline thin arrow  -- within-segment separator
+ARROW=$'\uE0B0' # powerline right arrow
 NULL=$'\u2205'  # empty set / null
 
 prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
   | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
 
 # Header is unconditional.
-printf '#[bg=blue,fg=white] PR '
+printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW"
 
 if [ -z "$prs" ]; then
-  printf '#[bg=black,fg=blue]%s#[bg=black,fg=white] %s #[bg=default,fg=black]%s' \
-    "$ARROW" "$NULL" "$ARROW"
+  printf '#[bg=black,fg=white] %s #[bg=default,fg=black]%s' \
+    "$NULL" "$ARROW"
   exit 0
 fi
 
-# Header (blue) -> PR block (green) transition.
-printf '#[bg=green,fg=blue]%s' "$ARROW"
-
-first=1
 while IFS=$'\t' read -r number url; do
-  if [ "$first" -eq 1 ]; then
-    first=0
-  else
-    printf '#[bg=green,fg=black] %s' "$THIN"
-  fi
   # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
-  printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ ' \
-    "$url" "$number"
+  printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=green]%s' \
+    "$url" "$number" "$ARROW"
 done <<<"$prs"
-
-# Closing arrow back to default.
-printf '#[bg=default,fg=green]%s' "$ARROW"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -1,20 +1,51 @@
 #!/usr/bin/env bash
-# Emit "PRs: #123  #456" where each #N is an OSC 8 hyperlink to the PR. The
-# zjstatus command_prs widget in ~/.config/zellij/layouts/pair.kdl invokes
-# this every 60s and renders {stdout} in the status line. Output is empty
-# when there are no open PRs or when gh fails (offline, rate-limited, not
-# authed) -- zjstatus then renders an empty segment, which is the right
-# silent-failure behaviour for a status widget.
+# Render the zjstatus PR widget for ~/.config/zellij/layouts/pair.kdl. The
+# script emits zjstatus `#[...]` style directives interleaved with OSC 8
+# hyperlinks, so the pair.kdl entry must set `command_prs_rendermode
+# "dynamic"` -- otherwise the directives render as literal text.
+#
+# Layout:
+#   [bg=blue]   PR        (header, always shown)
+#   [bg=green]  #N #N #N  (one segment, PRs separated by thin powerline
+#                          arrows; each #N is an OSC 8 link to the PR url)
+#   [bg=black]  ∅         (shown only when there are no open PRs or gh
+#                          fails -- offline, rate-limited, not authed)
+#
+# Outer boundaries use a solid powerline arrow (U+E0B0); inter-PR separators
+# inside the green block use the thin powerline arrow (U+E0B1).
 
 set -euo pipefail
 
+ARROW=$'\uE0B0' # powerline right arrow -- segment boundary
+THIN=$'\uE0B1'  # powerline thin arrow  -- within-segment separator
+NULL=$'\u2205'  # empty set / null
+
 prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
-        | jq -r '.[] | "\(.number)\t\(.url)"') || exit 0
+  | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
 
-[ -z "$prs" ] && exit 0
+# Header is unconditional.
+printf '#[bg=blue,fg=white] PR '
 
-printf 'PRs:'
+if [ -z "$prs" ]; then
+  printf '#[bg=black,fg=blue]%s#[bg=black,fg=white] %s #[bg=default,fg=black]%s' \
+    "$ARROW" "$NULL" "$ARROW"
+  exit 0
+fi
+
+# Header (blue) -> PR block (green) transition.
+printf '#[bg=green,fg=blue]%s' "$ARROW"
+
+first=1
 while IFS=$'\t' read -r number url; do
+  if [ "$first" -eq 1 ]; then
+    first=0
+  else
+    printf '#[bg=green,fg=black] %s' "$THIN"
+  fi
   # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
-  printf '  \033]8;;%s\033\\#%s\033]8;;\033\\' "$url" "$number"
+  printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ ' \
+    "$url" "$number"
 done <<<"$prs"
+
+# Closing arrow back to default.
+printf '#[bg=default,fg=green]%s' "$ARROW"


### PR DESCRIPTION
## Summary

Reshape the zjstatus PR widget added in #57 to mirror zellij's status-bar mode-indicator pattern: each open PR sits in its own coloured block tapering to default via a right-pointing powerline arrow, exactly the visual shell that ` NORMAL ` sits in below. Colours are named (`blue`, `green`, `black`) so they pick up the user's zellij theme palette — matching the standard status-bar's approach rather than zellaude's hard-coded Catppuccin RGB.

Four commits, smallest-to-biggest:

1. **`1dd229c` left-align** — move the widget from `format_right` to `format_left`. Zjstatus owns the entire row in this layout, so right-alignment was just a gap.
2. **`64af3a3` powerline arrow segment** — first pass at a green block ending in U+E0B0. Superseded by the redesign but kept for review legibility.
3. **`386caa8` redesign with header + per-PR segments** — push styling into the script (so each PR can be its own clickable subsegment), add a "PR" header, add a `∅` empty-state segment.
4. **`03ec5fe` independent status-bar-style segments** — replace the "thin arrows inside one block" shape with N independent segments, each in the status-bar mode-indicator pattern. Drops U+E0B1.

Rendered shape (with PRs):

```
 PR ▶ #42 ▶ #57 ▶ #58 ▶
```

Empty state:

```
 PR ▶ ∅ ▶
```

Each `#N` is an OSC 8 hyperlink to the PR url.

## Gotchas

- **`command_prs_rendermode "dynamic"` is required** — otherwise zjstatus treats `#[bg=...]` directives in stdout as literal text.
- **Powerline glyph U+E0B0** — same dependency the built-in zellij status-bar already has, so if the existing bar renders correctly this will too.
- **Layout-only** — no `config.kdl` touched, so `Alt+p` for a fresh pair tab picks it up. No server restart.
- **Empty-state colour** — using `black` (palette index 0) rather than `red`. "No open PRs" is informational, not an alert state.

## Verification

- `pre-commit` (shellcheck + shfmt) on the rewritten script: passed.
- `script/checks/zellij-config`: `[CONFIG FILE]: Well defined.`
- Smoke-rendered populated and empty cases through `cat -v` — confirmed the byte sequence: zjstatus directives, OSC 8 hyperlinks, and U+E0B0 in the right positions.
- **Live render not yet verified.** Needs a fresh pair tab to confirm zjstatus's dynamic mode parses the `#[...]` directives from stdout (assumption based on the documented `dynamic` rendermode behaviour) and that OSC 8 escapes survive the dynamic-mode pipeline alongside the directives.