### PR TITLE
Sync Claude settings to claustre+zellij state

### DIFF
--- a/dot_claude/private_settings.json.tmpl
+++ b/dot_claude/private_settings.json.tmpl
@@ -110,6 +110,7 @@
       "Bash(zellij:*)"
     ],
     "ask": [
+      "Bash",
       "Bash(chezmoi apply*)",
       "Bash(docker system prune*)",
       "Bash(docker volume rm*)",
@@ -129,7 +130,9 @@
       "Bash(git push --force*)",
       "Bash(git push*--force*)",
       "Bash(git push -f*)",
-      "Bash(git push* -f*)"
+      "Bash(git push* -f*)",
+      "Bash(git push*main*)"
     ]
-  }
+  },
+  "theme": "auto"
 }


### PR DESCRIPTION
## Summary

Folds three drift items from live `~/.claude/settings.json` (set by `claustre configure` and zellij hooks setup) back into the template so `chezmoi apply` preserves them: `theme: auto`, an extra `git push*main*` deny rail, and a bare `Bash` routed to `ask`. Renames source to `private_settings.json.tmpl` to deploy with mode 600.

## Gotchas

The bare `Bash` is intentionally in `ask`, not `allow` — putting it in `allow` would short-circuit the per-tool allowlist and punch through the `rm` / `sudo` / `chezmoi apply` ask gates added in #54. Confirm that's the right tradeoff for any wide bash command vs. tightening the per-tool list.

Hook command paths stay as `$HOME/...` (cross-machine) rather than the absolute `/home/alunduil/...` claustre/zellij currently writes; expect one cosmetic re-diff after future `claustre configure` runs that `chezmoi apply` will normalize.

## Verification

- `chezmoi execute-template < dot_claude/private_settings.json.tmpl | jq .` produced valid JSON with the three new entries (`theme=auto`, `Bash` in ask, `Bash(git push*main*)` in deny)
- `diff <(jq -S … rendered) <(jq -S … live)` confirmed remaining differences are array ordering and `$HOME` expansion — semantically equivalent