### PR TITLE
Use medium effort for claustre, not auto

### DIFF
--- a/dot_claustre/config.toml
+++ b/dot_claustre/config.toml
@@ -4,8 +4,9 @@
 [claude]
 # Alias tracks latest Opus; otherwise claustre's pinned default (claude-opus-4-6) wins.
 model = "opus"
-# claustre's default is "max"; "auto" lets the model's resolver pick.
-effort = "auto"
+# claustre's default is "max"; medium balances cost against capability for
+# mostly-autonomous work. Valid rungs: low, medium, high, xhigh, max.
+effort = "medium"
 
 [sync]
 auto_push = true


### PR DESCRIPTION
## Summary

Fixes the `effort = "auto"` value introduced in #94. claustre actually validates `effort` against `{low, medium, high, xhigh, max}` and rejects unknown values at the CLI parser, so `auto` errors out before any spawn. Switches to `medium` — balances cost against capability for mostly-autonomous work without reverting to `max`.

## Gotchas

- The verification claim in #94 ("clap `String` arg, no validator") was wrong. claustre does enforce the enum; reproduced the rejection by invoking it directly.

## Verification

- `pre-commit run --files dot_claustre/config.toml` — passed.
- Reproduced the original error to confirm the value set is one claustre accepts.