### PR TITLE
Add renovate skill

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -163,7 +163,8 @@ and examples that don't disambiguate.
 
 - `renovate.json` work (audit, write, troubleshoot dashboard, regex
   managers): `renovate` skill. Default preset is
-  `config:best-practices`; pre-commit manager is opt-in.
+  `config:best-practices` with the pre-commit manager enabled
+  unconditionally.
 
 ## Tests
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -159,6 +159,12 @@ and examples that don't disambiguate.
 - CONTRIBUTING work, including the warranted/not decision:
   `contributing` skill.
 
+## Renovate
+
+- `renovate.json` work (audit, write, troubleshoot dashboard, regex
+  managers): `renovate` skill. Default preset is
+  `config:best-practices`; pre-commit manager is opt-in.
+
 ## Tests
 
 - Don't test upstream. If a behaviour belongs to the language,

--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -13,16 +13,16 @@ Schema: <https://docs.renovatebot.com/renovate-schema.json>
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "baseBranches": ["main"],
+  "baseBranches": ["<default-branch>"],
   "reviewers": ["<owner>"],
   "pre-commit": { "enabled": true }
 }
 ```
 
 - `config:best-practices` — adds `helpers:pinGitHubActionDigests` (action SHA pinning) and OpenSSF scorecard alerts on top of `config:recommended`. Default for all repos.
-- `baseBranches` — auto-detected if omitted; explicit is more portable across repos and forks.
+- `baseBranches` — set to the repo's actual default branch (`main`, `master`, `trunk`, …), not a hard-coded value. Auto-detected if omitted; explicit is more portable across forks.
 - `reviewers` — without it, Renovate PRs land silent. Use `assignees` instead if you only want a creation-time ping (no rebase notifications).
-- `pre-commit: { enabled: true }` — opt-in manager. Add when `.pre-commit-config.yaml` exists; replaces the need for pre-commit.ci.
+- `pre-commit: { enabled: true }` — opt-in manager, enabled unconditionally. No-op when `.pre-commit-config.yaml` is absent (manager only acts on that file pattern); replaces the need for pre-commit.ci where the file does exist.
 
 ## Custom regex managers
 
@@ -53,7 +53,7 @@ Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
 
 ## Procedure
 
-1. Read `renovate.json` if present. Note the repo's default branch and whether `.pre-commit-config.yaml` exists.
-2. **Greenfield** — write the Defaults block; fill `<owner>` and the actual default branch. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
-3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, leftover `fileMatch`, ungoverned `*_VERSION=` pins).
+1. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
+2. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
+3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranches` not matching the actual default, leftover `fileMatch`, ungoverned `*_VERSION=` pins).
 4. Surface findings before editing. Apply only after scope is agreed.

--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: renovate
-description: Audit, write, or revise renovate.json. Use when adding Renovate to a repo, troubleshooting unexpected (or missing) update PRs, or evolving an existing config. Applies the config:best-practices preset, explicit baseBranches/reviewers, and pre-commit manager opt-in.
+description: Audit, write, or revise renovate.json. Use when adding Renovate to a repo, troubleshooting unexpected (or missing) update PRs, or evolving an existing config. Applies the config:best-practices preset, explicit baseBranchPatterns/reviewers, and pre-commit manager opt-in.
 ---
 
 # Renovate
@@ -13,14 +13,14 @@ Schema: <https://docs.renovatebot.com/renovate-schema.json>
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "baseBranches": ["<default-branch>"],
+  "baseBranchPatterns": ["<default-branch>"],
   "reviewers": ["<owner>"],
   "pre-commit": { "enabled": true }
 }
 ```
 
 - `config:best-practices` — adds `helpers:pinGitHubActionDigests` (action SHA pinning) and OpenSSF scorecard alerts on top of `config:recommended`. Default for all repos.
-- `baseBranches` — set to the repo's actual default branch (`main`, `master`, `trunk`, …), not a hard-coded value. Auto-detected if omitted; explicit is more portable across forks.
+- `baseBranchPatterns` — set to the repo's actual default branch (`main`, `master`, `trunk`, …), not a hard-coded value. Auto-detected if omitted; explicit is more portable across forks.
 - `reviewers` — without it, Renovate PRs land silent. Use `assignees` instead if you only want a creation-time ping (no rebase notifications).
 - `pre-commit: { enabled: true }` — opt-in manager, enabled unconditionally. No-op when `.pre-commit-config.yaml` is absent (manager only acts on that file pattern); replaces the need for pre-commit.ci where the file does exist.
 
@@ -48,12 +48,12 @@ Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
 
 - **Detected Dependencies** without `[Updates: ...]` = already current. Not a bug.
 - **Repository Problems** — investigate. "Base branch does not exist" usually means a stale config reference or a transient mid-run state.
-- **Config Migration Needed** — Renovate offers an automated PR for field renames (e.g. `fileMatch` → `managerFilePatterns`). Tick the checkbox or hand-migrate.
+- **Config Migration Needed** — Renovate offers an automated PR for field renames (e.g. `fileMatch` → `managerFilePatterns`, `baseBranches` → `baseBranchPatterns`). Tick the checkbox or hand-migrate.
 - **Open** — pending PRs; the per-row checkboxes force a rebase/retry.
 
 ## Procedure
 
 1. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
 2. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
-3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranches` not matching the actual default, leftover `fileMatch`, ungoverned `*_VERSION=` pins).
+3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins).
 4. Surface findings before editing. Apply only after scope is agreed.

--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: renovate
+description: Audit, write, or revise renovate.json. Use when adding Renovate to a repo, troubleshooting unexpected (or missing) update PRs, or evolving an existing config. Applies the config:best-practices preset, explicit baseBranches/reviewers, and pre-commit manager opt-in.
+---
+
+# Renovate
+
+Schema: <https://docs.renovatebot.com/renovate-schema.json>
+
+## Defaults
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "baseBranches": ["main"],
+  "reviewers": ["<owner>"],
+  "pre-commit": { "enabled": true }
+}
+```
+
+- `config:best-practices` — adds `helpers:pinGitHubActionDigests` (action SHA pinning) and OpenSSF scorecard alerts on top of `config:recommended`. Default for all repos.
+- `baseBranches` — auto-detected if omitted; explicit is more portable across repos and forks.
+- `reviewers` — without it, Renovate PRs land silent. Use `assignees` instead if you only want a creation-time ping (no rebase notifications).
+- `pre-commit: { enabled: true }` — opt-in manager. Add when `.pre-commit-config.yaml` exists; replaces the need for pre-commit.ci.
+
+## Custom regex managers
+
+For version pins inside scripts, KDL, etc.:
+
+```json
+{
+  "customType": "regex",
+  "managerFilePatterns": ["/^script/install/<tool>$/"],
+  "matchStrings": ["<TOOL>_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+  "depNameTemplate": "<owner>/<tool>",
+  "datasourceTemplate": "github-releases"
+}
+```
+
+- `managerFilePatterns` (renamed from `fileMatch`): wrap regex in `/.../`; bare strings are globs.
+- For URL-embedded versions, capture both `depName` and `currentValue` in `matchStrings` — no `depNameTemplate` needed.
+- One manager per `*_VERSION=` pattern; group only when the file shape is identical.
+
+## Dashboard reading
+
+Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
+
+- **Detected Dependencies** without `[Updates: ...]` = already current. Not a bug.
+- **Repository Problems** — investigate. "Base branch does not exist" usually means a stale config reference or a transient mid-run state.
+- **Config Migration Needed** — Renovate offers an automated PR for field renames (e.g. `fileMatch` → `managerFilePatterns`). Tick the checkbox or hand-migrate.
+- **Open** — pending PRs; the per-row checkboxes force a rebase/retry.
+
+## Procedure
+
+1. Read `renovate.json` if present. Note the repo's default branch and whether `.pre-commit-config.yaml` exists.
+2. **Greenfield** — write the Defaults block; fill `<owner>` and the actual default branch. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
+3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, leftover `fileMatch`, ungoverned `*_VERSION=` pins).
+4. Surface findings before editing. Apply only after scope is agreed.


### PR DESCRIPTION
## Summary

User-level `renovate` skill that codifies cross-repo Renovate conventions: `config:best-practices` preset, explicit `<default-branch>` baseBranchPattern and `<owner>` reviewer, unconditional pre-commit manager, and the regex-manager pattern for shell-script `*_VERSION=` pins. Mirrors the readme/contributing skills' shape.

## Gotchas

- Skill scope is intentionally narrow: defaults + regex managers + dashboard reading + audit/greenfield procedure. Deferred topics (groups, automerge, schedules, labels) — none currently used in this repo's renovate.json, easier to add when a real case forces the choice.
- Section heading is **Renovate** alongside **READMEs and CONTRIBUTING** rather than consolidating into a single "Skills" index. Matches the existing pattern (each section names its domain) and keeps the diff small.
- Pre-commit manager enabled unconditionally because Renovate's pre-commit manager only matches `/(^|/)\.pre-commit-config\.ya?ml$/`, so it's inert in repos without one. Confirmed against docs.renovatebot.com/modules/manager/pre-commit.
- This repo's own `renovate.json` (#77) still uses the now-deprecated `baseBranches` field. Migration is a separate concern — easiest fix is to tick the dashboard's "Config Migration Needed" checkbox to let Renovate auto-PR the rename.

## Verification

- Ran `pre-commit run --files dot_claude/skills/renovate/SKILL.md dot_claude/CLAUDE.md`; relevant hooks passed.
- `baseBranches` → `baseBranchPatterns` rename verified against the current `configuration-options` page on docs.renovatebot.com (quote: "This configuration option was formerly known as `baseBranches`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)