### PR TITLE
Install gh-poi via bootstrap to prune squash-merged branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ effect on `apply` until committed and pulled into the apply clone. Use
   reused by both bootstrap and CI. Bump in one place. Zellij *plugins*
   (`zellaude`, `zjstatus`) are pinned separately as alias tags in
   `dot_config/zellij/config.kdl`.
+- `gh` extensions install in script 05 alongside other bespoke
+  installers, not script 02 — they're managed by `gh extension`, not
+  the `script/install/` download-and-verify pattern. Version pin lives
+  inline in the script (e.g. `GH_POI_VERSION`).
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ claustre configure                         # wires up Claude Code permissions
 
 # PATH check for chezmoi-installed binaries:
 zellij --version && lazygit --version
+gh extension list                          # confirms gh-poi (squash-merge pruner)
 ```
 
 If SSH to GitHub isn't set up yet, clone over HTTPS first and swap remotes once keys are in place.

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,13 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_05-install-standalone-tools\\.sh\\.tmpl$/"],
+      "matchStrings": ["GH_POI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "seachicken/gh-poi",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"

--- a/run_once_before_05-install-standalone-tools.sh.tmpl
+++ b/run_once_before_05-install-standalone-tools.sh.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Installs tools that have their own bespoke curl installers and don't
-# belong to the apt, npm, or cargo ecosystems.
+# Installs tools whose canonical installer is bespoke -- curl scripts,
+# `gh extension install`, etc. -- and not part of the apt, npm, or cargo
+# ecosystems. `gh` extensions in particular live here, not in script 02
+# (binary tools), since they're managed by `gh` rather than downloaded
+# and sha256-verified per the script/install/ pattern.
 
 set -euo pipefail
 
@@ -14,6 +17,25 @@ if ! command -v rtk >/dev/null 2>&1; then
   curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 else
   log "rtk: already installed"
+fi
+
+# --------------------------------------------------------------- gh-poi
+# Prunes squash-merged local branches by consulting GitHub PR state --
+# `git branch --merged` can't see them. `gh poi` requires `gh` (apt,
+# script 01). Pin enforced: if a different version is already
+# installed, replace it so renovate-tracked bumps actually take effect.
+GH_POI_VERSION="v0.17.0"
+installed="$(gh extension list 2>/dev/null | awk -F'\t' '$2 == "seachicken/gh-poi" {print $3; exit}')"
+if [ "$installed" != "$GH_POI_VERSION" ]; then
+  if [ -n "$installed" ]; then
+    log "gh-poi: replacing $installed with $GH_POI_VERSION"
+    gh extension remove poi
+  else
+    log "gh-poi: installing $GH_POI_VERSION"
+  fi
+  gh extension install seachicken/gh-poi --pin "$GH_POI_VERSION"
+else
+  log "gh-poi: $GH_POI_VERSION already installed"
 fi
 
 log "standalone tools complete"


### PR DESCRIPTION
## Summary

`gh poi` is now installed on every chezmoi-managed host, pinned to v0.17.0 and tracked by renovate. Run `gh poi` in any repo to delete local branches whose squash-merged PRs have closed — branches `git branch --merged main` can't see.

Closes #52.

## Gotchas

- **Convention call** (codified in `CLAUDE.md`): `gh` extensions install in script 05 alongside other bespoke installers, not script 02 — the `script/install/` pattern is download-and-verify, but `gh extension install` delegates to `gh` itself. Inline `GH_POI_VERSION` in the script; renovate manager covers the bump.
- **Pin enforcement, not "install if missing"**: when `gh extension list` shows a different version, the script removes and reinstalls. `gh extension upgrade` would defeat the pin (it goes to latest), so renovate-tracked bumps need this replace path to actually take effect on next bootstrap.

## Verification

- `pre-commit run --all-files` — clean (shellcheck, shfmt, check-json).
- `bats test/` — 18/18 pass.
- `script/checks/zellij-config` and `script/checks/chezmoi-apply` — exit 0; rendered template valid.
- Exercised the gh-poi block in isolation against the live `gh`: fresh install installs v0.17.0; rerun is idempotent (skips); a forced downgrade to v0.16.0 followed by rerun replaces with v0.17.0.