### PR TITLE
Catppuccin Mocha + zjstatus PR widget redesign

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -1,0 +1,31 @@
+# Lazygit theme matched to zellij's Catppuccin Mocha (config.kdl), so the
+# pair layout (Claude pane + lazygit pane) presents a unified palette.
+# Source: https://github.com/catppuccin/lazygit (mocha/blue accent).
+
+gui:
+  theme:
+    activeBorderColor:
+      - "#89b4fa"
+      - bold
+    inactiveBorderColor:
+      - "#a6adc8"
+    searchingActiveBorderColor:
+      - "#f9e2af"
+    optionsTextColor:
+      - "#89b4fa"
+    selectedLineBgColor:
+      - "#313244"
+    inactiveViewSelectedLineBgColor:
+      - "#6c7086"
+    cherryPickedCommitFgColor:
+      - "#89b4fa"
+    cherryPickedCommitBgColor:
+      - "#45475a"
+    markedBaseCommitFgColor:
+      - "#89b4fa"
+    markedBaseCommitBgColor:
+      - "#f9e2af"
+    unstagedChangesColor:
+      - "#f38ba8"
+    defaultFgColor:
+      - "#cdd6f4"

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -9,6 +9,8 @@
 // anyway. The pair layout adds a zjstatus line for PR-aware status; default
 // stays minimal.
 
+theme "catppuccin-mocha"
+
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
     ghost    location="https://github.com/vdbulcke/ghost/releases/download/v0.7.1/ghost.wasm"

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -5,7 +5,7 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
-//   zjstatus   (1 line) — open-PR list (gh pr list, refreshed every 60s)
+//   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
 //   children   (the panes)
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
@@ -23,12 +23,16 @@ layout {
         }
         pane size=1 borderless=true {
             plugin location="zjstatus" {
-                format_left  "{command_prs}"
+                format_left  "{command_branch}{command_prs}"
                 format_right ""
-                command_prs_command    "bash -lc zellij-pr-status"
-                command_prs_format     "{stdout}"
-                command_prs_rendermode "dynamic"
-                command_prs_interval   "60"
+                command_branch_command    "bash -lc zellij-branch-status"
+                command_branch_format     "{stdout}"
+                command_branch_rendermode "dynamic"
+                command_branch_interval   "5"
+                command_prs_command       "bash -lc zellij-pr-status"
+                command_prs_format        "{stdout}"
+                command_prs_rendermode    "dynamic"
+                command_prs_interval      "60"
             }
         }
         children

--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -7,8 +7,9 @@
 # `#[...]` directives render rather than print as literal text.
 #
 # Layout:
-#   [bg=cyan]  <branch>     (always shown; "?" when not in a git repo)
+#   [bg=bright_black]  <branch>     (always shown; "?" when not in a git repo)
 #
+# Colours match zellaude's prefix segment aesthetic (dark gray + white text).
 # Rendered shape:
 #   main ▶
 #
@@ -24,4 +25,4 @@ ARROW=$'\uE0B0' # powerline right arrow
 
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
 
-printf '#[bg=cyan,fg=black] %s #[bg=default,fg=cyan]%s' "$branch" "$ARROW"
+printf '#[bg=bright_black,fg=white] %s #[bg=default,fg=bright_black]%s' "$branch" "$ARROW"

--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Render the zjstatus branch widget for ~/.config/zellij/layouts/pair.kdl.
+# Emits a cyan zjstatus segment showing the current git branch -- the
+# leftmost element in the bar, so only an exit chevron, no entry.
+#
+# zjstatus consumes this with `command_branch_rendermode "dynamic"` so the
+# `#[...]` directives render rather than print as literal text.
+#
+# Layout:
+#   [bg=cyan]  <branch>     (always shown; "?" when not in a git repo)
+#
+# Rendered shape:
+#   main ▶
+#
+# This script assumes zjstatus's command runner inherits the tab's cwd so
+# that `git rev-parse` finds the right repository. If it doesn't, the
+# branch will always render as "?" and we'll need a wrapper that finds
+# the cwd through another path (e.g., $ZJ_PANE_CWD if zjstatus exposes
+# one, or by reading from a sentinel file).
+
+set -euo pipefail
+
+ARROW=$'\uE0B0' # powerline right arrow
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
+
+printf '#[bg=cyan,fg=black] %s #[bg=default,fg=cyan]%s' "$branch" "$ARROW"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -9,34 +9,42 @@
 # palette rather than being hard-coded RGB.
 #
 # Layout:
-#   [bg=blue]   PR     (header, always shown)
-#   [bg=green]  #N     (one segment per open PR; #N is an OSC 8 link)
-#   [bg=black]  ∅      (shown only when there are no open PRs or gh fails
-#                       -- offline, rate-limited, not authed)
+#   [bg=blue]          PR     (header, leftmost -- right arrow only)
+#   [bg=green]         #N     (one segment per open PR; #N is an OSC 8 link)
+#   [bg=bright_black]  ∅      (shown only when there are no open PRs or gh
+#                              fails -- offline, rate-limited, not authed)
+#
+# Each non-leftmost segment has a U+E0B2 left arrow on entry and a U+E0B0
+# right arrow on exit so it reads as a "tab" tapered on both sides.
 #
 # Rendered shape:
-#   PR ▶ #42 ▶ #57 ▶ #58 ▶    (with PRs)
-#   PR ▶ ∅ ▶                  (empty)
+#   PR ▶◀ #42 ▶◀ #57 ▶◀ #58 ▶    (with PRs)
+#   PR ▶◀ ∅ ▶                    (empty)
 
 set -euo pipefail
 
-ARROW=$'\uE0B0' # powerline right arrow
-NULL=$'\u2205'  # empty set / null
+ARROW_R=$'\uE0B0' # powerline right arrow (closes a segment)
+ARROW_L=$'\uE0B2' # powerline left arrow  (opens a non-leftmost segment)
+NULL=$'\u2205'    # empty set / null
 
 prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
   | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
 
 # Header is unconditional.
-printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW"
+printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW_R"
 
 if [ -z "$prs" ]; then
-  printf '#[bg=black,fg=white] %s #[bg=default,fg=black]%s' \
-    "$NULL" "$ARROW"
+  # Null: bg=black would collide with fg=default ≈ bar bg; use bright_black
+  # so the left arrow's triangle has visible contrast.
+  printf '#[bg=bright_black,fg=default]%s' "$ARROW_L"
+  printf '#[bg=bright_black,fg=white] %s ' "$NULL"
+  printf '#[bg=default,fg=bright_black]%s' "$ARROW_R"
   exit 0
 fi
 
 while IFS=$'\t' read -r number url; do
+  printf '#[bg=green,fg=default]%s' "$ARROW_L"
   # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
   printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=green]%s' \
-    "$url" "$number" "$ARROW"
+    "$url" "$number" "$ARROW_R"
 done <<<"$prs"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -3,50 +3,61 @@
 # zjstatus `#[...]` style directives interleaved with OSC 8 hyperlinks, so
 # the pair.kdl entry must set `command_prs_rendermode "dynamic"`.
 #
-# Each segment mirrors zellij's status-bar mode-indicator pattern: a coloured
-# block tapering to default via a right-pointing powerline arrow (U+E0B0).
-# Colours are named (blue/green/black) so they track the user's zellij theme
-# palette rather than being hard-coded RGB.
+# One segment per open PR authored by the current user. The PR whose head
+# branch matches the current local branch is highlighted in mauve (the
+# Catppuccin "purple"; named `magenta` in this theme is pink, so the active
+# colour is the one hex value in this widget). All other PRs render in
+# bright_black with cyan text -- the same dark-gray-purple zellaude uses for
+# inactive tabs.
 #
-# Layout (preceded by zellij-branch-status, so the header is non-leftmost):
-#   [bg=blue]          PR     (header)
-#   [bg=green]         #N     (one segment per open PR; #N is an OSC 8 link)
-#   [bg=bright_black]  ∅      (shown only when there are no open PRs or gh
-#                              fails -- offline, rate-limited, not authed)
+# Layout (preceded by zellij-branch-status):
+#   [bg=#CBA6F7]       #N    (active PR -- head branch matches current)
+#   [bg=bright_black]  #N    (inactive PRs; #N is an OSC 8 link)
 #
-# Every segment has a U+E0B0 right arrow on both entry and exit (the entry
-# arrow's triangle "carves" the segment's left edge into a chevron pointing
-# into it; the exit arrow tapers it back to default). All arrows face the
-# same way, giving the segment list a flowing rightward chevron.
+# The first PR in the list has no entry chevron so it sits flush against
+# the branch widget's exit chevron. Subsequent PRs each open with their
+# own entry chevron.
 #
-# Rendered shape (in combination with zellij-branch-status):
-#   main ▶▶ PR ▶▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
-#   main ▶▶ PR ▶▶ ∅ ▶                    (empty)
+# When there are no open PRs (or gh fails -- offline, rate-limited, not
+# authed), the script exits silent; the bar then shows only the branch
+# widget, which is enough signal that the widget is alive.
+#
+# Rendered shape (with branch widget on the left):
+#   main ▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
+#   main ▶                        (empty -- no PR segment, just branch)
 
 set -euo pipefail
 
-ARROW=$'\uE0B0' # powerline right arrow (used at every segment boundary)
-NULL=$'\u2205'  # empty set / null
+ARROW=$'\uE0B0' # powerline right arrow
+ACTIVE_BG="#CBA6F7" # Catppuccin Mocha mauve
 
-prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
-  | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
 
-# Header is unconditional. Entry chevron first, since branch widget precedes.
-printf '#[bg=blue,fg=default]%s' "$ARROW"
-printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW"
+prs=$(gh pr list --author=@me --state=open --json number,url,headRefName 2>/dev/null \
+  | jq -r '.[] | "\(.number)\t\(.url)\t\(.headRefName)"') || prs=""
 
-if [ -z "$prs" ]; then
-  # Null: bg=black would collide with fg=default ≈ bar bg; use bright_black
-  # so the entry chevron's triangle has visible contrast.
-  printf '#[bg=bright_black,fg=default]%s' "$ARROW"
-  printf '#[bg=bright_black,fg=white] %s ' "$NULL"
-  printf '#[bg=default,fg=bright_black]%s' "$ARROW"
-  exit 0
-fi
+[ -z "$prs" ] && exit 0
 
-while IFS=$'\t' read -r number url; do
-  printf '#[bg=green,fg=default]%s' "$ARROW"
+first=1
+while IFS=$'\t' read -r number url branch; do
+  if [ "$branch" = "$current_branch" ]; then
+    bg="$ACTIVE_BG"
+    fg=white
+  else
+    bg=bright_black
+    fg=cyan
+  fi
+
+  # Entry chevron on every PR except the first (which sits flush against
+  # the branch widget's exit chevron).
+  if [ "$first" -eq 1 ]; then
+    first=0
+  else
+    printf '#[bg=%s,fg=default]%s' "$bg" "$ARROW"
+  fi
+
+  # PR body + exit chevron.
   # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
-  printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=green]%s' \
-    "$url" "$number" "$ARROW"
+  printf '#[bg=%s,fg=%s] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=%s]%s' \
+    "$bg" "$fg" "$url" "$number" "$bg" "$ARROW"
 done <<<"$prs"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -8,20 +8,20 @@
 # Colours are named (blue/green/black) so they track the user's zellij theme
 # palette rather than being hard-coded RGB.
 #
-# Layout:
-#   [bg=blue]          PR     (header, leftmost -- right arrow only)
+# Layout (preceded by zellij-branch-status, so the header is non-leftmost):
+#   [bg=blue]          PR     (header)
 #   [bg=green]         #N     (one segment per open PR; #N is an OSC 8 link)
 #   [bg=bright_black]  ∅      (shown only when there are no open PRs or gh
 #                              fails -- offline, rate-limited, not authed)
 #
-# Each non-leftmost segment has a U+E0B0 right arrow on both entry and exit
-# (the entry arrow's triangle "carves" the segment's left edge into a chevron
-# pointing into it; the exit arrow tapers it back to default). All arrows
-# face the same way, giving the segment list a flowing rightward chevron.
+# Every segment has a U+E0B0 right arrow on both entry and exit (the entry
+# arrow's triangle "carves" the segment's left edge into a chevron pointing
+# into it; the exit arrow tapers it back to default). All arrows face the
+# same way, giving the segment list a flowing rightward chevron.
 #
-# Rendered shape:
-#   PR ▶▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
-#   PR ▶▶ ∅ ▶                    (empty)
+# Rendered shape (in combination with zellij-branch-status):
+#   main ▶▶ PR ▶▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
+#   main ▶▶ PR ▶▶ ∅ ▶                    (empty)
 
 set -euo pipefail
 
@@ -31,7 +31,8 @@ NULL=$'\u2205'  # empty set / null
 prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
   | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
 
-# Header is unconditional.
+# Header is unconditional. Entry chevron first, since branch widget precedes.
+printf '#[bg=blue,fg=default]%s' "$ARROW"
 printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW"
 
 if [ -z "$prs" ]; then

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -14,37 +14,38 @@
 #   [bg=bright_black]  ∅      (shown only when there are no open PRs or gh
 #                              fails -- offline, rate-limited, not authed)
 #
-# Each non-leftmost segment has a U+E0B2 left arrow on entry and a U+E0B0
-# right arrow on exit so it reads as a "tab" tapered on both sides.
+# Each non-leftmost segment has a U+E0B0 right arrow on both entry and exit
+# (the entry arrow's triangle "carves" the segment's left edge into a chevron
+# pointing into it; the exit arrow tapers it back to default). All arrows
+# face the same way, giving the segment list a flowing rightward chevron.
 #
 # Rendered shape:
-#   PR ▶◀ #42 ▶◀ #57 ▶◀ #58 ▶    (with PRs)
-#   PR ▶◀ ∅ ▶                    (empty)
+#   PR ▶▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
+#   PR ▶▶ ∅ ▶                    (empty)
 
 set -euo pipefail
 
-ARROW_R=$'\uE0B0' # powerline right arrow (closes a segment)
-ARROW_L=$'\uE0B2' # powerline left arrow  (opens a non-leftmost segment)
-NULL=$'\u2205'    # empty set / null
+ARROW=$'\uE0B0' # powerline right arrow (used at every segment boundary)
+NULL=$'\u2205'  # empty set / null
 
 prs=$(gh pr list --author=@me --state=open --json number,url 2>/dev/null \
   | jq -r '.[] | "\(.number)\t\(.url)"') || prs=""
 
 # Header is unconditional.
-printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW_R"
+printf '#[bg=blue,fg=white] PR #[bg=default,fg=blue]%s' "$ARROW"
 
 if [ -z "$prs" ]; then
   # Null: bg=black would collide with fg=default ≈ bar bg; use bright_black
-  # so the left arrow's triangle has visible contrast.
-  printf '#[bg=bright_black,fg=default]%s' "$ARROW_L"
+  # so the entry chevron's triangle has visible contrast.
+  printf '#[bg=bright_black,fg=default]%s' "$ARROW"
   printf '#[bg=bright_black,fg=white] %s ' "$NULL"
-  printf '#[bg=default,fg=bright_black]%s' "$ARROW_R"
+  printf '#[bg=default,fg=bright_black]%s' "$ARROW"
   exit 0
 fi
 
 while IFS=$'\t' read -r number url; do
-  printf '#[bg=green,fg=default]%s' "$ARROW_L"
+  printf '#[bg=green,fg=default]%s' "$ARROW"
   # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
   printf '#[bg=green,fg=black] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=green]%s' \
-    "$url" "$number" "$ARROW_R"
+    "$url" "$number" "$ARROW"
 done <<<"$prs"


### PR DESCRIPTION
## Summary

Three iterations stacked on top of #59's zjstatus PR widget, ending in a Catppuccin-themed look:

1. **`f7b0871`+`3bc7f55` — chevron flow.** Each non-leftmost segment got both an entry and an exit U+E0B0 right arrow, so the bar reads as a flowing rightward chevron pattern.
2. **`43411c2` — branch widget.** Cyan segment showing the current git branch, polled every 5s, sitting to the left of the `PR` header.
3. **`ea8517a` — Catppuccin Mocha theme + PR widget redesign.** Set zellij theme; add matching lazygit theme; drop the `PR` header and the `∅` empty state; detect the active PR (head branch matches current); style active PR in mauve, others in bright_black + cyan.

Final render shape:

```
main ▶ #60 ▶▶ #61 ▶          (#60 active = mauve; others bright_black)
main ▶                       (no open PRs = just branch widget)
```

The first PR sits flush against the branch's exit chevron; subsequent PRs carry their own entry chevrons.

## Theming scope decisions

| Tool      | Action                                               |
| --------- | ---------------------------------------------------- |
| zellij    | `theme "catppuccin-mocha"` in `config.kdl`           |
| lazygit   | New `dot_config/lazygit/config.yml` with Catppuccin Mocha (blue accent), sourced from official catppuccin/lazygit |
| claustre  | No theme settings exist. Untouched.                  |
| claude    | Built-in themes only; no Catppuccin path. Untouched. |

## Gotchas

- **`magenta` in Catppuccin Mocha is pink (#F5C2E7), not purple.** The active PR uses hex `#CBA6F7` (Catppuccin Mauve) directly so it actually renders purple. This is the only hex value in the widget; everything else is named.
- **Theme line in `config.kdl` requires a server restart** — `chezmoi apply`, then `zellij delete-all-sessions --yes`, then `zellij --layout pair` for it to take effect. The widget changes alone (everything in the scripts and `pair.kdl`) are layout-only and pick up on a fresh pair tab.
- **`zjstatus-pr-status` re-runs `git rev-parse` on every poll** to know the current branch for active-PR detection. Adds one cheap syscall every 60s; not measurable.
- **Branch widget continues to assume zjstatus's command runner inherits the tab's cwd.** If branch shows `?`, active-PR detection also fails (both rely on the same git lookup).

## Verification

- `pre-commit` (shellcheck + shfmt + check-json) on all changed files: passed.
- `script/checks/zellij-config`: `[CONFIG FILE]: Well defined.` even with the theme line added.
- Smoke-test of `zellij-pr-status` from this branch: correctly identifies PR #60 as active (mauve bg + white fg) since #60's head branch is `zjstatus-tab-arrows`. Smoke-test of `zellij-branch-status`: `[bg=bright_black,fg=white] zjstatus-tab-arrows ▶`.
- **Live render not yet verified.** Things to eyeball: chevron triangle colour (`fg=default` carrying through theme correctly), mauve vs surrounding bar bg in Catppuccin Mocha, lazygit theme colours rendering as expected, branch widget showing the right branch in any tab.