### PR TITLE
Add issue-links and milestones skills

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -178,6 +178,18 @@ and examples that don't disambiguate.
   Manual maintenance only — never proposes adopting tooling, and
   cutting a release (tagging, version-file edits) is out of scope.
 
+## Issue relationships
+
+- Linking GitHub issues/PRs (blocked-by via GraphQL, parent/sub-issue,
+  Closes/Fixes, plain mention): `issue-links` skill. Strongest
+  accurate edge; size test resolves blocked-by vs parent/sub-issue.
+
+## Milestones
+
+- GitHub milestone work (creating, naming, scoping, closing):
+  `milestones` skill. One axis per project (release / date / theme),
+  no mixing, no using milestones as labels.
+
 ## Tests
 
 - Don't test upstream. If a behaviour belongs to the language,

--- a/dot_claude/skills/issue-links/SKILL.md
+++ b/dot_claude/skills/issue-links/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: issue-links
+description: Relate GitHub issues and PRs — pick the right edge type (blocked-by via GraphQL, parent/sub-issue, Closes/Fixes in PR body, plain mention) and apply it. Use when asked to link, block, depend on, make a subtask of, or close-on-merge.
+---
+
+# Issue links
+
+Pick the *strongest accurate* relationship — but no stronger.
+
+## Decision tree
+
+- **Closes / Fixes / Resolves #N in PR body** — auto-closes on merge.
+  Default when a PR ends an issue.
+- **blocked-by / blocks** — A can't proceed or ship until B lands.
+  Both are peer-sized; B is *not* a piece of A. Surfaces in the
+  dependency graph and gates closing.
+- **parent / sub-issue** — A is decomposition of parent B's work.
+  Sub wouldn't exist on its own; parent isn't done until subs are.
+  Subs roll up into parent's progress.
+- **plain `#N` mention** — context only, no causal edge. Discussion,
+  prior art, "see also". Default when nothing stronger fits.
+
+The trap: reaching for parent/sub-issue when blocked-by is what's
+meant, because sub-issues were the only hierarchy GitHub had for
+years. Size test — peer-sized → blocked-by; smaller-than-parent →
+sub-issue.
+
+## How to apply each
+
+### Closes / Fixes / Resolves
+
+In the PR body or commit message:
+
+```
+Closes #123
+```
+
+Same-repo number, or `owner/repo#123` cross-repo. Recognized verbs:
+close, fix, resolve (any tense).
+
+### blocked-by (GraphQL only — no `gh issue` flag, no REST)
+
+```bash
+A=$(gh issue view <A> --json id --jq .id)   # blocked issue
+B=$(gh issue view <B> --json id --jq .id)   # blocker
+gh api graphql -f query='
+  mutation($a: ID!, $b: ID!) {
+    addBlockedBy(input: { issueId: $a, blockingIssueId: $b }) {
+      issue { number }
+      blockingIssue { number }
+    }
+  }' -f a="$A" -f b="$B"
+```
+
+Removal: `removeBlockedBy(input: { issueId, blockingIssueId })`.
+Read: `Issue.blockedBy`, `Issue.blocking`, `Issue.issueDependenciesSummary`.
+Use `-f` (not `-F`) for `ID!` variables — `-F` coerces to Int/Bool.
+
+### Parent / sub-issue
+
+```bash
+P=$(gh issue view <parent> --json id --jq .id)
+S=$(gh issue view <sub>    --json id --jq .id)
+gh api graphql -f query='
+  mutation($p: ID!, $s: ID!) {
+    addSubIssue(input: { issueId: $p, subIssueId: $s }) {
+      issue { number }
+    }
+  }' -f p="$P" -f s="$S"
+```
+
+Removal: `removeSubIssue`. Reorder: `reprioritizeSubIssue`. Reparent
+an existing sub: `addSubIssue` with `replaceParent: true`. Read:
+`Issue.parent`, `Issue.subIssues`, `Issue.subIssuesSummary`.
+
+### Plain mention
+
+Just `#123` in the body. No tooling.
+
+## Procedure
+
+1. Read both issues — what each is *for*. Don't link from the user's
+   framing alone.
+2. Apply the strongest accurate edge using the size test: peer-sized
+   → blocked-by; smaller-than-parent → sub-issue; resolved-by-merge →
+   Closes; otherwise → plain mention. If torn between two, surface;
+   don't silently pick.
+3. Verify it reads back: `Issue.blockedBy` / `Issue.subIssues` for
+   graph edges, the PR body for Closes.

--- a/dot_claude/skills/milestones/SKILL.md
+++ b/dot_claude/skills/milestones/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: milestones
+description: Create, name, scope, assign, and close GitHub milestones. Use when adding a milestone, deciding whether work belongs in one, or naming the next one. One axis per project (release / date / theme); never as labels.
+---
+
+# Milestones
+
+A milestone is a *finite, scoped* group of issues converging on a
+shipping or closing event. If it doesn't converge, it's a label — use
+`gh label` instead.
+
+## Pick one axis per project
+
+- **Release-anchored** — name = the version it targets: `v1.0.0`,
+  `v1.1.0` (semver), or `1.0.0.0` (PVP). Best when the project ships
+  releases.
+- **Date-anchored** — name = the calendar window: `2026-Q2`,
+  `2026-05`, `Sprint 23`. Best when work is time-bounded.
+- **Theme-anchored** — name = the outcome: `Auth overhaul`,
+  `Public beta`. Best for project phases not pegged to a release or
+  window.
+
+Don't mix axes within one project — `v1.1.0` and `2026-Q2` and
+`Auth overhaul` together leaves contributors guessing where to file.
+Pick one and inherit it for the next milestone.
+
+## Description: outcome, not inventory
+
+The description states the user-visible outcome the milestone
+delivers — present-tense, the way you'd phrase an OKR objective.
+Issues are the actions; the milestone is what those actions add up to.
+
+- Outcome-shaped: "Auth flows can be configured without code
+  changes." "Cold-start latency under 200ms on the free tier."
+- Not outcome-shaped: "Refactor auth middleware." (That's a task —
+  file as an issue.) "All v1.1 work." (Restates the title — adds
+  nothing.) A list of issue links. (Readers can see those.)
+- Optional: a short *non-goals* line to bound scope.
+
+The description is the contract the convergence test runs against —
+"does closing this issue advance *this outcome*?"
+
+## When *not* to use a milestone
+
+- Categorical tag (area, type, priority) → label.
+- Ongoing planning surface across many issues → Project board.
+- Ad-hoc "see also" between two issues → plain `#N` mention or the
+  `issue-links` skill.
+
+## Due dates
+
+- Release- / date-anchored: set the due date to the release date or
+  window end. Slipping the date is fine; missing data is worse than
+  imprecise data — the rollup needs a horizon.
+- Theme-anchored: skip unless there's a real deadline.
+
+## Closing
+
+A milestone closes when both:
+
+1. Every issue inside is closed, AND
+2. The convergent event happened (release cut, window ended, theme
+   shipped).
+
+If the event didn't happen yet, leave it open even with an empty
+issue list — it's still expecting work. If issues remain when the
+event hits, move spillover to the next milestone (or unset) before
+closing; don't close with open issues — it falsifies the rollup.
+
+Closed milestones are immutable history. Don't reopen to slot in
+late work; create the next milestone.
+
+## Operations
+
+```bash
+# List
+gh api repos/:owner/:repo/milestones?state=all
+
+# Create
+gh api repos/:owner/:repo/milestones \
+  -f title='v1.1.0' \
+  -f due_on='2026-06-01T00:00:00Z' \
+  -f description='...'
+
+# Assign
+gh issue create -m 'v1.1.0' ...
+gh issue edit <N> -m 'v1.1.0'
+
+# Close
+gh api -X PATCH repos/:owner/:repo/milestones/<num> -f state=closed
+```
+
+## Procedure
+
+1. Read existing milestones; identify the project's axis. If none is
+   set and a milestone is being created, surface the choice (release
+   / date / theme); don't silently pick.
+2. New milestone: name in the axis; outcome-shaped description; due
+   date if release- or date-anchored.
+3. "Does this issue belong here?" — convergence test: will closing
+   it advance the description's outcome? If not, leave it unassigned.
+4. Closing: confirm the event happened and spillover is moved.


### PR DESCRIPTION
## Summary

Two new GitHub-flavored skills:

- `issue-links` — picks the strongest accurate edge between issues/PRs (Closes/Fixes in PR body, blocked-by via GraphQL `addBlockedBy`, parent/sub-issue via `addSubIssue`, plain mention). Size test disambiguates blocked-by from sub-issue.
- `milestones` — one axis per project (release / date / theme), outcome-shaped descriptions (OKR-objective form) as the contract the convergence test runs against, no using milestones as labels.

Routing entries added to `dot_claude/CLAUDE.md` alongside the existing skill router.

## Gotchas

- `issue-links` recommends `-f` (not `-F`) for GraphQL `ID!` variables — `-F` silently coerces to Int/Bool. Called out inline because it's a real footgun the schema doesn't surface.
- Routing sections placed after Changelogs, grouped with the other skill routers (Renovate, Changelogs), rather than near "Issues" at the top. Worth a redirect if you'd rather keep issue-adjacent rules clustered.
- Token-pass already done — the skills currently sit at 89 lines (`issue-links`) and 104 lines (`milestones`). Further trims should weigh against losing decision-support content (the size test, the convergence test).

## Verification

- GraphQL surface verified live against the schema (`addBlockedBy`, `addSubIssue`, `Issue.blockedBy`, `Issue.subIssues`, `Issue.parent`).
- `pre-commit run --files dot_claude/skills/issue-links/SKILL.md dot_claude/skills/milestones/SKILL.md dot_claude/CLAUDE.md` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)