### PR TITLE
Lint edited files via pre-commit PostToolUse hook

### DIFF
--- a/dot_claude/hooks/executable_pre-commit-edit-guard.sh
+++ b/dot_claude/hooks/executable_pre-commit-edit-guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run pre-commit on the just-edited file so lint
+# failures surface immediately instead of piling up at commit time.
+# Matched on Edit/Write/MultiEdit/NotebookEdit by settings.json.
+#
+# Exit 0 = silent pass / nothing to do; exit 2 surfaces stderr to
+# Claude as feedback for the next turn. Parse failures exit 0 — we
+# lose lint coverage rather than loop on infrastructure noise.
+#
+# Skips when the edited path isn't in a git repo, the repo has no
+# .pre-commit-config.yaml, or pre-commit isn't on PATH.
+
+set -euo pipefail
+
+input="$(cat)"
+
+file_path="$(jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' <<<"$input" 2>/dev/null || true)"
+[ -n "$file_path" ] || exit 0
+[ -e "$file_path" ] || exit 0
+
+command -v pre-commit >/dev/null || exit 0
+
+repo_root="$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$repo_root" ] || exit 0
+[ -f "$repo_root/.pre-commit-config.yaml" ] || exit 0
+
+if ! output="$(cd "$repo_root" && pre-commit run --files "$file_path" 2>&1)"; then
+  cat >&2 <<EOF
+pre-commit reported issues on $file_path (some hooks may have auto-fixed —
+re-read the file before continuing):
+
+$output
+EOF
+  exit 2
+fi
+exit 0

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -32,6 +32,15 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alunduil/.claude/hooks/pre-commit-edit-guard.sh"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit"
       }
     ],
     "PostToolUseFailure": [


### PR DESCRIPTION
## Summary

Pre-commit failures (Vale, yamllint, shellcheck, shfmt, …) now
surface to Claude on the same turn as the edit instead of piling up
until commit time. Targets the friction in the `/insights` report
where late-session lint scrambles burned quota and left nothing
committed.

The hook no-ops outside repos that opt in via
`.pre-commit-config.yaml`, so non-pre-commit projects see no change.

## Gotchas

- **No bats coverage yet.** `pr_draft_guard.bats` is the precedent
  for hook tests, but mirroring it here needs a temp git repo and
  a `pre-commit` stub on PATH (heavier than the JSON fixture
  pattern). Easy to add as a follow-up — flag if you want it in
  this PR instead.
- **Auto-fix path.** Hooks like `trailing-whitespace` rewrite the
  file. The hook surfaces that as a failure with a "re-read the
  file" hint so Claude's stale in-memory copy doesn't clobber the
  fix on the next Edit.
- **Fails open on parse errors**, unlike `pr-draft-guard.sh` which
  fails closed. Rationale in the script header — losing one lint
  pass to a jq quirk is cheaper than blocking every Edit.
- **No timeout.** Single-file `pre-commit run --files` is fast for
  the hooks I actually use. If a slow hook (mypy on a big project)
  becomes painful, add `timeout: 60` to the settings entry.

## Verification

- `pre-commit run --all-files` — passed (shellcheck, shfmt,
  check-json, detect-private-key).
- `bats test/` — 18/18 pass; no regression in `pr_draft_guard`
  or `gh_wrapper` suites.
- `script/checks/chezmoi-apply` — round-trip apply succeeded with
  the new hook + settings entry.