### PR TITLE
Cut claustre max effort and wire rtk Bash hook

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -217,3 +217,5 @@ behaviour:
   both wanted.
 - **Per-project sensors** (tests, linters, type-checkers) — detect
   violations after the fact. Live with the project.
+
+@RTK.md

--- a/dot_claude/RTK.md
+++ b/dot_claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -20,6 +20,15 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ],
+        "matcher": "Bash"
       }
     ],
     "PostToolUse": [

--- a/dot_claustre/config.toml
+++ b/dot_claustre/config.toml
@@ -4,8 +4,9 @@
 [claude]
 # Alias tracks latest Opus; otherwise claustre's pinned default (claude-opus-4-6) wins.
 model = "opus"
-# claustre's default is "max"; "auto" lets the model's resolver pick.
-effort = "auto"
+# claustre's default is "max"; medium balances cost against capability for
+# mostly-autonomous work. Valid rungs: low, medium, high, xhigh, max.
+effort = "medium"
 
 [sync]
 auto_push = true

--- a/dot_claustre/config.toml
+++ b/dot_claustre/config.toml
@@ -4,6 +4,8 @@
 [claude]
 # Alias tracks latest Opus; otherwise claustre's pinned default (claude-opus-4-6) wins.
 model = "opus"
+# claustre's default is "max"; "auto" lets the model's resolver pick.
+effort = "auto"
 
 [sync]
 auto_push = true


### PR DESCRIPTION
## Summary

- Drops claustre's per-turn effort from `max` to `medium`, cutting Opus 4.7 token spend on mostly-autonomous sessions while leaving headroom for harder work.
- Wires `rtk hook claude` as a PreToolUse Bash hook so shell calls get rewritten through the Rust Token Killer proxy (60-90% savings on dev ops, 0 token overhead).
- Ports the matching `rtk init -g --auto-patch` artefacts (RTK.md, `@RTK.md` import in global CLAUDE.md, hook entry in `private_settings.json`) into chezmoi source so the next `chezmoi apply` preserves them.

## Gotchas

- The first commit on this branch claimed `effort = "auto"` worked via clap pass-through. It doesn't — claustre validates against `{low, medium, high, xhigh, max}`. The follow-up commit corrects to `medium`; the original is left in history rather than rebased.
- `~/.config/rtk/filters.toml` is intentionally left unmanaged (template generated per-host, not worth tracking).
- Hook only attaches on next Claude Code restart.

## Verification

- `pre-commit run --files dot_claustre/config.toml` — passed (only detect-private-key applied; shellcheck/shfmt/check-json skipped, no matching files).
- Confirmed claustre rejects `auto` at the CLI parser by reproducing the error message.