### PR TITLE
match zellij status-bar palette with 8-bit slot indices

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -23,8 +23,8 @@ layout {
         }
         pane size=1 borderless=true {
             plugin location="zjstatus" {
-                format_left  "#[bg=black]{command_branch}{command_prs}"
-                format_right "#[bg=black]"
+                format_left  "#[bg=16]{command_branch}{command_prs}"
+                format_right "#[bg=16]"
                 command_branch_command    "bash -lc zellij-branch-status"
                 command_branch_format     "{stdout}"
                 command_branch_rendermode "dynamic"

--- a/dot_local/bin/executable_zellij-branch-status
+++ b/dot_local/bin/executable_zellij-branch-status
@@ -11,4 +11,4 @@ set -euo pipefail
 
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"
 
-printf '#[bg=black,fg=white] %s ' "$branch"
+printf '#[bg=16,fg=255] %s ' "$branch"

--- a/dot_local/bin/executable_zellij-pr-status
+++ b/dot_local/bin/executable_zellij-pr-status
@@ -3,9 +3,9 @@
 # `command_prs_rendermode "dynamic"` in pair.kdl so the #[...] directives
 # render rather than printing as literal text.
 #
-# Active PR (head branch matches current local branch) renders in green
-# matching zellij's status-bar mode pill; inactive PRs in white. Same cwd
-# assumption as zellij-branch-status.
+# Active PR (head branch matches current local branch) renders in green and
+# inactive PRs in gray, matching zellij's bundled status-bar ribbons. Same
+# cwd assumption as zellij-branch-status.
 
 set -euo pipefail
 
@@ -20,17 +20,15 @@ prs=$(gh pr list --author=@me --state=open --json number,url,headRefName 2>/dev/
 
 while IFS=$'\t' read -r number url branch; do
   if [ "$branch" = "$current_branch" ]; then
-    bg=green
-    fg=black
+    bg=154
   else
-    bg=white
-    fg=black
+    bg=245
   fi
 
-  # Prefix arrow: black triangle carves the segment from the black bar bg.
-  printf '#[bg=%s,fg=black]%s' "$bg" "$ARROW"
+  # Prefix arrow: bar-coloured triangle carves the segment from the bar bg.
+  printf '#[bg=%s,fg=16]%s' "$bg" "$ARROW"
 
   # shellcheck disable=SC1003 # \\ in the printf format is the OSC 8 ST.
-  printf '#[bg=%s,fg=%s] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=black,fg=%s]%s' \
-    "$bg" "$fg" "$url" "$number" "$bg" "$ARROW"
+  printf '#[bg=%s,fg=16] \033]8;;%s\033\\#%s\033]8;;\033\\ #[bg=16,fg=%s]%s' \
+    "$bg" "$url" "$number" "$bg" "$ARROW"
 done <<<"$prs"


### PR DESCRIPTION
## Summary

Pin the zjstatus widget colours to the same xterm 256-colour slot indices that zellij's bundled status-bar resolves to under its no-theme path (`default_palette()` → `From<Palette> for Styling`, dark hue): `16` for bar bg + pill text, `154` for the active PR pill, `245` for inactive PR / inactive ribbon match, `255` for branch text. These slots are spec-fixed RGB regardless of terminal ANSI-16 overrides, so the widget tracks zellij's bundled bar identically and stays put when the terminal theme changes — same property that makes zellij's bar visually stable across themes.

Branch becomes plain text on the bar (mirroring zellij's superkey "Ctrl +" portion). With no PRs it trails off bare; the chevron between branch and the first PR is owned by the PR's prefix arrow, so #62's missing-chevron-when-empty observation gets resolved by re-aligning the branch widget with zellij's superkey style instead of giving it a self-owned chevron.

## Gotchas

The slot-hardcoding is a deliberate regression on theme portability — widgets stop following user-supplied zellij themes that override `palette.fg` / `palette.bg`. The named-ANSI scheme from #61 is gone for that reason. The trade is accepted because the only zjstatus directive language can't reference `palette.bg` in an `fg=` slot, and upstream has explicitly closed that ask (dj95/zjstatus#34, #49). Long-term fix is a native zellij plugin — tracked in #67.

Reviewer focus: the slot indices in `pair.kdl:26-27` and the two widget scripts. The shape of the chevron model (prefix `bg=segment, fg=16`, suffix `bg=16, fg=segment`) is unchanged from #63; only the colour slots and the branch widget's role moved.

## Verification

- `pre-commit` (shellcheck + shfmt + check-json): passed.
- Smoke-rendered both scripts. Branch emits `#[bg=16,fg=255] <branch> ` cleanly. PR widget emits the expected `#[bg=<seg>,fg=16]▶ … #[bg=16,fg=<seg>]▶` per PR with `<seg>` ∈ {154, 245}.
- Live render not yet eyeballed — CI's `script/checks/{zellij-config,chezmoi-apply}` cover the structural validity; the colour match against zellij's bundled bar is something I'll confirm post-apply.

Refs: #67