### PR TITLE
audit Claude permissions + tighten PR Summary rule

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -31,11 +31,15 @@ A per-repo `CLAUDE.md` overrides anything here.
   `GH_DRAFT_GUARD=off gh pr create ...`.
 - Use the repo's PR template when one exists. Otherwise, structure
   the body (squash-merged, so this becomes the commit context):
-  - **Summary** — 1-2 sentences on what this PR delivers. Surface
-    the approach only if the choice isn't obvious from the diff.
-    Don't restate commit messages (squash collapses them) or
-    reproduce content visible in the diff (diagrams, snippets,
-    before/after). Link the issue; don't re-explain it.
+  - **Summary** — 1-2 sentences. Lead with the user-visible
+    outcome ("X now works"), not the diff line ("set Y to Z in
+    foo.kdl"). The diff shows what changed; the Summary explains
+    what now works. Surface mechanism only when the choice isn't
+    obvious from the diff. Link the issue; don't re-explain.
+
+    Bad: "Set `format_space \"#[bg=16]\"` in pair.kdl."
+    Good: "Bar paints uniformly black across the format gap,
+    closing the lighter strip from #68."
   - **Gotchas** — direct the reviewer: "focus on X because Y." Where
     to spend time, not just what's risky. Omit when nothing to flag.
   - **Verification** — material checks beyond CI in past tense ("ran

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -1,12 +1,3 @@
-{{- /*
-  zellaude-hook.sh fires on every Claude Code lifecycle event so the
-  zellij plugin can reflect session state. Define the hook entry once;
-  PreToolUse adds it alongside pr-draft-guard, the rest add it solo via
-  the range below. Keep the events list in sync with what the plugin
-  consumes upstream.
-*/ -}}
-{{- $zellaude := printf `{ "hooks": [{ "type": "command", "command": "%s/.config/zellij/plugins/zellaude-hook.sh", "timeout": 5, "async": true }] }` .chezmoi.homeDir -}}
-{{- $zellaudeOnly := list "PostToolUse" "PostToolUseFailure" "UserPromptSubmit" "PermissionRequest" "Notification" "Stop" "SubagentStop" "SessionStart" "SessionEnd" -}}
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
@@ -14,15 +5,131 @@
       {
         "hooks": [
           {
-            "command": "{{ .chezmoi.homeDir }}/.claude/hooks/pr-draft-guard.sh",
+            "command": "/home/alunduil/.claude/hooks/pr-draft-guard.sh",
             "type": "command"
           }
         ],
         "matcher": "mcp__github__create_pull_request(_with_copilot)?"
       },
-      {{ $zellaude }}
-    ]{{ range $event := $zellaudeOnly }},
-    "{{ $event }}": [{{ $zellaude }}]{{ end }}
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ]
   },
   "permissions": {
     "allow": [
@@ -35,7 +142,6 @@
       "Read(*)",
       "TodoWrite(*)",
       "Write(*)",
-
       "mcp__claude_ai_Readwise__reader_get_*",
       "mcp__claude_ai_Readwise__reader_list_*",
       "mcp__claude_ai_Readwise__reader_search_*",
@@ -43,7 +149,6 @@
       "mcp__claude_ai_Readwise__readwise_get_*",
       "mcp__claude_ai_Readwise__readwise_list_*",
       "mcp__claude_ai_Readwise__readwise_search_*",
-
       "Bash(awk:*)",
       "Bash(basename:*)",
       "Bash(bats:*)",
@@ -140,10 +245,10 @@
       "Bash(git push -f*)",
       "Bash(git push* -f*)",
       "Bash(git push*main*)",
-      "Read({{ .chezmoi.homeDir }}/.claude/.credentials.json)",
-      "Read({{ .chezmoi.homeDir }}/.claustre/claustre.db*)",
-      "Read({{ .chezmoi.homeDir }}/.gnupg/**)",
-      "Read({{ .chezmoi.homeDir }}/.ssh/**)"
+      "Read(/home/alunduil/.claude/.credentials.json)",
+      "Read(/home/alunduil/.claustre/claustre.db*)",
+      "Read(/home/alunduil/.gnupg/**)",
+      "Read(/home/alunduil/.ssh/**)"
     ]
   },
   "theme": "auto"

--- a/dot_claude/private_settings.json.tmpl
+++ b/dot_claude/private_settings.json.tmpl
@@ -5,7 +5,7 @@
   the range below. Keep the events list in sync with what the plugin
   consumes upstream.
 */ -}}
-{{- $zellaude := `{ "hooks": [{ "type": "command", "command": "$HOME/.config/zellij/plugins/zellaude-hook.sh", "timeout": 5, "async": true }] }` -}}
+{{- $zellaude := printf `{ "hooks": [{ "type": "command", "command": "%s/.config/zellij/plugins/zellaude-hook.sh", "timeout": 5, "async": true }] }` .chezmoi.homeDir -}}
 {{- $zellaudeOnly := list "PostToolUse" "PostToolUseFailure" "UserPromptSubmit" "PermissionRequest" "Notification" "Stop" "SubagentStop" "SessionStart" "SessionEnd" -}}
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
@@ -14,7 +14,7 @@
       {
         "hooks": [
           {
-            "command": "$HOME/.claude/hooks/pr-draft-guard.sh",
+            "command": "{{ .chezmoi.homeDir }}/.claude/hooks/pr-draft-guard.sh",
             "type": "command"
           }
         ],
@@ -110,14 +110,22 @@
       "Bash(zellij:*)"
     ],
     "ask": [
-      "Bash",
+      "Bash(bash -c*)",
       "Bash(chezmoi apply*)",
       "Bash(docker system prune*)",
       "Bash(docker volume rm*)",
       "Bash(find* -delete*)",
       "Bash(find* -exec*)",
       "Bash(find* -ok*)",
+      "Bash(gh api*)",
+      "Bash(git config*)",
+      "Bash(git remote add*)",
+      "Bash(node -e*)",
+      "Bash(perl -e*)",
+      "Bash(python -c*)",
+      "Bash(python3 -c*)",
       "Bash(rm:*)",
+      "Bash(sh -c*)",
       "Bash(sudo:*)",
       "Bash(terraform apply*)",
       "Bash(terraform destroy*)",
@@ -131,7 +139,11 @@
       "Bash(git push*--force*)",
       "Bash(git push -f*)",
       "Bash(git push* -f*)",
-      "Bash(git push*main*)"
+      "Bash(git push*main*)",
+      "Read({{ .chezmoi.homeDir }}/.claude/.credentials.json)",
+      "Read({{ .chezmoi.homeDir }}/.claustre/claustre.db*)",
+      "Read({{ .chezmoi.homeDir }}/.gnupg/**)",
+      "Read({{ .chezmoi.homeDir }}/.ssh/**)"
     ]
   },
   "theme": "auto"


### PR DESCRIPTION
## Summary

Plain `git status` now auto-allows. New gates around inline-script RCE (`python -c`, `node -e`, `bash -c`, …), `gh api` (generic HTTP), and credential-diverting `git remote add` / `git config`. New denies block reads of SSH keys, GPG keys, the Claude credentials file, and the claustre DB. Settings file is now literal JSON instead of a Go template, so `chezmoi apply` and claustre stop reformatting it on every run — semantic and literal diffs match.

PR Summary rule tightened in `dot_claude/CLAUDE.md`: lead with user-visible outcome, with a bad/good pair anchored to #69.

## Gotchas

Bare `Bash` in `ask` was shadowing every per-tool allow because Claude Code resolves permissions `deny → ask → allow` first-match-wins, no specificity tiebreaker ([docs](https://code.claude.com/docs/en/permissions.md)). Default mode already prompts on unmatched, so dropping the bare entry restores the per-tool allows without weakening safety.

Settings file went from `.tmpl` to literal because the compact `$zellaude` template variable rendered hook events as one line each, while claustre and the zellij plugin write each event as 11 pretty-printed lines — every `chezmoi apply` reformatted, every `claustre configure` reformatted back. Trading template features (path templating, DRY range over events) for byte-stability against the other writers. If multi-host portability becomes real, re-template — the conversion is mechanical.

The most likely false-positive is `gh api` — if you script directly against GitHub's REST API, expect a prompt; the ergonomic `gh pr` / `gh issue` / `gh repo` subcommands stay auto-allowed.

The Read denies cover the `Read` tool, not `Bash(cat:*)`. Bash-based bypass via `cat ~/.ssh/id_ed25519` is an accepted trust boundary — closing it would mean dropping common bash tools from allow with too many false-positives.

## Verification

- `bats test/` → 18/18 passing
- `pre-commit run --files dot_claude/private_settings.json` → `check-json` passes (the `.tmpl` form was skipped by all hooks)
- `diff ~/.claude/settings.json dot_claude/private_settings.json` → exactly the four intentional clusters: bare `Bash` removed, 9 asks added, 4 `Read` denies added, pr-draft-guard path absolutized

Refs: #65 (prior settings sync that introduced bare `Bash`), #69 (PR whose Summary motivated the CLAUDE.md change).