### PR TITLE
remove ghost plugin: use zellij floating panes instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-lim
 - `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell + git config.
 - `dot_claude/` — user-level Claude Code harness: `CLAUDE.md` rules, `settings.json` hook wiring (pr-draft-guard for the GitHub MCP tools, zellaude across every Claude Code lifecycle event), `hooks/pr-draft-guard.sh` blocking non-draft PRs. Per-project sensors (tests/linters/types) stay with the project.
 - `dot_claustre/config.toml` — Claustre user config (`sync.auto_push = true`).
-- `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, ghost, notepad — all pinned to release tags) and `Alt+p`/`Alt+g`/`Alt+m` keybinds.
+- `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus — both pinned to release tags) and the `Alt+p` keybind.
 - `dot_config/zellij/layouts/default.kdl` — initial-tab layout: zellaude top strip + 1-line `status-bar` (mode only, tips clipped).
-- `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window; ghost (`Alt+g`) handles on-demand shells.
+- `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window.
 - `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
 - `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:
   - `01-install-system-packages` — apt packages, HashiCorp repo, Tailscale.

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -11,7 +11,6 @@
 
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
-    ghost    location="https://github.com/vdbulcke/ghost/releases/download/v0.7.1/ghost.wasm"
     zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm"
 }
 
@@ -22,14 +21,6 @@ keybinds {
             Run "git-repo-picker" {
                 floating true
                 close_on_exit true
-            }
-        }
-        // Floating ad-hoc terminal (gh, chezmoi diff, rg, etc.).
-        bind "Alt g" {
-            LaunchOrFocusPlugin "ghost" {
-                floating true
-                shell "bash"
-                shell_flag "-ic"
             }
         }
     }

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -1,7 +1,6 @@
 // Deep-pairing layout: Claude Code (40%) alongside lazygit (60%). The editing
 // surface is VS Code in its own window; this layout is for the "watch the
-// changes, drive Claude" side of pairing. On-demand shells come from ghost
-// (Alt+g) so no fixed terminal strip is reserved.
+// changes, drive Claude" side of pairing.
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list


### PR DESCRIPTION
## Summary

Alt+g no longer launches a ghost-plugin shell — zellij's built-in floating panes (Alt+f) cover the same ad-hoc shell use case, so the wasm dependency goes.

## Gotchas

The README's Layout bullets had already drifted (mentioned a `notepad` plugin and `Alt+m` keybind that aren't in `config.kdl`). Cleaned those up alongside the ghost references rather than file separately — same paragraph, same rot.

## Verification

- `script/checks/zellij-config` passed against the edited config.
- `pre-commit run --files ...` skipped (no shell/JSON files in the diff).