### PR TITLE
Move picker keybind to Alt+/ and install golang-petname

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ claustre configure                         # wires up Claude Code permissions
 # PATH check for chezmoi-installed binaries:
 zellij --version && lazygit --version && act --version && rtk --version
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
+golang-petname                             # repo-picker worktree namer
 gh extension list                          # confirms gh-poi (squash-merge pruner)
 ```
 

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -16,8 +16,10 @@ plugins {
 
 keybinds {
     shared_except "locked" {
-        // Searchable git-repo picker → pair layout in the chosen repo.
-        bind "Alt p" {
+        // Searchable repo/session picker → pair layout in the chosen repo.
+        // Alt+/ matches the universal "search/launcher" mnemonic and leaves
+        // Alt+p free for zellij's TogglePaneInGroup default.
+        bind "Alt /" {
             Run "git-repo-picker" {
                 floating true
                 close_on_exit true

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -11,7 +11,7 @@
 // Invoke:
 //   zellij --layout pair                         # fresh session
 //   zellij action new-tab --layout pair          # new tab in current session
-//   Alt+p                                        # keybind, same as above
+//   Alt+/                                        # keybind, same as above
 //                                                # (git-repo-picker renames the
 //                                                # spawned tab to the repo name)
 

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -29,6 +29,7 @@ fi
 APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
+  golang-petname
 )
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do


### PR DESCRIPTION
## Summary

`Alt+/` now opens the repo picker; `Alt+p` returns to zellij's `TogglePaneInGroup` default. `golang-petname` joins the apt package list as the worktree namer for the upcoming picker rewrite.

Groundwork for the picker overhaul (worktree-per-tab, three-set fzf with sessions/local/remote, dim-and-refocus open sessions). Petname and the freed keybind land first so the picker rewrite can build on them without churn.

## Gotchas

- The Debian package installs `/usr/bin/golang-petname`, not `petname` — scripts will need to call the full name. Flagged in the README PATH check too.
- `Alt+/` may require Shift on non-US layouts; `Alt+r` is the documented fallback if that bites.

## Verification

- `pre-commit run --all-files` clean (shellcheck, shfmt, check-json, detect-private-key)
- `script/checks/zellij-config` exits 0
- `bats test/` 18/18 pass
- Confirmed `golang-petname -words 2` produces `<adverb>-<adjective>` style names from the Debian package contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)