### PR TITLE
Pull canonical before spawning a picker worktree

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -195,14 +195,21 @@ ensure_canonical() {
     printf '%s' "$dir"
 }
 
-# Create a fresh worktree off the canonical clone's HEAD on a new branch
-# <ME>/worktree/<petname>. The user/worktree/ prefix scopes picker-created
-# branches into a personal namespace so they stay visually distinct from
-# upstream branches in `git branch` and remote refs.
+# Create a fresh worktree off the canonical's origin/HEAD on a new branch
+# <ME>/worktree/<petname>. Fetches first and branches from the remote ref
+# (not the canonical's local HEAD) so the worktree never starts on a stale
+# base when the canonical's default branch hasn't been pulled lately. The
+# user/worktree/ prefix scopes picker-created branches into a personal
+# namespace, distinct from upstream branches in `git branch` and remote refs.
 make_worktree() {
     local canonical=$1 wt_dir=$2 petname=$3
+    if ! git -C "$canonical" fetch --quiet origin; then
+        printf 'git-repo-picker: fetch failed; branching off possibly stale origin/HEAD\n' >&2
+    fi
+    local default_ref
+    default_ref=$(git -C "$canonical" symbolic-ref --short refs/remotes/origin/HEAD)
     mkdir -p "$(dirname "$wt_dir")"
-    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname"
+    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname" "$default_ref"
 }
 
 spawn_pair_tab() {

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -195,21 +195,24 @@ ensure_canonical() {
     printf '%s' "$dir"
 }
 
-# Create a fresh worktree off the canonical's origin/HEAD on a new branch
-# <ME>/worktree/<petname>. Fetches first and branches from the remote ref
-# (not the canonical's local HEAD) so the worktree never starts on a stale
-# base when the canonical's default branch hasn't been pulled lately. The
-# user/worktree/ prefix scopes picker-created branches into a personal
-# namespace, distinct from upstream branches in `git branch` and remote refs.
+# Create a fresh worktree off the canonical's default branch on a new branch
+# <ME>/worktree/<petname>. Pulls the canonical first (best-effort) so the
+# worktree starts on a current base; on failure we branch from whatever the
+# local default ref points at, which both manual pulls and prior picker runs
+# keep current. The user/worktree/ prefix scopes picker-created branches
+# into a personal namespace, distinct from upstream branches in `git branch`
+# and remote refs.
 make_worktree() {
     local canonical=$1 wt_dir=$2 petname=$3
-    if ! git -C "$canonical" fetch --quiet origin; then
-        printf 'git-repo-picker: fetch failed; branching off possibly stale origin/HEAD\n' >&2
-    fi
-    local default_ref
+    local default_ref default_branch
     default_ref=$(git -C "$canonical" symbolic-ref --short refs/remotes/origin/HEAD)
+    default_branch=${default_ref#origin/}
+    if ! git -C "$canonical" pull --ff-only --quiet; then
+        printf 'git-repo-picker: pull failed; branching off possibly stale local %s\n' \
+            "$default_branch" >&2
+    fi
     mkdir -p "$(dirname "$wt_dir")"
-    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname" "$default_ref"
+    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname" "$default_branch"
 }
 
 spawn_pair_tab() {


### PR DESCRIPTION
## Summary

Picker-spawned worktrees now start from a freshly-pulled local default branch on the canonical clone, instead of inheriting whatever the canonical's HEAD happened to be. Worktrees no longer start on a stale base when the canonical hasn't been kept current.

Surfaced concretely on #110: that PR's branch was rooted at a `main` SHA seven squash-merges behind `origin/main` because the canonical hadn't been fetched in a while. Diff was correct but the commit list looked like it was reverting merged history.

Mechanics: `git pull --ff-only --quiet` on the canonical (best-effort), then `git worktree add ... <default-branch>` against the local ref. Pull is fetch + fast-forward in one; it keeps the canonical's default branch in sync with origin in the picker's normal state (canonical on default, clean). Branching from the local ref — not `origin/HEAD` — means pull failure falls back to whatever the canonical was last pulled to, capturing both prior picker runs and any direct `git pull` the user did themselves.

## Gotchas

- Every picker invocation now runs a network pull on the canonical. Typical cost is sub-second; large repos may notice.
- Pull failures (offline, auth, divergence, dirty) soft-fail with a stderr diagnostic naming the local branch we're falling back to, then proceed.
- If the canonical happens to be checked out on a non-default branch, pull fast-forwards *that* branch (or fails); local default may then be slightly stale. Doesn't occur in normal picker use — the canonical isn't meant to be directly worked on.
- Two commits on this branch reflect the design iteration (fetch + branch-from-`origin/HEAD` → pull + branch-from-local). Squash-merge collapses to the final shape.

## Verification

- pre-commit (shellcheck, shfmt) on the touched script: passed
- This PR's own branch (`alunduil/worktree/superb-bullfrog`) was created off the post-#110 `origin/main` — first dogfood of the new picker shape.