### PR TITLE
Move rate limits to dedicated pair status line

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -4,9 +4,9 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
-//   zjstatus   (1 line) — left: current branch (5s) + open-PR list (60s)
-//                          right: gh rate-limit flags (60s)
+//   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
 //   children   (the panes)
+//   zjstatus   (1 line) — gh rate-limit flags (60s), left-aligned
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
 // Invoke:
@@ -25,7 +25,6 @@ layout {
             plugin location="zjstatus" {
                 format_left  "#[bg=16]{command_branch}{command_prs}"
                 format_space "#[bg=16]"
-                format_right "#[bg=16]{command_ratelimits}"
                 command_branch_command         "bash -lc zellij-branch-status"
                 command_branch_format          "{stdout}"
                 command_branch_rendermode      "dynamic"
@@ -34,13 +33,19 @@ layout {
                 command_prs_format             "{stdout}"
                 command_prs_rendermode         "dynamic"
                 command_prs_interval           "60"
+            }
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="zjstatus" {
+                format_left  "#[bg=16]{command_ratelimits}"
+                format_space "#[bg=16]"
                 command_ratelimits_command     "bash -lc zellij-rate-limit-status"
                 command_ratelimits_format      "{stdout}"
                 command_ratelimits_rendermode  "dynamic"
                 command_ratelimits_interval    "60"
             }
         }
-        children
         pane size=1 borderless=true {
             plugin location="status-bar"
         }

--- a/dot_local/bin/executable_zellij-rate-limit-status
+++ b/dot_local/bin/executable_zellij-rate-limit-status
@@ -3,7 +3,7 @@
 # `command_ratelimits_rendermode "dynamic"` so the #[...] directives render
 # rather than printing as literal text.
 #
-# Three right-aligned ribbons for the GitHub `core`, `graphql`, and `search`
+# Three left-aligned ribbons for the GitHub `core`, `graphql`, and `search`
 # rate-limit buckets. Green by default; amber under 25% remaining; red under
 # 10%. Silent on failure (no auth, offline, gh missing) — no flag rather than
 # a "?" placeholder, so absence is ambiguous between healthy-and-quiet and
@@ -39,7 +39,7 @@ emit() {
   local label=$1 remaining=$2 limit=$3
   local bg
   bg=$(bucket_color "$remaining" "$limit")
-  printf '#[bg=16,fg=%s]%s#[bg=%s,fg=16] %s %s/%s #[bg=%s,fg=16]%s' \
+  printf '#[bg=%s,fg=16]%s#[bg=%s,fg=16] %s %s/%s #[bg=16,fg=%s]%s' \
     "$bg" "$ARROW" "$bg" "$label" "$remaining" "$limit" "$bg" "$ARROW"
 }
 


### PR DESCRIPTION
## Summary
Rate-limit ribbons now ride their own zjstatus line below the panes, so they no longer jump position when PRs are listed in the top bar.

## Gotchas
The PR widget's OSC 8 hyperlink escapes (the bytes that make `#123` clickable) appear to be counted as visible width by zjstatus, which is why right-alignment broke once PRs were present. Splitting the row sidesteps the bug rather than fixing it; if zjstatus's width math is patched upstream we could collapse back to a single line. Requires a layout reload (new tab via `Alt+/` or fresh session) to take effect.

## Verification
- `pre-commit run --all-files`, `bats test/`, `script/checks/zellij-config` — all green.
- Smoke-tested `zellij-rate-limit-status` output: wedges now use U+E0B2 (◀) with mirrored bg/fg so the slants land correctly for left-aligned ribbons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)