### PR TITLE
fill bar bg gap with format_space so the whole row is slot 16

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -24,6 +24,7 @@ layout {
         pane size=1 borderless=true {
             plugin location="zjstatus" {
                 format_left  "#[bg=16]{command_branch}{command_prs}"
+                format_space "#[bg=16]"
                 format_right "#[bg=16]"
                 command_branch_command    "bash -lc zellij-branch-status"
                 command_branch_format     "{stdout}"


### PR DESCRIPTION
## Summary

Set `format_space "#[bg=16]"` in `pair.kdl` so the gap zjstatus leaves between `format_left` and `format_right` paints to slot 16 (the same `#000000` as the rest of the bar) instead of falling through to terminal default bg. Closes the visible "lighter strip" in the middle of the bar that #68 left behind.

Side benefit: with the bar uniformly black, the empty-PR case has nothing to terminate against, so branch text trails off cleanly on the bar — no closing chevron needed. (My earlier proposal to emit one from the PR widget was solving a problem that goes away once the bar fills.)

## Verification

- `script/checks/zellij-config` → `[CONFIG FILE]: Well defined.`
- `pre-commit`: nothing to lint on a kdl-only diff (skipped cleanly).
- Live render not yet eyeballed — CI covers structural validity, the actual bar uniformity is the thing to confirm post-apply.