### PR TITLE
Install gcx CLI in bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ effect on `apply` until committed and pulled into the apply clone. Use
 
 - Bootstrap scripts (`run_once_before_NN-*.sh.tmpl`) are idempotent;
   re-running is safe. Numeric prefix orders them.
-- Tool versions live in `script/install/{zellij,lazygit,act}` and are
+- Tool versions live in `script/install/{zellij,lazygit,act,gcx}` and are
   reused by both bootstrap and CI. Bump in one place. Zellij *plugins*
   (`zellaude`, `zjstatus`) are pinned separately as alias tags in
   `dot_config/zellij/config.kdl`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo tailscale up                          # tailnet auth
 claustre configure                         # wires up Claude Code permissions
 
 # PATH check for chezmoi-installed binaries:
-zellij --version && lazygit --version
+zellij --version && lazygit --version && gcx --version
 ```
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ chmod 600 ~/.config/chezmoi/key.txt
 # Interactive logins (per-machine, never managed):
 gh auth login                              # ~/.config/gh/
 claude                                     # ~/.claude/.credentials.json
+gcx login                                  # ~/.config/gcx/
 sudo tailscale up                          # tailnet auth
 claustre configure                         # wires up Claude Code permissions
 
 # PATH check for chezmoi-installed binaries:
-zellij --version && lazygit --version && gcx --version
+zellij --version && lazygit --version
 ```
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,13 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^script/install/gcx$/"],
+      "matchStrings": ["GCX_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "grafana/gcx",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -2,6 +2,7 @@
 # zellij content:  {{ include "script/install/zellij" | sha256sum }}
 # lazygit content: {{ include "script/install/lazygit" | sha256sum }}
 # act content:     {{ include "script/install/act" | sha256sum }}
+# gcx content:     {{ include "script/install/gcx" | sha256sum }}
 # lib.sh content:  {{ include "script/install/lib.sh" | sha256sum }}
 # The hashes above embed the install scripts' content into this file's
 # rendered output so chezmoi re-runs this script when any of them change
@@ -13,5 +14,12 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/zellij" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/lazygit" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/act" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/gcx" --bin-dir "$HOME/.local/bin"
+
+# gcx ships its skill bundle inside the binary; `skills install --all`
+# extracts it to ~/.agents/skills (the cross-harness convention read by
+# Claude Code, Cursor, Copilot). --force re-syncs gcx-managed files on
+# version bumps without touching anything outside the bundle.
+"$HOME/.local/bin/gcx" skills install --all --force >/dev/null
 
 mkdir -p "$HOME/.config/zellij/plugins"

--- a/script/install/gcx
+++ b/script/install/gcx
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCX_VERSION="v0.2.11"
+ARCH="linux_amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/gcx"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${GCX_VERSION#v}"; then
+  printf '==> gcx: %s already installed at %s\n' "$GCX_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> gcx: downloading %s\n' "$GCX_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/grafana/gcx/releases/download/${GCX_VERSION}"
+asset="gcx_${GCX_VERSION#v}_${ARCH}.tar.gz"
+checksums="gcx_${GCX_VERSION#v}_checksums.txt"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/$checksums" "$base/$checksums"
+
+expected="$(expected_from_checksums "$tmp/$checksums" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp" gcx
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/gcx" "$bin"


### PR DESCRIPTION
## Summary

`gcx --version` works after `chezmoi apply` on a fresh host. The
binary lands in `~/.local/bin` via a new `script/install/gcx` (v0.2.11,
SHA-verified), and the bundled skill set unpacks to `~/.agents/skills`
on the same bootstrap pass. The README's "Interactive logins" block
gains a `gcx login` line alongside `gh auth login` and `claude`.

## Gotchas

- Issue #53's last AC asked for skills under `dot_claude/`. Upstream
  actually ships them inside the binary and `gcx skills install`
  writes to `~/.agents/skills` — the cross-harness convention read
  by Claude Code, Cursor, and Copilot. That path is host-wide and
  not per-project, so the intent ("not into any per-project Claude
  configuration") is preserved; only the path differs from what the
  issue assumed. Skills are gcx-managed, so vendoring them into
  `dot_claude/skills/` would couple this repo to gcx's internal
  bundle format and drift on every version bump.
- gcx is auth-first (`gcx login`), parallel to `gh` and `claude` —
  not a fire-and-forget binary like `zellij` or `lazygit`. README
  routes it through the interactive-logins block instead of the
  PATH-reachability check. PATH coverage is implicit because
  `gcx login` would fail if the binary weren't on PATH.
- `gcx skills install --all --force` only overwrites files the gcx
  bundle owns, so it's safe to re-run on version bumps without
  clobbering anything outside the bundle. Verified by running it
  twice against a temp `--dir`: second run reported `unchanged: 33`.
- `run_once_before_02` includes a `gcx content` hash so chezmoi
  re-fires the bootstrap whenever `script/install/gcx` changes (the
  same pattern zellij/lazygit/act use).
- Renovate gets a custom manager entry mirroring the act/lazygit
  ones, so `GCX_VERSION` tracks `grafana/gcx` releases.

## Verification

- `pre-commit run --all-files` — passed
- `bats test/` — 18/18
- `script/checks/chezmoi-apply` — exit 0
- `script/install/gcx --bin-dir <tmp>` — downloaded, SHA-verified,
  installed; `gcx --version` reported `0.2.11`. Second run: "already
  installed" no-op.
- `gcx skills install --all --dir <tmp>` twice — first run wrote 33
  files, second reported all 33 unchanged.

Closes #53