### PR TITLE
add readme and contributing skills

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -150,6 +150,12 @@ templates) is loaded every relevant turn. Optimise for tokens, not
 readability: cut filler, decorative connectors, restated headings,
 and examples that don't disambiguate.
 
+## READMEs and CONTRIBUTING
+
+- README work (audit, write, revise, badges): `readme` skill.
+- CONTRIBUTING work, including the warranted/not decision:
+  `contributing` skill.
+
 ## Tests
 
 - Don't test upstream. If a behaviour belongs to the language,

--- a/dot_claude/skills/contributing/SKILL.md
+++ b/dot_claude/skills/contributing/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: contributing
+description: Audit, write, or revise CONTRIBUTING.md, including the decision of whether one is warranted. Use when creating contribution guidance, editing existing CONTRIBUTING, or when a README points to missing/thin contribution docs. Applies the nayafia/contributing-template framework.
+---
+
+# CONTRIBUTING
+
+Reference: <https://github.com/nayafia/contributing-template> (CC0).
+
+## Is one warranted?
+
+- Open source, accepting contributions: yes — fill in nayafia.
+- Closed source / personal config / archived: no — a one-line note in
+  the README suffices. Don't manufacture process for a project that
+  won't use it.
+- Library or tool with even occasional outside contributors: yes,
+  even if minimal.
+
+If not warranted, say so and stop.
+
+## Template (fill what applies, drop the rest)
+
+- **Welcome / how to contribute** — issues, PRs, docs, design. Be
+  concrete about what's wanted.
+- **Ground rules** — code of conduct pointer, scope boundaries, what
+  won't be accepted.
+- **Your first contribution** — "good first issue" filter or a small
+  task.
+- **Getting started** — clone, prerequisites, dev loop (sensors:
+  tests, linters, type checks). Mirror the README's install but for
+  the contributor path.
+- **Reporting bugs / suggesting features** — issue templates if any;
+  otherwise required fields.
+- **Code review process** — who reviews, turnaround, draft-PR
+  convention if used.
+- **Commit / PR conventions** — message style, branch naming,
+  sign-off, PR template.
+- **Community** — chat, mailing list — only when they exist.
+
+Concise, friendly, action-oriented. Drop sections rather than pad.
+
+## Procedure
+
+1. Decide warranted vs. not.
+2. If warranted: read existing CONTRIBUTING (if any), README, and 1-2
+   recent PRs to learn the *actual* process. Don't invent process the
+   project doesn't use.
+3. Surface scope and any inferences before drafting. Apply only after
+   agreement.

--- a/dot_claude/skills/readme/SKILL.md
+++ b/dot_claude/skills/readme/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: readme
+description: Audit, write, or revise README.md. Use when creating a README, editing one, or noticing smells (missing badges, no install steps, unclear purpose, no engagement guidance). Applies ddbeck's checklist and a shields.io badge principle.
+---
+
+# README
+
+Reference: <https://github.com/ddbeck/readme-checklist/blob/main/checklist.md>
+
+## Checklist (condensed)
+
+**Identify** — project name as first heading; repo/homepage URL near top; owner/author named.
+
+**Evaluate** — describe *why* (what it achieves), not *what* (what it's made of). Active voice, second person. License named (open source) or authorized users named (closed source).
+
+**Use** — prerequisites before install; install + basic usage, tested.
+
+**Engage** — pointer to deeper docs (CONTRIBUTING, LICENSE, CHANGELOG, etc.) when they exist; where to get help (or explicit "no support"); how to contribute (or explicit "not accepting").
+
+**Final** — TOC for 10+ screens; split into files past that.
+
+## Badges (shields.io)
+
+Each badge earns its place: real-time, decision-relevant info not already visible on the rendered page (e.g. on github.com).
+
+Usually qualifies:
+
+- License — `img.shields.io/github/license/<owner>/<repo>` — survives off-GitHub renders.
+- Code coverage when codecov/coveralls is wired up.
+- Tool/config presence (pre-commit, Renovate, Dependabot) when used.
+- Single-target platform/runtime when exactly one is supported.
+
+Usually doesn't:
+
+- CI status — GitHub shows it on commits; multi-workflow makes "build" ambiguous. Promote only when one named workflow is the gate.
+- Last commit — already on the GitHub page.
+- Release version — already on the sidebar; promote when README is rendered off-GitHub (npm, mirrors).
+- Dependency counters — noisy/stale. "Renovate enabled" / "Dependabot enabled" is the usable substitute.
+
+Test: would removing this badge lose information the reader couldn't get from the page above?
+
+## Procedure
+
+1. Read the README.
+2. Walk the checklist; note gaps.
+3. Walk the badges; flag any that don't earn their place and gaps the principle implies.
+4. Surface findings before editing. Apply only after scope is agreed.


### PR DESCRIPTION
## Summary

Claude now reaches for a dedicated skill when a README or CONTRIBUTING file
is created, edited, or smells funny — `readme` for README work and badges,
`contributing` for CONTRIBUTING guidance including the warranted-or-not
decision. Reference material (ddbeck's checklist, nayafia's template, the
shields.io badge principle) loads on demand instead of riding along in
every-turn `CLAUDE.md` context. A short breadcrumb under Documentation in
`dot_claude/CLAUDE.md` points at both skills so the trigger phrasing
matches how this comes up in practice.

## Gotchas

- The `readme` skill embeds a condensed copy of ddbeck's checklist rather
  than fetching it every invocation. If ddbeck updates the source, the
  skill drifts until re-synced — the link in the skill is the canonical
  pointer.
- Skill auto-invocation depends on Claude reading the `description`
  frontmatter and matching the situation. Descriptions name the smells
  explicitly ("missing badges, no install steps, unclear purpose") to give
  auto-invocation a fighting chance; explicit `/readme` / `/contributing`
  always works.
- This is host-wide guidance — once merged and applied, every Claude
  Code session on this host can reach the skills, not just sessions in
  this repo.

## Verification

- `pre-commit run --all-files` passes (shellcheck, shfmt, check-json — no
  markdown hooks).
- `bats test/` passes (18/18).
- The two URLs added (`github.com/ddbeck/readme-checklist/blob/main/checklist.md`,
  `github.com/nayafia/contributing-template`) were verified live via WebFetch
  during drafting; the Lychee workflow in CI re-checks them.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>