### PR TITLE
Add issue-work skill

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -85,6 +85,9 @@ A per-repo `CLAUDE.md` overrides anything here.
   has been replaced).
 - Multi-step tasks: commit incrementally rather than batching.
   Interruptions leave a recoverable branch, not lost work.
+- Picking up a specific issue (`work #N`, `implement #N`, `fix #N`):
+  `issue-work` skill. Carries the inspect commands, staleness signals,
+  and go/no-go format.
 
 ## Feedback preference
 

--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: issue-work
+description: Pick up an existing GitHub issue in the checked-out repo — implement from scratch or take over an in-flight PR. Use when asked to work, take, implement, fix, or close issue #N. Confirms relevance before coding (comments, recent commits, linked PRs/branches), surfaces a go/no-go on staleness, then commits incrementally.
+---
+
+# Issue work
+
+## Inspect
+
+```bash
+gh issue view <N> --comments                     # body + comments + cross-refs
+gh issue develop <N> --list                      # branches linked to this issue
+gh pr list --search "<N> in:body" --state open   # open PR taking it forward?
+```
+
+For recent commits in the area:
+
+- Path-scoped: `git log --oneline -- <path>` over files the issue names.
+- Otherwise: `git log --oneline --since=<issue createdAt>` over the likely subsystem.
+
+## Reproduce (bug-typed issues)
+
+Attempt repro on the default branch before writing the fix:
+
+- A confirmed repro becomes the failing test the fix has to flip.
+- A failed repro is itself a staleness signal — issue may be obsolete.
+- If repro is hard because the harness for this code path doesn't exist, surface it. Tiny harness lifts can land inline; anything bigger files separately and waits for direction.
+
+## Staleness signals
+
+Any one fires a go/no-go before writing code:
+
+- A commit since the issue was filed already implements or supersedes the change.
+- A linked PR is already merged — the issue should close, not be re-implemented.
+- The issue assumes tooling/files that have since been replaced or removed.
+- The motivating dependency resolved differently (e.g. "waiting on upstream X" — X shipped via a different mechanism).
+- A maintainer comment narrows or vetoes the original scope and the body wasn't updated.
+- Repro fails on the default branch.
+- The issue lacks enough detail to start without guessing.
+
+## Go/no-go format
+
+Name (1) the signal, (2) where you saw it (file:line, SHA, comment URL), (3) the proposed call: proceed as written / proceed with adjusted scope / close as obsolete / ask the filer.
+
+Raise in chat by default. Escalate to an issue comment when durability matters: the filer isn't the user, work will pause waiting on an answer, or the resolution is structural enough that future readers need the context.
+
+## Working branch
+
+Prefer existing context over creating new:
+
+- Already on a fresh branch (e.g. claustre worktree pre-pack): use it.
+- Open PR taking the issue forward → takeover: `gh pr checkout <PR#>`.
+- Linked branch but no PR yet: `gh issue develop --checkout <N>` checks it out.
+- Nothing linked: `gh issue develop --checkout <N>` creates and links a branch.
+
+## Procedure
+
+1. Inspect the issue, its comments, and linked branches/PRs.
+2. For bug-typed issues, attempt repro.
+3. Scan recent commits in the named area.
+4. If any staleness signal fires, surface go/no-go and stop.
+5. Otherwise state intent, pick the working branch, and proceed. Commit incrementally for multi-step work. Open a draft PR with `Closes #<N>` (skip if takeover — push to the existing PR's branch).


### PR DESCRIPTION
## Summary

Adds an `issue-work` skill that packages the implement-an-issue procedure (inspect, reproduce, staleness signals, go/no-go format, working-branch decision) into a callable skill, deployed host-wide via `chezmoi apply`. `dot_claude/CLAUDE.md` `Issue workflow` gains a one-line pointer, mirroring the renovate/readme/contributing pattern.

The skill carries:

- `gh` commands for inspecting an issue and any linked branches/PRs.
- Reproduction step for bug-typed issues, including surfacing harness gaps as a finding (with scope discipline).
- Staleness signals that should fire a go/no-go before writing code, plus the format for raising one.
- Working branch as a decision (claustre worktree pre-pack, PR takeover via `gh pr checkout`, linked branch, fresh) rather than a single command.
- Chat-first ambiguity surfacing; escalate to issue comment when durability matters.

No upstream baseline: `anthropics/skills` has no issue skill, and `mattpocock/skills` `triage`/`to-issues` cover grooming and filing rather than implementation.

## Gotchas

- The skill assumes GitHub Issues + `gh` CLI; non-GitHub repos won't trigger it. Cross-repo bias was specifically audited — `main`/`master` references replaced with "default branch", and `gh` commands work universally.
- Section ordering puts Reproduce before Staleness because repro outcomes feed two staleness signals (bug already fixed; harness-gap).

## Verification

- `pre-commit run --all-files` passed (shellcheck, shfmt, check-json, detect-private-key).