### PR TITLE
Namespace picker branches under <user>/worktree/

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -195,13 +195,14 @@ ensure_canonical() {
     printf '%s' "$dir"
 }
 
-# Create a fresh worktree off the canonical clone's HEAD, on a new branch
-# named after the petname. The branch and worktree share the petname so the
-# zjstatus branch line in the pair layout reads as the worktree label.
+# Create a fresh worktree off the canonical clone's HEAD on a new branch
+# <ME>/worktree/<petname>. The user/worktree/ prefix scopes picker-created
+# branches into a personal namespace so they stay visually distinct from
+# upstream branches in `git branch` and remote refs.
 make_worktree() {
     local canonical=$1 wt_dir=$2 petname=$3
     mkdir -p "$(dirname "$wt_dir")"
-    git -C "$canonical" worktree add "$wt_dir" -b "$petname"
+    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname"
 }
 
 spawn_pair_tab() {

--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -134,8 +134,8 @@ while IFS= read -r line; do
 
     if git -C "$canonical" worktree remove "$wt"; then
         # Branch delete is best-effort: -d (safe) refuses unmerged; we don't
-        # force, since the picker can only generate petname branches and the
-        # user's safety guard above gates merge state already.
+        # force, since the picker only creates branches under <user>/worktree/
+        # and the safety guard above gates merge state already.
         [[ -n "$branch" ]] && git -C "$canonical" branch -d "$branch" 2>/dev/null || true
         removed=$((removed + 1))
     else


### PR DESCRIPTION
## Summary

Picker-spawned worktrees now sit on a `<github-user>/worktree/<petname>` branch instead of a bare `<petname>`. Picker-authored branches become visually distinguishable from upstream branches in `git branch` and remote-ref listings.

Worktree directory layout (`$XDG_DATA_HOME/git-worktrees/<org>/<repo>/<petname>`) and zellij tab names are unchanged — only the underlying ref moves. The zjstatus branch widget renders the full new ref by design (the petname-as-tab-label coupling is dropped on purpose).

## Gotchas

Existing pre-rename worktrees keep their bare-petname branches; only worktrees created after this lands get the prefix. `git-worktree-poi --prune` still cleans both via `git symbolic-ref` lookup, so no migration is forced.

This PR's own branch (`alunduil/worktree/neutral-mouse`) dogfoods the new convention — the worktree directory it lives in was created pre-rename, so the branch was renamed by hand to match the new shape.

## Verification

- pre-commit (shellcheck, shfmt) on both touched scripts: passed