### PR TITLE
Bind Alt+Left/Right to pure tab switch

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -23,5 +23,9 @@ keybinds {
                 close_on_exit true
             }
         }
+        // Pure tab navigation. Default `MoveFocusOrTab` switches panes when
+        // one exists in the direction, which surprises during tab-hopping.
+        bind "Alt Left"  { GoToPreviousTab; }
+        bind "Alt Right" { GoToNextTab; }
     }
 }


### PR DESCRIPTION
## Summary

Alt+Left and Alt+Right now switch tabs unconditionally. The default `MoveFocusOrTab` action only falls back to a tab change when no pane exists in the requested direction, so in a multi-pane layout the same keystroke moved the cursor sideways instead — surprising when the intent was tab navigation.

## Gotchas

Pane-direction motion is still available via the default Alt+h/j/k/l vim-direction keys. The override lives in `shared_except "locked"` so it applies in every interactive mode.

## Verification

- `script/checks/zellij-config` — `[CONFIG FILE]: Well defined.` (also covered by `.github/workflows/zellij.yml`).