### PR TITLE
Fix rate-limit ribbon arrows and pad stacked bars

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -4,9 +4,11 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
+//   spacer     (1 line) — bar-bg gap between stacked top bars
 //   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
 //   children   (the panes)
 //   zjstatus   (1 line) — gh rate-limit flags (60s), left-aligned
+//   spacer     (1 line) — bar-bg gap between stacked bottom bars
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
 // Invoke:
@@ -20,6 +22,12 @@ layout {
     default_tab_template {
         pane size=1 borderless=true {
             plugin location="zellaude"
+        }
+        pane size=1 borderless=true {
+            plugin location="zjstatus" {
+                format_left  "#[bg=16]"
+                format_space "#[bg=16]"
+            }
         }
         pane size=1 borderless=true {
             plugin location="zjstatus" {
@@ -44,6 +52,12 @@ layout {
                 command_ratelimits_format      "{stdout}"
                 command_ratelimits_rendermode  "dynamic"
                 command_ratelimits_interval    "60"
+            }
+        }
+        pane size=1 borderless=true {
+            plugin location="zjstatus" {
+                format_left  "#[bg=16]"
+                format_space "#[bg=16]"
             }
         }
         pane size=1 borderless=true {

--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -4,11 +4,9 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
-//   spacer     (1 line) — bar-bg gap between stacked top bars
 //   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
 //   children   (the panes)
 //   zjstatus   (1 line) — gh rate-limit flags (60s), left-aligned
-//   spacer     (1 line) — bar-bg gap between stacked bottom bars
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
 // Invoke:
@@ -22,12 +20,6 @@ layout {
     default_tab_template {
         pane size=1 borderless=true {
             plugin location="zellaude"
-        }
-        pane size=1 borderless=true {
-            plugin location="zjstatus" {
-                format_left  "#[bg=16]"
-                format_space "#[bg=16]"
-            }
         }
         pane size=1 borderless=true {
             plugin location="zjstatus" {
@@ -52,12 +44,6 @@ layout {
                 command_ratelimits_format      "{stdout}"
                 command_ratelimits_rendermode  "dynamic"
                 command_ratelimits_interval    "60"
-            }
-        }
-        pane size=1 borderless=true {
-            plugin location="zjstatus" {
-                format_left  "#[bg=16]"
-                format_space "#[bg=16]"
             }
         }
         pane size=1 borderless=true {

--- a/dot_local/bin/executable_zellij-rate-limit-status
+++ b/dot_local/bin/executable_zellij-rate-limit-status
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-ARROW=$''
+ARROW=$''
 
 json=$(gh api rate_limit 2>/dev/null) || exit 0
 [ -n "$json" ] || exit 0


### PR DESCRIPTION
## Summary
Rate-limit ribbons now show the same right-pointing wedge slants as the PR ribbons, fixing the inverted-look that arrived with #115 (which left U+E0B2 — the right-aligned variant — on a left-aligned line).

## Verification
- Confirmed visually by translating the script's zjstatus markup to ANSI and rendering in-terminal — wedge slants and color halves now sit where they should.
- `pre-commit run --all-files`, `bats test/`, `script/checks/zellij-config` — all green.