### PR TITLE
Add gh rate-limit flags to pair status bar

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -4,7 +4,8 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
-//   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
+//   zjstatus   (1 line) — left: current branch (5s) + open-PR list (60s)
+//                          right: gh rate-limit flags (60s)
 //   children   (the panes)
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
@@ -24,15 +25,19 @@ layout {
             plugin location="zjstatus" {
                 format_left  "#[bg=16]{command_branch}{command_prs}"
                 format_space "#[bg=16]"
-                format_right "#[bg=16]"
-                command_branch_command    "bash -lc zellij-branch-status"
-                command_branch_format     "{stdout}"
-                command_branch_rendermode "dynamic"
-                command_branch_interval   "5"
-                command_prs_command       "bash -lc zellij-pr-status"
-                command_prs_format        "{stdout}"
-                command_prs_rendermode    "dynamic"
-                command_prs_interval      "60"
+                format_right "#[bg=16]{command_ratelimits}"
+                command_branch_command         "bash -lc zellij-branch-status"
+                command_branch_format          "{stdout}"
+                command_branch_rendermode      "dynamic"
+                command_branch_interval        "5"
+                command_prs_command            "bash -lc zellij-pr-status"
+                command_prs_format             "{stdout}"
+                command_prs_rendermode         "dynamic"
+                command_prs_interval           "60"
+                command_ratelimits_command     "bash -lc zellij-rate-limit-status"
+                command_ratelimits_format      "{stdout}"
+                command_ratelimits_rendermode  "dynamic"
+                command_ratelimits_interval    "60"
             }
         }
         children

--- a/dot_local/bin/executable_zellij-rate-limit-status
+++ b/dot_local/bin/executable_zellij-rate-limit-status
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# zjstatus rate-limit widget for ~/.config/zellij/layouts/pair.kdl. Requires
+# `command_ratelimits_rendermode "dynamic"` so the #[...] directives render
+# rather than printing as literal text.
+#
+# Three right-aligned ribbons for the GitHub `core`, `graphql`, and `search`
+# rate-limit buckets. Green by default; amber under 25% remaining; red under
+# 10%. Silent on failure (no auth, offline, gh missing) — no flag rather than
+# a "?" placeholder, so absence is ambiguous between healthy-and-quiet and
+# broken.
+#
+# /rate_limit itself does not count against the rate limit, so polling is free.
+
+set -euo pipefail
+
+ARROW=$''
+
+json=$(gh api rate_limit 2>/dev/null) || exit 0
+[ -n "$json" ] || exit 0
+
+tsv=$(jq -r '[.resources.core.remaining, .resources.core.limit, .resources.graphql.remaining, .resources.graphql.limit, .resources.search.remaining, .resources.search.limit] | @tsv' <<<"$json" 2>/dev/null) || exit 0
+[ -n "$tsv" ] || exit 0
+
+read -r core_remaining core_limit graphql_remaining graphql_limit search_remaining search_limit <<<"$tsv"
+
+bucket_color() {
+  local remaining=$1 limit=$2
+  local pct=$(( remaining * 100 / limit ))
+  if [ "$pct" -lt 10 ]; then
+    printf 196
+  elif [ "$pct" -lt 25 ]; then
+    printf 214
+  else
+    printf 154
+  fi
+}
+
+emit() {
+  local label=$1 remaining=$2 limit=$3
+  local bg
+  bg=$(bucket_color "$remaining" "$limit")
+  printf '#[bg=16,fg=%s]%s#[bg=%s,fg=16] %s %s/%s #[bg=%s,fg=16]%s' \
+    "$bg" "$ARROW" "$bg" "$label" "$remaining" "$limit" "$bg" "$ARROW"
+}
+
+emit core "$core_remaining" "$core_limit"
+printf '#[bg=16] '
+emit gql "$graphql_remaining" "$graphql_limit"
+printf '#[bg=16] '
+emit search "$search_remaining" "$search_limit"


### PR DESCRIPTION
## Summary

The pair status bar now renders three right-aligned ribbons for GitHub's `core`, `graphql`, and `search` rate-limit buckets (e.g. `core 4978/5000  gql 4708/5000  search 30/30`), colored green by default, amber under 25% remaining, red under 10%. Useful when picker fuzzy-search or `gh` PR ops start chewing through a quota you can't otherwise see.

## Gotchas

- Silent on every failure path (no `gh`, no auth, offline, jq parse error) — matches the `zellij-pr-status` precedent. Tradeoff: absence is ambiguous between healthy-and-quiet and broken.
- `/rate_limit` itself doesn't count against any bucket per GitHub docs, so the 60s poll is free.
- Powerline arrow is `` (left-pointing) for right-aligned segments, mirroring the existing PR widget's use of `` for left-aligned. Needs a Nerd Font to render.
- For the small `search` bucket (30/min), the percentage thresholds are coarse: amber at 7 remaining, red at 3.

## Verification

- `pre-commit run --files dot_local/bin/executable_zellij-rate-limit-status dot_config/zellij/layouts/pair.kdl` — shellcheck, shfmt, detect-private-key passed.
- `script/checks/zellij-config` — KDL well-defined.
- Live `gh api rate_limit` query through the script rendered three green ribbons in an ANSI-translated terminal preview (`core 4978/5000`, `gql 4708/5000`, `search 30/30`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)