### PR TITLE
Document login vs no-login routing for new tools

### DIFF
--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: add-tool
+description: Decide where a new tool slots into the chezmoi bootstrap and README. Use when adding a CLI/binary to the host bootstrap so it lands in the right install pass and the right README block. Routes auth-required tools to "Interactive logins" and fire-and-forget binaries to "PATH check".
+---
+
+# Add a tool to bootstrap
+
+Two decisions, made independently.
+
+## Auth axis
+
+Does the tool need interactive auth (login, browser flow, API token)
+to do real work?
+
+- **Yes** (gh, claude, gcx, readwise, tailscale): list in README
+  "Interactive logins" with a config-path comment so a fresh-host
+  bootstrap surfaces where state lands. No PATH-check line — running
+  the login command itself proves reachability. Auth state is
+  runtime, never managed by chezmoi.
+- **No** (zellij, lazygit, act, rtk, gh-poi): list in README "PATH
+  check" line.
+
+## Install mechanism
+
+Pick the canonical installer for the ecosystem:
+
+| Source                | Pass                                            | Pattern                          |
+| --------------------- | ----------------------------------------------- | -------------------------------- |
+| Debian package        | `run_once_before_01`                            | append to `APT_PACKAGES`         |
+| Pinned binary release | `run_once_before_02` + `script/install/<tool>`  | template below                   |
+| npm package           | `run_once_before_03`                            | `npm install -g`, `command -v`   |
+| Cargo crate           | `run_once_before_04`                            | `cargo install`, `command -v`    |
+| `gh` extension        | `run_once_before_05`                            | `gh extension install --pin`     |
+| `curl \| sh`          | `run_once_before_05`                            | guard with `command -v`          |
+
+Auth and install axes are independent: `gcx` is auth-required *and*
+uses `script/install/`; `gh-poi` is fire-and-forget *and* uses
+`gh extension install`.
+
+## script/install/<tool> template
+
+Mirror `script/install/{zellij,lazygit,act,gcx}`. Mode 0755:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOOL_VERSION="vX.Y.Z"
+ARCH="<release-arch-string>"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/<tool>"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${TOOL_VERSION#v}"; then
+  printf '==> <tool>: %s already installed at %s\n' "$TOOL_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> <tool>: downloading %s\n' "$TOOL_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/<owner>/<tool>/releases/download/${TOOL_VERSION}"
+asset="<tool>_${TOOL_VERSION#v}_${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
+
+expected="$(expected_from_checksums "$tmp/checksums.txt" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp" <tool>
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/<tool>" "$bin"
+```
+
+In `run_once_before_02-install-binary-tools.sh.tmpl`, add both:
+
+- `# <tool> content: {{ include "script/install/<tool>" | sha256sum }}`
+  to the hash-include block — without this, chezmoi won't re-fire
+  bootstrap on version bumps.
+- `"$INSTALL_DIR/<tool>" --bin-dir "$HOME/.local/bin"` to the call list.
+
+Add a Renovate custom-manager entry so `<TOOL>_VERSION` tracks GitHub
+releases — see the `renovate` skill for the regex-manager pattern.
+
+## Procedure
+
+1. Identify the auth axis and install mechanism.
+2. Wire the installer into the right `run_once_before_NN` pass.
+3. Update README:
+   - Auth-required → add to "Interactive logins" with config-path comment
+   - Fire-and-forget → add to "PATH check" line
+4. Pin via Renovate when the version lives in shell/script.
+5. Run sensors before claiming done:
+
+   ```bash
+   pre-commit run --all-files
+   bats test/
+   script/checks/chezmoi-apply
+   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,27 @@ effect on `apply` until committed and pulled into the apply clone. Use
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
 
+## Adding a new tool
+
+Decide first: does the tool need interactive auth (login, browser
+flow, API token) to do real work?
+
+- **Yes** (gh, claude, gcx, readwise, tailscale): list in README
+  "Interactive logins" with a config-path comment so a fresh-host
+  bootstrap surfaces where state lands. No PATH-check line — running
+  the login command itself proves reachability. Auth state is
+  runtime, never managed by chezmoi.
+- **No** (zellij, lazygit, act, rtk, gh-poi): list in README "PATH
+  check". If the tool isn't in apt/npm/cargo, follow the
+  `script/install/<tool>` pattern: pinned version, SHA-256 verified
+  via `lib.sh`, `--bin-dir DIR` interface, idempotent on `--version`
+  match. Add a `{{ include "script/install/<tool>" | sha256sum }}`
+  line in `run_once_before_02` so version bumps re-fire bootstrap.
+
+Auth and install mechanism are independent: `gcx` uses
+`script/install/` *and* lands in interactive logins; `gh-poi` uses
+`gh extension install` *and* lands in PATH check.
+
 ## Sensors
 
 CI is authoritative. Run locally before claiming done:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,27 +27,6 @@ effect on `apply` until committed and pulled into the apply clone. Use
 - `dot_local/bin/executable_gh` shadows system `gh` to enforce `--draft`
   on `gh pr create`. PRs Claude opens go through this wrapper.
 
-## Adding a new tool
-
-Decide first: does the tool need interactive auth (login, browser
-flow, API token) to do real work?
-
-- **Yes** (gh, claude, gcx, readwise, tailscale): list in README
-  "Interactive logins" with a config-path comment so a fresh-host
-  bootstrap surfaces where state lands. No PATH-check line — running
-  the login command itself proves reachability. Auth state is
-  runtime, never managed by chezmoi.
-- **No** (zellij, lazygit, act, rtk, gh-poi): list in README "PATH
-  check". If the tool isn't in apt/npm/cargo, follow the
-  `script/install/<tool>` pattern: pinned version, SHA-256 verified
-  via `lib.sh`, `--bin-dir DIR` interface, idempotent on `--version`
-  match. Add a `{{ include "script/install/<tool>" | sha256sum }}`
-  line in `run_once_before_02` so version bumps re-fire bootstrap.
-
-Auth and install mechanism are independent: `gcx` uses
-`script/install/` *and* lands in interactive logins; `gh-poi` uses
-`gh extension install` *and* lands in PATH check.
-
 ## Sensors
 
 CI is authoritative. Run locally before claiming done:

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ chmod 600 ~/.config/chezmoi/key.txt
 gh auth login                              # ~/.config/gh/
 claude                                     # ~/.claude/.credentials.json
 gcx login                                  # ~/.config/gcx/
+readwise login                             # ~/.readwise-cli.json
 sudo tailscale up                          # tailnet auth
 claustre configure                         # wires up Claude Code permissions
 
 # PATH check for chezmoi-installed binaries:
-zellij --version && lazygit --version
+zellij --version && lazygit --version && act --version && rtk --version
 gh extension list                          # confirms gh-poi (squash-merge pruner)
 ```
 


### PR DESCRIPTION
## Summary

Adding a new tool now has a written decision tree, loaded on demand:
the `add-tool` repo-local skill routes auth-required tools
(gh/claude/gcx/readwise/tailscale) to README's interactive-logins
block, fire-and-forget binaries (zellij/lazygit/act/rtk/gh-poi) to
PATH check, and inlines a `script/install/<tool>` template for
pinned tarball releases. The next tool PR can cite the skill instead
of rediscovering the pattern from #53/#83.

## Gotchas

- The skill lives at `.claude/skills/add-tool/`, not
  `dot_claude/skills/`. The routing is specific to this chezmoi
  source layout (run_once_before_NN passes, script/install/lib.sh,
  README block names) — not a cross-repo pattern, so it stays
  repo-local.
- Skill instead of CLAUDE.md text: tool additions fire maybe once
  a quarter, so paying always-on context tokens for the routing
  guide is poor value. The skill description triggers on "add CLI
  to bootstrap" / "install tool X" / similar.
- Three drift fixes landed alongside the skill: `readwise login`
  was missing from interactive logins despite the CLI needing OAuth,
  and `act`/`rtk` were missing from the PATH-check line despite
  being fire-and-forget binaries in `~/.local/bin`. Writing the
  example lists in the skill body was the forcing function.
- Skipped the optional `script/install/_template` file; the skill
  inlines the template instead, so there's no separate file to keep
  in sync with the four real installers.

## Verification

- `pre-commit run --all-files` — passed (shellcheck, shfmt,
  check-json, detect-private-key)
- `bats test/` — 18/18

Closes #84