### PR TITLE
Add ghcup bootstrap with GHC and cabal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ claustre configure                         # wires up Claude Code permissions
 
 # PATH check for chezmoi-installed binaries:
 zellij --version && lazygit --version && act --version && rtk --version
+ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 gh extension list                          # confirms gh-poi (squash-merge pruner)
 ```
 

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -121,3 +121,6 @@ export NVM_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvm"
 
 # cargo/rustup: add ~/.cargo/bin to PATH when installed.
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+# ghcup: add ~/.ghcup/bin (ghc, cabal) to PATH when installed.
+[ -f "$HOME/.ghcup/env" ] && . "$HOME/.ghcup/env"

--- a/run_once_before_06-install-haskell-ecosystem.sh.tmpl
+++ b/run_once_before_06-install-haskell-ecosystem.sh.tmpl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Installs ghcup, GHC, and cabal-install. Canonical installer only:
+# get-ghcup.haskell.org. Debian apt ghc/cabal-install are avoided by design
+# (they lag upstream).
+
+set -euo pipefail
+
+log() { printf '==> %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------- ghcup + ghc + cabal
+# NONINTERACTIVE skips prompts and installs the recommended GHC and cabal.
+# INSTALL_NO_STACK skips stack; HLS is opt-in (default off). The installer
+# would also append to ~/.bashrc, but chezmoi overwrites that on apply -- the
+# managed dot_bashrc sources ~/.ghcup/env itself.
+if ! command -v ghcup >/dev/null 2>&1; then
+  log "ghcup: installing recommended GHC + cabal"
+  curl -fsSL https://get-ghcup.haskell.org |
+    BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
+      BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 \
+      sh
+else
+  log "ghcup: already installed"
+fi
+
+log "haskell ecosystem complete"


### PR DESCRIPTION
## Summary

Fresh-host bootstrap now lands `ghc` and `cabal` on PATH via ghcup, alongside the existing Node and Rust toolchains. ghcup is the canonical Haskell toolchain manager, so it gets its own ecosystem pass (script 06) parallel to script 03 (Node/nvm) and script 04 (Rust/rustup).

`BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1` skips stack; HLS stays opt-in. ghcup itself is rolling (no version pin), matching the rustup script's precedent — GHC/cabal versions are managed by ghcup at runtime, not chezmoi.

## Gotchas

- The bootstrap script has not been executed end-to-end on a real host yet. CI sensors (shellcheck/shfmt, bats, chezmoi-apply round-trip) all pass, but the actual `curl get-ghcup.haskell.org | sh` flow is unexercised here.
- The ghcup installer normally appends to `~/.bashrc`. That's a no-op in this repo because chezmoi overwrites `~/.bashrc` from `dot_bashrc` on apply — `dot_bashrc` sources `~/.ghcup/env` directly, mirroring the cargo/rustup line above it.
- Decision worth a glance: stack omitted to match the request literally ("ghc and cabal"). Easy to flip later by dropping `INSTALL_NO_STACK` and/or adding `BOOTSTRAP_HASKELL_INSTALL_HLS=1`.

## Verification

- Ran `pre-commit run --all-files` — shellcheck, shfmt, check-json, detect-private-key all passed.
- Ran `bats test/` — 18/18 passed.
- Ran `script/checks/chezmoi-apply` — exit 0; rendered settings.json hooks all resolve.