### PR TITLE
use named palette and tighten widget scripts

### DIFF
--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Render the zjstatus branch widget for ~/.config/zellij/layouts/pair.kdl.
-# Emits a cyan zjstatus segment showing the current git branch -- the
-# leftmost element in the bar, so only an exit chevron, no entry.
+# Emits a zjstatus segment showing the current git branch -- the leftmost
+# element in the bar.
 #
 # zjstatus consumes this with `command_branch_rendermode "dynamic"` so the
 # `#[...]` directives render rather than print as literal text.
@@ -10,8 +10,11 @@
 #   [bg=bright_black]  <branch>     (always shown; "?" when not in a git repo)
 #
 # Colours match zellaude's prefix segment aesthetic (dark gray + white text).
-# Rendered shape:
-#   main ▶
+# No exit chevron -- the segment ends square so the first PR (or nothing,
+# when there are no open PRs) sits flush against it. When the first PR is
+# active (mauve), the colour change provides the visual transition; when
+# inactive (also bright_black), branch and first PR visually merge into one
+# block, which conveys "the PRs in this widget are not for this branch."
 #
 # This script assumes zjstatus's command runner inherits the tab's cwd so
 # that `git rev-parse` finds the right repository. If it doesn't, the
@@ -21,8 +24,6 @@
 
 set -euo pipefail
 
-ARROW=$'\uE0B0' # powerline right arrow
-
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
 
-printf '#[bg=bright_black,fg=white] %s #[bg=default,fg=bright_black]%s' "$branch" "$ARROW"
+printf '#[bg=bright_black,fg=white] %s ' "$branch"

--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+ARROW=$'\uE0B0'
+
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
 
-printf '#[bg=bright_black,fg=white] %s ' "$branch"
+printf '#[bg=bright_black,fg=white] %s #[bg=default,fg=bright_black]%s' "$branch" "$ARROW"

--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -1,26 +1,11 @@
 #!/usr/bin/env bash
-# Render the zjstatus branch widget for ~/.config/zellij/layouts/pair.kdl.
-# Emits a zjstatus segment showing the current git branch -- the leftmost
-# element in the bar.
+# zjstatus branch widget for ~/.config/zellij/layouts/pair.kdl. Requires
+# `command_branch_rendermode "dynamic"` in pair.kdl so the #[...] directive
+# renders rather than printing as literal text.
 #
-# zjstatus consumes this with `command_branch_rendermode "dynamic"` so the
-# `#[...]` directives render rather than print as literal text.
-#
-# Layout:
-#   [bg=bright_black]  <branch>     (always shown; "?" when not in a git repo)
-#
-# Colours match zellaude's prefix segment aesthetic (dark gray + white text).
-# No exit chevron -- the segment ends square so the first PR (or nothing,
-# when there are no open PRs) sits flush against it. When the first PR is
-# active (mauve), the colour change provides the visual transition; when
-# inactive (also bright_black), branch and first PR visually merge into one
-# block, which conveys "the PRs in this widget are not for this branch."
-#
-# This script assumes zjstatus's command runner inherits the tab's cwd so
-# that `git rev-parse` finds the right repository. If it doesn't, the
-# branch will always render as "?" and we'll need a wrapper that finds
-# the cwd through another path (e.g., $ZJ_PANE_CWD if zjstatus exposes
-# one, or by reading from a sentinel file).
+# Assumes zjstatus's command runner inherits the tab's cwd. If branch
+# renders as "?", that assumption broke and we need a wrapper that locates
+# cwd another way.
 
 set -euo pipefail
 

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -1,35 +1,16 @@
 #!/usr/bin/env bash
-# Render the zjstatus PR widget for ~/.config/zellij/layouts/pair.kdl. Emits
-# zjstatus `#[...]` style directives interleaved with OSC 8 hyperlinks, so
-# the pair.kdl entry must set `command_prs_rendermode "dynamic"`.
+# zjstatus PR widget for ~/.config/zellij/layouts/pair.kdl. Requires
+# `command_prs_rendermode "dynamic"` in pair.kdl so the #[...] directives
+# render rather than printing as literal text.
 #
-# One segment per open PR authored by the current user. The PR whose head
-# branch matches the current local branch is highlighted in mauve (the
-# Catppuccin "purple"; named `magenta` in this theme is pink, so the active
-# colour is the one hex value in this widget). All other PRs render in
-# bright_black with cyan text -- the same dark-gray-purple zellaude uses for
-# inactive tabs.
-#
-# Layout (preceded by zellij-branch-status):
-#   [bg=#CBA6F7]       #N    (active PR -- head branch matches current)
-#   [bg=bright_black]  #N    (inactive PRs; #N is an OSC 8 link)
-#
-# The first PR in the list has no entry chevron so it sits flush against
-# the branch widget's exit chevron. Subsequent PRs each open with their
-# own entry chevron.
-#
-# When there are no open PRs (or gh fails -- offline, rate-limited, not
-# authed), the script exits silent; the bar then shows only the branch
-# widget, which is enough signal that the widget is alive.
-#
-# Rendered shape (with branch widget on the left):
-#   main ▶ #42 ▶▶ #57 ▶▶ #58 ▶    (with PRs)
-#   main ▶                        (empty -- no PR segment, just branch)
+# Active PR (head branch matches current local branch) renders in mauve;
+# the hex is hardcoded because Catppuccin Mocha's named `magenta` is pink,
+# not purple. Same cwd assumption as zellij-branch-status.
 
 set -euo pipefail
 
-ARROW=$'\uE0B0' # powerline right arrow
-ACTIVE_BG="#CBA6F7" # Catppuccin Mocha mauve
+ARROW=$'\uE0B0'
+ACTIVE_BG="#CBA6F7"
 
 current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
 
@@ -48,16 +29,13 @@ while IFS=$'\t' read -r number url branch; do
     fg=cyan
   fi
 
-  # Entry chevron on every PR except the first (which sits flush against
-  # the branch widget's exit chevron).
   if [ "$first" -eq 1 ]; then
     first=0
   else
     printf '#[bg=%s,fg=default]%s' "$bg" "$ARROW"
   fi
 
-  # PR body + exit chevron.
-  # shellcheck disable=SC1003 # \\ inside the single-quoted printf format is the OSC 8 ST.
+  # shellcheck disable=SC1003 # \\ in the printf format is the OSC 8 ST.
   printf '#[bg=%s,fg=%s] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=%s]%s' \
     "$bg" "$fg" "$url" "$number" "$bg" "$ARROW"
 done <<<"$prs"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -3,14 +3,14 @@
 # `command_prs_rendermode "dynamic"` in pair.kdl so the #[...] directives
 # render rather than printing as literal text.
 #
-# Active PR (head branch matches current local branch) renders in mauve;
-# the hex is hardcoded because Catppuccin Mocha's named `magenta` is pink,
-# not purple. Same cwd assumption as zellij-branch-status.
+# Active PR (head branch matches current local branch) renders in magenta;
+# in Catppuccin Mocha that's pink, but staying in named-palette colours
+# keeps the widget theme-portable. Same cwd assumption as
+# zellij-branch-status.
 
 set -euo pipefail
 
 ARROW=$'\uE0B0'
-ACTIVE_BG="#CBA6F7"
 
 current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
 
@@ -19,21 +19,16 @@ prs=$(gh pr list --author=@me --state=open --json number,url,headRefName 2>/dev/
 
 [ -z "$prs" ] && exit 0
 
-first=1
 while IFS=$'\t' read -r number url branch; do
   if [ "$branch" = "$current_branch" ]; then
-    bg="$ACTIVE_BG"
-    fg=white
+    bg=magenta
+    fg=black
   else
-    bg=bright_black
+    bg=black
     fg=cyan
   fi
 
-  if [ "$first" -eq 1 ]; then
-    first=0
-  else
-    printf '#[bg=%s,fg=default]%s' "$bg" "$ARROW"
-  fi
+  printf '#[bg=%s,fg=default]%s' "$bg" "$ARROW"
 
   # shellcheck disable=SC1003 # \\ in the printf format is the OSC 8 ST.
   printf '#[bg=%s,fg=%s] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=%s]%s' \


### PR DESCRIPTION
## Summary

Three commits on the zjstatus widget polish from #60, ending up with a fully named-palette design:

1. **`2b12514` flush branch widget** — initial drop of branch's exit chevron (later reversed; kept in history for context).
2. **`53bf6af` trim narrating comments** — cut layout pseudo-diagrams, rendered-shape ASCII art, and inline comments that just restate the next line. ~37 net lines removed.
3. **`7327185` named palette + restored chevrons** — drop the `#CBA6F7` hex for active PR, switch to named `magenta` (renders pink in Catppuccin Mocha but stays theme-portable). Split branch and inactive PR backgrounds into different gray shades. Restore chevrons on every segment boundary.

Final colour scheme (all named — no hex):

| Segment      | bg           | fg    |
| ------------ | ------------ | ----- |
| Branch       | bright_black | white |
| Active PR    | magenta      | black |
| Inactive PRs | black        | cyan  |

Final render shape:

```
main ▶▶ #42 ▶▶ #57 ▶▶ #58 ▶
main ▶                          (no open PRs)
```

`#42` highlighted in magenta if it's the PR for `main`; others render in the dark `black` shade with cyan text. Branch's lighter `bright_black` distinguishes it visually from inactive PRs.

## Trade-offs accepted

- **Active PR is pink in Catppuccin Mocha** because `magenta` in this theme's palette is `#F5C2E7`. The user's preference for theme-portable colours wins over the zellaude purple aesthetic. Switching themes will adjust the active PR colour without code changes.
- **Branch and inactive PR are both grays** rather than zellaude's purple-tinted gray, because the named palette has no purple-gray slot. Closest available distinction is `bright_black` vs `black` (lighter vs darker gray).

## Verification

- `pre-commit` (shellcheck + shfmt): passed.
- Smoke-rendered both scripts; outputs are clean directive sequences with chevrons in the right positions and the active branch correctly identified (PR #61 renders in magenta from this branch).
- **Live render not yet verified.** Things to check on apply: pink magenta vs your taste, contrast of black text on pink active PR, distinguishability of `bright_black` (branch) vs `black` (inactive PRs).