### PR TITLE
Add Claude Code status line for pair-pane sessions

### DIFF
--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Claude Code status line: model · context% · session cost.
+# Reads stdin JSON per https://code.claude.com/docs/en/statusline.md.
+
+set -euo pipefail
+
+input="$(cat)"
+
+model=$(jq -r '.model.display_name // .model.id // "?"' <<<"$input")
+ctx=$(jq -r '.context_window.used_percentage // empty' <<<"$input")
+cost=$(jq -r '.cost.total_cost_usd // empty' <<<"$input")
+
+# Shorten labels for narrow zellij pair panes.
+case "$model" in
+  *"Opus 4.7"*)   model="O4.7" ;;
+  *"Opus 4.6"*)   model="O4.6" ;;
+  *"Sonnet 4.6"*) model="S4.6" ;;
+  *"Sonnet 4.5"*) model="S4.5" ;;
+  *"Haiku 4.5"*)  model="H4.5" ;;
+esac
+
+parts=("$model")
+[ -n "$ctx" ]  && parts+=("$(printf '%.0f%%' "$ctx")")
+[ -n "$cost" ] && parts+=("$(printf '$%.2f' "$cost")")
+
+out=""
+for p in "${parts[@]}"; do out="${out:+$out · }$p"; done
+printf '%s\n' "$out"

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "statusLine": {
+    "type": "command",
+    "command": "/home/alunduil/.claude/statusline.sh"
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Claude Code sessions now render a tight `model · context% · session cost` status line at the bottom of the pane (e.g. `O4.7 · 43% · $0.18`), so the active model, context-window pressure, and burn rate are visible at a glance during pairing.

## Gotchas

- Branch and worktree are intentionally **not** in the status line — the zellij git status bar in the pair format already surfaces them, and the pair pane is narrow. If that bar ever stops showing branch, revisit.
- Model labels are matched against `display_name` substrings (`Opus 4.7`, `Sonnet 4.6`, etc.). When Anthropic ships a new model, the script falls back to the raw `display_name` until a new case is added — visible but ugly, not broken.
- Path in `private_settings.json` is absolute (`/home/alunduil/.claude/statusline.sh`), matching the existing hooks pattern. Single-user host config, so this is fine.

## Verification

- `pre-commit run --files dot_claude/executable_statusline.sh dot_claude/private_settings.json` — shellcheck, shfmt, check-json, detect-private-key all passed.
- Smoke-tested the script against three stdin payloads: full (Opus 4.7 + cost + context → `O4.7 · 43% · $0.18`), partial (Sonnet display name only → `S4.6`), and empty `{}` (graceful `?` fallback, no crash).