### PR TITLE
Tune lychee for slow churn and anchor checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,2 +1,4 @@
 cache = true
+max_cache_age = "14d"
 retry_wait_time = 5
+include_fragments = "full"

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,4 @@
 cache = true
 max_cache_age = "14d"
 retry_wait_time = 5
-include_fragments = "full"
+include_fragments = true


### PR DESCRIPTION
## Summary

Lychee now caches valid links for 14 days instead of 1, and verifies anchor fragments (`#section`) inside markdown — previously only the page existence was checked.

## Gotchas

`include_fragments = \"full\"` is the judgment call. It will catch genuinely dead `#anchors` in our own READMEs, but GitHub renders heading slugs with rules lychee may not match exactly. If runs go red on legit anchors, drop it back to the default (off) rather than papering over with `exclude` entries.

`max_cache_age` cannot fire stale cache entries on its own — the CI cache key in `.github/workflows/lychee.yml` already busts on any change to `lychee.toml` or `**/*.md` / `**/*.kdl`, so this just lets the cache survive longer when nothing changed.

## Verification

- `pre-commit run --files lychee.toml` passed (json/shfmt/shellcheck skipped — no relevant files; detect-private-key clean).
- Lychee CI run against this branch is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)