### PR TITLE
match zellij status-bar pattern: single chevrons + status-bar palette

### DIFF
--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -13,4 +13,4 @@ ARROW=$'\uE0B0'
 
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
 
-printf '#[bg=bright_black,fg=white] %s #[bg=default,fg=bright_black]%s' "$branch" "$ARROW"
+printf '#[bg=black,fg=white] %s #[bg=default,fg=black]%s' "$branch" "$ARROW"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -3,10 +3,9 @@
 # `command_prs_rendermode "dynamic"` in pair.kdl so the #[...] directives
 # render rather than printing as literal text.
 #
-# Active PR (head branch matches current local branch) renders in magenta;
-# in Catppuccin Mocha that's pink, but staying in named-palette colours
-# keeps the widget theme-portable. Same cwd assumption as
-# zellij-branch-status.
+# Active PR (head branch matches current local branch) renders in green
+# matching zellij's status-bar mode pill; inactive PRs in white. Same cwd
+# assumption as zellij-branch-status.
 
 set -euo pipefail
 
@@ -21,11 +20,11 @@ prs=$(gh pr list --author=@me --state=open --json number,url,headRefName 2>/dev/
 
 while IFS=$'\t' read -r number url branch; do
   if [ "$branch" = "$current_branch" ]; then
-    bg=magenta
+    bg=green
     fg=black
   else
-    bg=black
-    fg=cyan
+    bg=white
+    fg=black
   fi
 
   # shellcheck disable=SC1003 # \\ in the printf format is the OSC 8 ST.

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -28,8 +28,6 @@ while IFS=$'\t' read -r number url branch; do
     fg=cyan
   fi
 
-  printf '#[bg=%s,fg=default]%s' "$bg" "$ARROW"
-
   # shellcheck disable=SC1003 # \\ in the printf format is the OSC 8 ST.
   printf '#[bg=%s,fg=%s] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=default,fg=%s]%s' \
     "$bg" "$fg" "$url" "$number" "$bg" "$ARROW"


### PR DESCRIPTION
## Summary

Two commits aligning the zjstatus widget with what zellij's bundled status-bar actually does:

1. **`cad88b7` — single closing chevron per segment.** Confirmed white wedges on the entry chevrons traced back to my misread of zellij's pattern. zellij uses one closing chevron per segment (`bg=bar_bg, fg=seg_bg`), not the `▶▶` double-chevron I'd built. Dropped the entry chevron printf; the widget no longer references `fg=default` anywhere.
2. **`e931b6a` — status-bar palette.** Drop the zellaude-mimicry colours and adopt what zellij's status-bar actually uses for its mode-pill chain.

Final colour map (all named):

| Segment      | bg     | fg    | Visual role                              |
| ------------ | ------ | ----- | ---------------------------------------- |
| Branch       | black  | white | Dim, contextual label                    |
| Inactive PR  | white  | black | Bright, prompts "look at these"          |
| Active PR    | green  | black | Mode-pill accent, "this is the active one" |

Render shape:

```
main ▶ #42 ▶ #57 ▶ #58 ▶          (#42 = active = green; others on light gray)
main ▶                            (no PRs)
```

Visual hierarchy intentionally inverts the typical "label-bright, content-dim" pattern: branch is the dimmest because it's just contextual; inactive PRs are bright because they're actionable items; active PR is the most prominent (green accent matching zellij's mode pill).

## Verification

- `pre-commit` (shellcheck + shfmt): passed.
- Smoke-rendered both scripts; outputs are clean directive sequences using only named-palette colours, with `bg=default` only on the closing chevron (the only place `default` works as expected).
- **Live render not yet verified.** Things to eyeball: contrast of `white` text on `black` branch (`#BAC2DE` on `#45475A` in Catppuccin Mocha — should be readable), `black` text on `white` inactive PR (`#45475A` on `#BAC2DE` — high contrast), green accent on active.