### PR TITLE
Cut claustre max effort and wire rtk Bash hook

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -217,3 +217,5 @@ behaviour:
   both wanted.
 - **Per-project sensors** (tests, linters, type-checkers) — detect
   violations after the fact. Live with the project.
+
+@RTK.md

--- a/dot_claude/RTK.md
+++ b/dot_claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -20,6 +20,15 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ],
+        "matcher": "Bash"
       }
     ],
     "PostToolUse": [

--- a/dot_claustre/config.toml
+++ b/dot_claustre/config.toml
@@ -4,6 +4,8 @@
 [claude]
 # Alias tracks latest Opus; otherwise claustre's pinned default (claude-opus-4-6) wins.
 model = "opus"
+# claustre's default is "max"; "auto" lets the model's resolver pick.
+effort = "auto"
 
 [sync]
 auto_push = true


### PR DESCRIPTION
## Summary

Routine claustre sessions and host-wide Bash invocations burn fewer tokens per turn. claustre stops launching every spawn at `--effort max`, and rtk's pre-Bash hook now rewrites noisy commands (`ls`, `git`, `tree`, …) before they reach Claude's context.

## Gotchas

- The rtk hook only attaches on Claude Code **restart**. New sessions get it automatically; the session that opens this PR won't.
- `effort = "auto"` pass-through is verified against claustre 0.x + Claude Code 2.1.126 (clap `String` arg, no validator). If either pins effort to an enum later, this needs revisiting.
- `~/.config/rtk/filters.toml` is left unmanaged — rtk regenerates the template on `init`, and there are no real filters to track yet.
- `dot_claude/CLAUDE.md` now ends with an `@RTK.md` import directive. If you reorder or trim the tail, keep that line at the bottom.

## Verification

- Diffed `~/.claude/{CLAUDE.md,settings.json}` after `rtk init -g --auto-patch` against pre-rtk snapshots; ported the exact additions to chezmoi source so `chezmoi apply` won't drift.
- Verified `--effort auto` pass-through by reading `claustre/src` (no validator on the `String` field) and the Claude Code 2.1.126 binary — `ePH()` accepts `"auto"`, returns null, falls through to model default.
- `python3 -m json.tool dot_claude/private_settings.json` — parses cleanly after the new PreToolUse entry.