### PR TITLE
polish README, lead skill with ethos check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .lycheecache
+key.txt
+.credentials.json
+**/id_rsa*
+**/id_ed25519*
+**/id_ecdsa*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,4 @@ repos:
         # malformed.json is intentionally invalid — a fixture for the
         # pr-draft-guard hook's fail-closed-on-bad-input test.
         exclude: ^test/fixtures/pr_draft_guard/malformed\.json$
+      - id: detect-private-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Chezmoi source directory. Files deploy to `$HOME` via `chezmoi apply`;
 names follow chezmoi rules (`dot_` → `.`, `executable_` → +x, `.tmpl` →
 Go template, `run_once_before_NN-…` → ordered idempotent bootstrap).
-README.md has the user-facing layout and bootstrap walkthrough.
+README.md has the bootstrap walkthrough.
 
 ## Source vs. apply path
 
@@ -17,7 +17,9 @@ effect on `apply` until committed and pulled into the apply clone. Use
 - Bootstrap scripts (`run_once_before_NN-*.sh.tmpl`) are idempotent;
   re-running is safe. Numeric prefix orders them.
 - Tool versions live in `script/install/{zellij,lazygit,act}` and are
-  reused by both bootstrap and CI. Bump in one place.
+  reused by both bootstrap and CI. Bump in one place. Zellij *plugins*
+  (`zellaude`, `zjstatus`) are pinned separately as alias tags in
+  `dot_config/zellij/config.kdl`.
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ effect on `apply` until committed and pulled into the apply clone. Use
   `dot_config/zellij/config.kdl`.
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
+- Never committed: credentials/secrets, runtime state
+  (`.credentials.json`, session history, `~/.claustre/db/`), the age
+  private key, SSH private keys, toolchain binaries (chezmoi/Node/Rust
+  install via canonical installers).
 
 ## Sensors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,6 @@ effect on `apply` until committed and pulled into the apply clone. Use
   `dot_config/zellij/config.kdl`.
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
-- Never committed: credentials/secrets, runtime state
-  (`.credentials.json`, session history, `~/.claustre/db/`), the age
-  private key, SSH private keys, toolchain binaries (chezmoi/Node/Rust
-  install via canonical installers).
 
 ## Sensors
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # alunduil-chezmoi
 
+By [@alunduil](https://github.com/alunduil)
+
 [![License: 0BSD](https://img.shields.io/github/license/alunduil/alunduil-chezmoi)](LICENSE)
 [![Managed with chezmoi](https://img.shields.io/badge/managed%20with-chezmoi-blue)](https://chezmoi.io)
 [![Platform: Debian / Crostini](https://img.shields.io/badge/platform-Debian%20%2F%20Crostini-A81D33?logo=debian&logoColor=white)](https://www.debian.org)
+[![Claude skills: shareable](https://img.shields.io/badge/Claude%20skills-shareable-262625?logo=claude&logoColor=D97757)](dot_claude/skills/)
 
-Personal [chezmoi](https://chezmoi.io)-managed dotfiles for [@alunduil](https://github.com/alunduil). Run one command on a fresh Debian/Crostini host to go from bare OS to a fully configured development environment with AI pair programming, terminal multiplexing, and git integration — layouts, keybinds, and guardrails included. Source: <https://github.com/alunduil/alunduil-chezmoi>.
+Personal [chezmoi](https://chezmoi.io)-managed dotfiles. Run one command on a fresh Debian/Crostini host to go from bare OS to a fully configured development environment with AI pair programming, terminal multiplexing, and git integration — layouts, keybinds, and guardrails included. Source: <https://github.com/alunduil/alunduil-chezmoi>.
 
 Personal config — no warranty, no support. [0BSD licensed](LICENSE).
 
@@ -37,33 +40,6 @@ After bootstrap, confirm the key tools are on PATH:
 ```bash
 claude --version && claustre --version && zellij --version && lazygit --version
 ```
-
-## Companion repo
-
-`alunduil-claustre-state` (planned, private) holds Claustre's cross-machine task/project state:
-
-```bash
-claustre sync init git@github.com:alunduil/alunduil-claustre-state.git
-claustre sync pull
-```
-
-Only projects, tasks, and subtasks sync; sessions, worktrees, PIDs, and rate-limit state stay local.
-
-## Layout
-
-- `dot_bashrc`, `dot_profile`, `dot_bash_profile`, `dot_gitconfig` — shell + git config.
-- `dot_claude/` — user-level Claude Code harness: `CLAUDE.md` rules, `settings.json` hook wiring (pr-draft-guard for the GitHub MCP tools, zellaude across every Claude Code lifecycle event), `hooks/pr-draft-guard.sh` blocking non-draft PRs. Per-project sensors (tests/linters/types) stay with the project.
-- `dot_claustre/config.toml` — Claustre user config (`sync.auto_push = true`).
-- `dot_config/zellij/config.kdl` — Zellij config: plugin aliases (zellaude, zjstatus — both pinned to release tags) and the `Alt+p` keybind.
-- `dot_config/zellij/layouts/default.kdl` — initial-tab layout: zellaude top strip + 1-line `status-bar` (mode only, tips clipped).
-- `dot_config/zellij/layouts/pair.kdl` — deep-pairing layout: Claude Code (40%) alongside lazygit (60%). VS Code handles editing in its own window.
-- `dot_local/bin/gh` — wrapper that shadows `/usr/bin/gh` to require `--draft` on `gh pr create`. Bypass with `GH_DRAFT_GUARD=off`.
-- `run_once_before_*.sh.tmpl` — idempotent bootstrap scripts, split by concern:
-  - `01-install-system-packages` — apt packages, HashiCorp repo, Tailscale.
-  - `02-install-binary-tools` — Zellij, lazygit, act (GitHub release binaries).
-  - `03-install-node-ecosystem` — nvm, Node LTS, `@anthropic-ai/claude-code`, `@readwise/cli`.
-  - `04-install-rust-ecosystem` — rustup, Claustre.
-  - `05-install-standalone-tools` — rtk.
 
 ## Never in the repo
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,12 @@ gh auth login                              # ~/.config/gh/
 claude                                     # ~/.claude/.credentials.json
 sudo tailscale up                          # tailnet auth
 claustre configure                         # wires up Claude Code permissions
+
+# PATH check for chezmoi-installed binaries:
+zellij --version && lazygit --version
 ```
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.
-
-### Verify
-
-After bootstrap, confirm the key tools are on PATH:
-
-```bash
-claude --version && claustre --version && zellij --version && lazygit --version
-```
 
 ## Never in the repo
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ zellij --version && lazygit --version
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.
 
-## Never in the repo
-
-Credentials of any kind, runtime state (`.credentials.json`, session history, `~/.claustre/db/`), the age private key, SSH private keys, and toolchain binaries (chezmoi/Node/Rust install via canonical installers).
-
 ## Contributing
 
 Personal configuration — not accepting contributions. Fork freely under [0BSD](LICENSE).

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -46,6 +46,9 @@ A per-repo `CLAUDE.md` overrides anything here.
     X, confirmed Y"). Skip trivial steps (file reads, listings) unless
     load-bearing. Omit the section when CI covers everything.
     Unverified items belong in Gotchas, not here.
+- When adding commits to an open PR, regenerate the body from scratch.
+  The body describes the merge state, not the commit log; appending
+  each round drifts toward changelog narration.
 
 ## Commits
 

--- a/dot_claude/skills/readme/SKILL.md
+++ b/dot_claude/skills/readme/SKILL.md
@@ -41,7 +41,15 @@ Test: would removing this badge lose information the reader couldn't get from th
 
 ## Procedure
 
-1. Read the README.
-2. Walk the checklist; note gaps.
-3. Walk the badges; flag any that don't earn their place and gaps the principle implies.
-4. Surface findings before editing. Apply only after scope is agreed.
+1. Read the README. Name the actual audience.
+2. **Ethos first** — for each existing section, name the reader need it
+   serves (identify / evaluate / use / engage). Sections serving no
+   need are noise; flag them to cut, even if the checklist nominally
+   has a slot. "What it's made of" tours, internal implementation
+   notes, and speculative future plans usually fall here.
+3. **Gaps** — walk the checklist to find reader needs *not yet*
+   covered. The checklist is a prompt for missing needs, not a license
+   for existing sections.
+4. Walk the badges against the principle; flag any that don't earn
+   their place.
+5. Surface findings before editing. Apply only after scope is agreed.


### PR DESCRIPTION
## Summary

README and `CLAUDE.md` align to their audiences: the README earns each
section against an actual reader need (identify / evaluate / use /
engage); repo `CLAUDE.md` carries AI-load-bearing invariants (zellij
plugin pinning); hard rules like "never commit credentials" enforce
via `detect-private-key` + `.gitignore` patterns instead of trusting
prose to be read. The `readme` skill leads with the same ethos check
so future audits don't rubber-stamp checklist-eligible noise.

## Gotchas

- "Claude skills: shareable" badge is a repo-local convention — no
  community standard yet. Not codified into the `readme` skill until
  a rule-of-three pass.
- Badge relies on simple-icons' `claude` slug and Anthropic's coral
  `#D97757`. Falls back to text-only if the slug ever drops.
- Credential enforcement is two-layered: `detect-private-key` catches
  PEM content; `.gitignore` covers non-PEM shapes (age `key.txt`,
  `.credentials.json`) and SSH key file shapes. Removing either layer
  reduces coverage.
- Skill bug surfaced from self-application — worth reading the skill
  diff alongside the README diff to see why one motivated the other.

## Verification

Probed the new badge URL: HTTP 200, 3.8 KB SVG with the claude glyph
embedded and coral fill applied — Lychee in CI only confirms 200.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>