### PR TITLE
Adopt renovate best-practices, track pre-commit hooks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:best-practices"],
+  "baseBranches": ["main"],
+  "reviewers": ["alunduil"],
+  "pre-commit": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^script/install/zellij$"],
+      "managerFilePatterns": ["/^script/install/zellij$/"],
       "matchStrings": ["ZELLIJ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "zellij-org/zellij",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["run_once_before_.*\\.sh\\.tmpl$"],
+      "managerFilePatterns": ["/run_once_before_.*\\.sh\\.tmpl$/"],
       "matchStrings": ["NVM_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "nvm-sh/nvm",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^script/install/lazygit$"],
+      "managerFilePatterns": ["/^script/install/lazygit$/"],
       "matchStrings": ["LAZYGIT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "jesseduffield/lazygit",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^script/install/act$"],
+      "managerFilePatterns": ["/^script/install/act$/"],
       "matchStrings": ["ACT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "nektos/act",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["dot_config/zellij/config\\.kdl$"],
+      "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"
     }


### PR DESCRIPTION
## Summary

Renovate now tracks the hook revisions in `.pre-commit-config.yaml`, requests review from @alunduil on every PR it opens, and pins GitHub Actions to commit SHAs. Removes the need for pre-commit.ci.

## Gotchas

- After merge, expect a wave of PRs from `helpers:pinGitHubActionDigests` (bundled with `config:best-practices`) converting `actions/checkout@v4` → `actions/checkout@<sha> # v4` for every action in `.github/workflows/`. Each is independently reviewable.
- The `fileMatch` → `managerFilePatterns` rename keeps regex semantics by wrapping each pattern in `/.../`. The new field accepts both regex and globs and defaults to glob, so the slashes are load-bearing.
- `baseBranches: ["main"]` is normally auto-detected. Setting it explicitly is a portability convention for cross-repo reuse; whether it clears the dashboard's "Base branch does not exist" warning is unverified.

## Verification

- Ran `pre-commit run --files renovate.json`; check-json passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)