### PR TITLE
tighten repo CLAUDE.md, surface chezmoi gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,69 +1,39 @@
 # alunduil-chezmoi
 
-Chezmoi-managed dotfiles. Source files in this repo deploy to `$HOME` via
-`chezmoi apply`. This is the *chezmoi source directory*, not a conventional
-software project — naming conventions and file structure follow chezmoi rules.
+Chezmoi source directory. Files deploy to `$HOME` via `chezmoi apply`;
+names follow chezmoi rules (`dot_` → `.`, `executable_` → +x, `.tmpl` →
+Go template, `run_once_before_NN-…` → ordered idempotent bootstrap).
+README.md has the user-facing layout and bootstrap walkthrough.
 
-## Chezmoi naming conventions
+## Source vs. apply path
 
-- `dot_` prefix → deployed as `.` (e.g. `dot_bashrc` → `~/.bashrc`)
-- `executable_` prefix → deployed with mode +x
-- `.tmpl` suffix → expanded as a Go template before deployment
-- `run_once_before_` prefix → script executed once on `chezmoi apply`; re-runs
-  only when the file's content hash changes
-- `.chezmoiignore` → lists source files excluded from deployment (CLAUDE.md,
-  LICENSE, README.md, renovate.json, script/, test/)
+`chezmoi diff`/`apply` read the *applied* clone at
+`~/.local/share/chezmoi`, not this working tree. Edits here don't take
+effect on `apply` until committed and pulled into the apply clone. Use
+`chezmoi diff --source-path .` to preview from this checkout.
 
-## Layout
+## Invariants
 
-- `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell and
-  git config
-- `dot_claude/` — user-level Claude Code harness deployed to `~/.claude/`:
-  `CLAUDE.md` (guide), `settings.json` (hook wiring), `hooks/` (pr-draft-guard)
-- `dot_claustre/config.toml` — Claustre user config
-- `dot_config/zellij/` — Zellij config and layouts (pair.kdl for deep-pairing)
-- `dot_local/bin/executable_gh` — wrapper shadowing system `gh` to enforce
-  `--draft` on PR creation
-- `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:
-  01 system packages, 02 binary tools, 03 Node ecosystem, 04 Rust ecosystem,
-  05 standalone tools
-- `script/install/{zellij,lazygit,act}` — per-tool installers (version
-  pinned inside, `--bin-dir DIR` required, SHA256-verified). Invoked by
-  the 02 bootstrap script and reused by CI workflows so versions live in
-  one place. Shared helpers in `script/install/lib.sh`.
-- `script/checks/{zellij-config,chezmoi-apply}` — repo sanity checks run
-  in CI and locally.
+- Bootstrap scripts (`run_once_before_NN-*.sh.tmpl`) are idempotent;
+  re-running is safe. Numeric prefix orders them.
+- Tool versions live in `script/install/{zellij,lazygit,act}` and are
+  reused by both bootstrap and CI. Bump in one place.
+- `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
+  on `gh pr create`. PRs Claude opens go through this wrapper.
 
-## Previewing and testing changes
+## Sensors
+
+CI is authoritative. Run locally before claiming done:
 
 ```bash
-chezmoi diff          # show what chezmoi apply would change on the host
-chezmoi apply -n      # dry-run: same as diff but in apply format
-chezmoi apply -v      # apply with verbose output
+pre-commit run --all-files     # shellcheck, shfmt, check-json
+bats test/                     # unit tests
+script/checks/zellij-config    # zellij KDL validation (needs zellij)
+script/checks/chezmoi-apply    # apply round-trip (needs chezmoi + age)
 ```
-
-CI runs pre-commit (shellcheck, shfmt, check-json), bats tests, zellij config
-validation, chezmoi apply validation, and lychee link checking. Run locally:
-
-```bash
-pre-commit run --all-files   # lint
-bats test/                   # unit tests
-script/checks/zellij-config  # requires zellij on PATH
-script/checks/chezmoi-apply  # requires chezmoi + age
-```
-
-The bootstrap scripts are idempotent; re-running them is safe.
-
-## Never commit
-
-Credentials, private keys (`key.txt`, `.credentials.json`), runtime state
-(`~/.claustre/db/`), SSH private keys, or toolchain binaries. See README
-"Never in the repo" for the full list.
 
 ## Two CLAUDE.md files
 
-- **This file** (`CLAUDE.md` at repo root): instructions for AI tools working
-  on the chezmoi source — naming conventions, layout, testing.
-- **`dot_claude/CLAUDE.md`**: the deployed user-level Claude Code guide
-  (`~/.claude/CLAUDE.md`). It governs Claude Code behaviour on the host, not
-  contributions to this repo.
+- This file: rules for AI editing the chezmoi *source*.
+- `dot_claude/CLAUDE.md` → deploys to `~/.claude/CLAUDE.md`. Edits there
+  change Claude's host-wide behaviour on next `chezmoi apply`.


### PR DESCRIPTION
## Summary

Repo-local `CLAUDE.md` now leads with the chezmoi-specific gotchas
AI editors actually need (source vs. apply path, version-pinning
invariant, `gh` wrapper), and stops paraphrasing README. Cuts the
file ~50% so it earns its every-turn load cost.

## Verification

- `pre-commit run --all-files` passes (shellcheck, shfmt, check-json
   — no markdown hooks, so content is reviewer-checked).