### PR TITLE
Add issue-create skill

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -62,8 +62,7 @@ A per-repo `CLAUDE.md` overrides anything here.
 ## Issues
 
 - Filing a new issue (search for duplicates, detect templates,
-  compose title/body/labels/milestone): `issue-create` skill. Title
-  is a statement true when done.
+  compose title/body/labels/milestone): `issue-create` skill.
 
 ## Issue workflow
 
@@ -153,30 +152,22 @@ and examples that don't disambiguate.
 ## Renovate
 
 - `renovate.json` work (audit, write, troubleshoot dashboard, regex
-  managers): `renovate` skill. Default preset is
-  `config:best-practices` with the pre-commit manager enabled
-  unconditionally.
+  managers): `renovate` skill.
 
 ## Changelogs
 
 - `CHANGELOG.md` work (bootstrap, review against commits) following
-  Keep a Changelog 1.1.0: `changelog` skill. Defers to auto-managed
-  setups (changesets, release-please, git-cliff, semantic-release,
-  towncrier); semver 2.0.0 by default, PVP for Haskell projects.
-  Manual maintenance only — never proposes adopting tooling, and
-  cutting a release (tagging, version-file edits) is out of scope.
+  Keep a Changelog 1.1.0: `changelog` skill.
 
 ## Issue relationships
 
 - Linking GitHub issues/PRs (blocked-by via GraphQL, parent/sub-issue,
-  Closes/Fixes, plain mention): `issue-links` skill. Strongest
-  accurate edge; size test resolves blocked-by vs parent/sub-issue.
+  Closes/Fixes, plain mention): `issue-links` skill.
 
 ## Milestones
 
 - GitHub milestone work (creating, naming, scoping, closing):
-  `milestones` skill. One axis per project (release / date / theme),
-  no mixing, no using milestones as labels.
+  `milestones` skill.
 
 ## Tests
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -61,21 +61,9 @@ A per-repo `CLAUDE.md` overrides anything here.
 
 ## Issues
 
-- Use the repo's issue template when one exists. Otherwise:
-  - **Title** — statement true when done. Active voice, outcome
-    ("Profile writes persist across API restarts in Firestore",
-    not "Fix profile persistence").
-  - **Summary** — 1-2 sentences on what this delivers.
-  - **Motivation** — what problem, dependency, or opportunity drives
-    this.
-  - **Scope** — concrete changes required, specific enough to start
-    without ambiguity.
-  - **Acceptance criteria** — measurable conditions true when done.
-    Task-list syntax (`- [ ]`).
-  - **Additional context** — links, screenshots, related issues, when
-    they help.
-- Before filing, check milestones and labels. Assign to the most
-  relevant milestone (unset if none fits) and apply matching labels.
+- Filing a new issue (search for duplicates, detect templates,
+  compose title/body/labels/milestone): `issue-create` skill. Title
+  is a statement true when done.
 
 ## Issue workflow
 

--- a/dot_claude/skills/issue-create/SKILL.md
+++ b/dot_claude/skills/issue-create/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: issue-create
+description: File a new GitHub issue in the checked-out repo — search first for duplicates/adjacent issues to update or reference, detect the repo's issue template if any, then compose title/body/labels/milestone matching house style. Use when asked to file, create, open, report, or track an issue.
+---
+
+# Issue create
+
+Don't `gh issue create` first. Search and inspect before composing.
+
+## Dedup pre-flight
+
+Open *and* closed:
+
+```bash
+gh search issues "<keywords>" --repo <owner>/<repo> --state all --limit 20
+```
+
+Read near-matches with `gh issue view <N>`. Decide:
+
+- **Same outcome already open** — update the existing one
+  (`gh issue edit <N>` for body, `gh issue comment <N>` for new
+  context). Don't file a new one.
+- **Same outcome closed for stale reasons** — `gh issue reopen <N>`
+  with a comment citing what changed. Don't file a new one.
+- **Adjacent** (same area, different angle) — file new, cite the
+  existing in *Additional context*; consider an `issue-links` edge.
+- **Partially covers** — narrow the new issue to the uncovered
+  slice; cross-reference both ways.
+- **Nothing close** — file new.
+
+If torn, surface the call rather than silently pick.
+
+## Detect repo conventions
+
+```bash
+ls .github/ISSUE_TEMPLATE/ 2>/dev/null
+gh label list --limit 100
+gh api repos/:owner/:repo/milestones --jq '.[] | "\(.title)\t\(.state)"'
+gh issue list --limit 5      # skim recent house style
+```
+
+Template present → `gh issue create --template <name>`. Templates
+encode the project's required fields; don't bypass with a freeform
+body.
+
+## Standard structure (no template)
+
+- **Title** — statement true when done. Active voice, outcome.
+  *"Profile writes persist across API restarts in Firestore"*,
+  not *"Fix profile persistence"*.
+- **Summary** — 1-2 sentences. What this delivers.
+- **Motivation** — what problem, dependency, or opportunity drives
+  it. Cite the trigger (PR review, incident, related issue).
+- **Scope** — concrete changes, specific enough to start without
+  guessing. Bullets, not prose.
+- **Acceptance criteria** — measurable conditions, `- [ ]` task-list.
+- **Additional context** — links, screenshots, related issues, only
+  when they help. Skip the section if empty.
+
+Optimise for tokens — no filler, no restated headings, no "this
+issue tracks the work to..." preambles.
+
+## Labels and milestones
+
+- Pick existing labels. Don't invent inline — if nothing fits, skip
+  or raise the label question separately.
+- Milestone: assign if one fits the outcome (convergence test —
+  closing the issue advances the milestone's description). Unset
+  otherwise. Never use milestones as labels.
+- Creating a new milestone → `milestones` skill.
+- Relating to other issues/PRs → `issue-links` skill, after submit.
+
+## Submit
+
+Filing creates shared state — propose the body before submitting on
+any non-obvious choice (scope, label call, dedup verdict).
+
+```bash
+gh issue create \
+  --title '<title>' \
+  --label <label1>,<label2> \
+  --milestone '<name>' \
+  --body "$(cat <<'EOF'
+## Summary
+...
+EOF
+)"
+```
+
+HEREDOC body avoids escaping. `--web` opens the browser for manual
+review before submit.
+
+## Procedure
+
+1. Search open + closed; decide update / reopen / new / link.
+2. Detect template; else prepare standard structure.
+3. Fetch labels and milestones; pick fitters or skip.
+4. Compose; surface non-obvious choices.
+5. Submit; capture URL.
+6. Apply cross-edges via `issue-links` if related.


### PR DESCRIPTION
## Summary

New `issue-create` skill closes the issue-lifecycle gap: `issue-work`
picks up, `issue-links` relates, `milestones` scopes — but nothing
carried "file a new one." The marquee addition over what previously
lived in CLAUDE.md is a **dedup pre-flight**: search open + closed
before composing, decide update / reopen / adjacent / new.

CLAUDE.md skill-routing pointers also get a uniform trim. Five sections
(Issues, Renovate, Changelogs, Issue relationships, Milestones) shed
orphan inline rules that were already duplicated in their skill
bodies — and, load-bearing for the trim, in each skill's
`description:` frontmatter, which Claude sees in the skills list every
turn. No constraint dropped, just deduplicated.

## Gotchas

- Focus review on the `## Dedup pre-flight` section of the new
  `SKILL.md` — it encodes a decision tree (update existing /
  `gh issue reopen` / file new + cite / file new) that's the part
  with no prior CLAUDE.md precedent. Other sections (structure, labels,
  submit) are mechanical.
- The CLAUDE.md trim is mechanical line removal; if it reads
  too-terse to you, the precedent to push back on is `## READMEs and
  CONTRIBUTING`, which has been pure routing pointers since adoption.

## Verification

- Filed `alunduil/blog.alunduil.com#65` earlier in the session using the
  dedup pre-flight as a dry run — caught `woodland-generators#182`
  was already covering CLAUDE.md territory there before duplicating.
- `pre-commit run --files dot_claude/skills/issue-create/SKILL.md
  dot_claude/CLAUDE.md` clean (markdown — only `detect-private-key`
  applies).