### PR TITLE
Stop pipefail from swallowing successful picker selections

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -184,6 +184,12 @@ spawn_pair_tab() {
     zellij action rename-tab "$tab"
 }
 
+# fzf exits as soon as the user selects a row, after which build_rows hits
+# SIGPIPE on the next write. With pipefail set that propagates a non-zero
+# exit through the substitution and the trailing `|| exit 0` would swallow
+# the whole picker silently. Disable pipefail just for this one pipeline so
+# a clean fzf selection wins regardless of the upstream's death.
+set +o pipefail
 selection=$(build_rows | fzf \
     --ansi \
     --delimiter $'\t' \
@@ -191,6 +197,7 @@ selection=$(build_rows | fzf \
     --nth=1 \
     --prompt "repo> " \
     --header "worktree: dim = open tab · enter to focus or spawn") || exit 0
+set -o pipefail
 
 [[ -z "$selection" ]] && exit 0
 


### PR DESCRIPTION
## Summary

Picking any row in `git-repo-picker` exited cleanly without dispatching: select `local:zfs-replicate`, get a prompt, no clone, no worktree, no tab. Cause is `set -o pipefail` interacting with fzf's early exit — fzf returns 0 on selection, build_rows is still streaming remote rows behind it, the next `printf` hits SIGPIPE, build_rows dies non-zero, and the substitution carries that through `|| exit 0`.

Fix: localise `set +o pipefail` around the one substitution where SIGPIPE on the upstream is expected. fzf's clean exit alone decides whether dispatch runs.

Latent since #103 (same pattern). Surfaced now because we finally exercised the picker end-to-end with a populated remote list.

## Gotchas

- pipefail stays on for every other pipeline in the script — only the fzf substitution turns it off, and turns it back on immediately after. No general weakening of failure detection.
- Confirmed via `bash -x` trace with `BASH_XTRACEFD=19` redirected to a log: selection captures correctly (`local:zfs-replicate\tspawn-fresh\talunduil\tzfs-replicate\t/home/alunduil/zfs-replicate`), then `+ exit 0` fires immediately — matching the `|| exit 0` exit point.
- A follow-up issue covers regression test coverage for this case (and other picker test gaps).

## Verification

- `pre-commit run --all-files` clean
- Manual test on the live host: copied the fixed picker to `~/.local/bin/git-repo-picker`, ran via `Alt+/`, picked `local:zfs-replicate` — clone reused via origin-derived hint, worktree created, pair tab spawned. (Confirming with the user before marking ready.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)