### PR TITLE
Add bats coverage for git-repo-picker

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -120,6 +120,10 @@ print_remotes() {
     done
 }
 
+# Tests source this script to exercise helpers above without triggering the
+# --rows handler or main entry below.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
+
 # fzf re-invokes this script with --rows on every change event. Worktree and
 # local rows always render; remotes appear once the query reaches
 # REMOTE_THRESHOLD characters and stay for the rest of this invocation via

--- a/test/fixtures/git_repo_picker/stubs/fzf
+++ b/test/fixtures/git_repo_picker/stubs/fzf
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# fzf stub: emits $FZF_OUTPUT and exits 0; exits 130 (cancel) when unset.
+[[ -n "${FZF_OUTPUT:-}" ]] || exit 130
+printf '%s\n' "$FZF_OUTPUT"

--- a/test/fixtures/git_repo_picker/stubs/gh
+++ b/test/fixtures/git_repo_picker/stubs/gh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# gh stub: returns $GH_USER for `api user`, empty for memberships, clones $GH_CLONE_SRC for `repo clone`.
+case "${1:-} ${2:-}" in
+  "api user")
+    printf '%s' "${GH_USER:-test-user}"
+    ;;
+  "api user/memberships/orgs")
+    : # no admin orgs by default
+    ;;
+  "repo list")
+    printf '%s' "${GH_REPO_LIST:-}"
+    ;;
+  "repo clone")
+    git clone --quiet "${GH_CLONE_SRC:?GH_CLONE_SRC must be set}" "$4"
+    ;;
+esac

--- a/test/fixtures/git_repo_picker/stubs/golang-petname
+++ b/test/fixtures/git_repo_picker/stubs/golang-petname
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# golang-petname stub: prints $PETNAME (default "test-petname"), ignoring args.
+printf '%s\n' "${PETNAME:-test-petname}"

--- a/test/fixtures/git_repo_picker/stubs/zellij
+++ b/test/fixtures/git_repo_picker/stubs/zellij
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# zellij stub: appends "$@" to $ZELLIJ_RECORDER; emits $ZELLIJ_TABS_JSON for action list-tabs.
+printf '%s\n' "$*" >>"$ZELLIJ_RECORDER"
+if [[ "${1:-}" == "action" && "${2:-}" == "list-tabs" ]]; then
+  printf '%s' "${ZELLIJ_TABS_JSON:-[]}"
+fi

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  PICKER="$REPO_ROOT/dot_local/bin/executable_git-repo-picker"
+  FIXTURES="$BATS_TEST_DIRNAME/fixtures/git_repo_picker"
+
+  TMPROOT="$(mktemp -d)"
+  STUB_DIR="$TMPROOT/stubs"
+  mkdir -p "$STUB_DIR"
+  for stub in fzf zellij gh golang-petname; do
+    install -m 0755 "$FIXTURES/stubs/$stub" "$STUB_DIR/$stub"
+  done
+
+  export HOME="$TMPROOT/home"
+  export XDG_DATA_HOME="$TMPROOT/xdg-data"
+  mkdir -p "$HOME" "$XDG_DATA_HOME"
+
+  export PATH="$STUB_DIR:/usr/bin:/bin"
+  export ZELLIJ_RECORDER="$TMPROOT/zellij.log"
+  : >"$ZELLIJ_RECORDER"
+  export GH_USER=me
+  unset FZF_OUTPUT ZELLIJ_TABS_JSON GH_CLONE_SRC GH_REPO_LIST PETNAME
+}
+
+teardown() {
+  rm -rf "$TMPROOT"
+}
+
+# Build a real git checkout with the given origin URL. URL parsing in
+# collect_locals runs against `git remote get-url`, so the fixtures exercise
+# the real plumbing rather than a parser harness.
+mklocal() {
+  local dir="$1" url="$2"
+  git init --quiet "$dir"
+  git -C "$dir" remote add origin "$url"
+}
+
+# Build a bare "remote" plus a canonical clone with origin/HEAD set up, so
+# `make_worktree`'s symbolic-ref + pull + worktree-add chain succeeds.
+mkcanonical() {
+  local canonical="$1" name="$2"
+  local bare="$TMPROOT/remotes/$name.git"
+  local seed="$TMPROOT/seeds/$name"
+  mkdir -p "$bare" "$seed"
+  git init --quiet --bare --initial-branch=main "$bare"
+  git init --quiet --initial-branch=main "$seed"
+  git -C "$seed" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  git -C "$seed" push --quiet "$bare" main
+  git clone --quiet "$bare" "$canonical"
+  printf '%s' "$bare"
+}
+
+# --- collect_locals: origin URL parsing ---
+
+@test "collect_locals: SSH origin parses to org/repo" {
+  mklocal "$HOME/me/zfs-replicate" "git@github.com:me/zfs-replicate.git"
+  run bash -c 'source "$1"; collect_locals' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'me\tzfs-replicate\t%s' "$HOME/me/zfs-replicate")" ]
+}
+
+@test "collect_locals: HTTPS origin parses to org/repo" {
+  mklocal "$HOME/grafana/k6" "https://github.com/grafana/k6.git"
+  run bash -c 'source "$1"; collect_locals' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'grafana\tk6\t%s' "$HOME/grafana/k6")" ]
+}
+
+@test "collect_locals: token-auth HTTPS origin parses to org/repo" {
+  mklocal "$HOME/owner/repo" "https://x-access-token:abc123@github.com/owner/repo.git"
+  run bash -c 'source "$1"; collect_locals' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'owner\trepo\t%s' "$HOME/owner/repo")" ]
+}
+
+@test "collect_locals: non-github origin is dropped" {
+  mklocal "$HOME/elsewhere/repo" "git@gitlab.com:elsewhere/repo.git"
+  run bash -c 'source "$1"; collect_locals' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- fmt_repo / fmt_tab: org elision ---
+
+@test "fmt_repo: elides org when it matches \$ME" {
+  run bash -c 'source "$1"; ME=me fmt_repo me hello' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+
+@test "fmt_repo: keeps org/repo when org differs from \$ME" {
+  run bash -c 'source "$1"; ME=me fmt_repo grafana k6' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "grafana/k6" ]
+}
+
+@test "fmt_tab: elides own org and appends petname" {
+  run bash -c 'source "$1"; ME=me fmt_tab me hello kind-newt' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello (kind-newt)" ]
+}
+
+@test "fmt_tab: keeps other-org prefix and appends petname" {
+  run bash -c 'source "$1"; ME=me fmt_tab grafana k6 kind-newt' _ "$PICKER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "grafana/k6 (kind-newt)" ]
+}
+
+# --- TSV dispatch (end-to-end) ---
+
+@test "dispatch focus: zellij go-to-tab-name fires with selected tab" {
+  export FZF_OUTPUT=$'\033[2mworktree:hello (kind-newt)\033[0m\tfocus\thello (kind-newt)'
+  run bash "$PICKER"
+  [ "$status" -eq 0 ]
+  grep -Fxq "action go-to-tab-name hello (kind-newt)" "$ZELLIJ_RECORDER"
+}
+
+@test "dispatch spawn: zellij new-tab + rename-tab fire with petdir and tab name" {
+  local petdir="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
+  export FZF_OUTPUT=$'worktree:hello (kind-newt)\tspawn\t'"$petdir"$'\thello (kind-newt)'
+  run bash "$PICKER"
+  [ "$status" -eq 0 ]
+  grep -Fxq "action new-tab --layout pair --cwd $petdir" "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab hello (kind-newt)" "$ZELLIJ_RECORDER"
+}
+
+@test "dispatch spawn-fresh: reuses canonical hint, creates worktree, spawns tab" {
+  mkcanonical "$HOME/hello" hello >/dev/null
+  export PETNAME=fresh-petname
+  export FZF_OUTPUT=$'local:hello\tspawn-fresh\tme\thello\t'"$HOME/hello"
+  run bash "$PICKER"
+  [ "$status" -eq 0 ]
+
+  local wt="$XDG_DATA_HOME/git-worktrees/me/hello/fresh-petname"
+  [ -d "$wt" ]
+  [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "me/worktree/fresh-petname" ]
+  grep -Fxq "action new-tab --layout pair --cwd $wt" "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab hello (fresh-petname)" "$ZELLIJ_RECORDER"
+}
+
+@test "dispatch clone-and-spawn: clones canonical, creates worktree, spawns tab" {
+  GH_CLONE_SRC="$(mkcanonical "$TMPROOT/remote-only" hello)"
+  rm -rf "$TMPROOT/remote-only"  # only the bare remains; canonical must be cloned by the picker
+  export GH_CLONE_SRC
+  export PETNAME=cloned-petname
+  export FZF_OUTPUT=$'remote:hello\tclone-and-spawn\tme\thello'
+  run bash "$PICKER"
+  [ "$status" -eq 0 ]
+
+  [ -d "$HOME/hello/.git" ]
+  local wt="$XDG_DATA_HOME/git-worktrees/me/hello/cloned-petname"
+  [ -d "$wt" ]
+  grep -Fxq "action new-tab --layout pair --cwd $wt" "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab hello (cloned-petname)" "$ZELLIJ_RECORDER"
+}


### PR DESCRIPTION
## Summary

git-repo-picker is now covered by bats. Twelve cases land across the
four areas the issue called out: origin-URL parsing in `collect_locals`
(SSH, HTTPS, token-auth, non-github drop), `fmt_repo`/`fmt_tab` org
elision, and end-to-end dispatch for each verb (`focus`, `spawn`,
`spawn-fresh`, `clone-and-spawn`) driven through stubbed fzf, zellij,
gh, and golang-petname. Closes #108.

## Gotchas

- The `#108` scope item for a SIGPIPE regression test (head -1 upstream
  of fzf) targets the pre-#107 architecture. Post-#107, fzf reads from
  `STATIC_FILE` (`dot_local/bin/executable_git-repo-picker:235`) — no
  upstream pipe to die. The dispatch tests instead lock in the static-
  file pathway end-to-end, so a future change that re-pipes fzf would
  have to break or update them. Worth a sanity check that this
  substitution matches the spirit of the issue.
- Tiny source-guard added to the picker
  (`if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi`) so bats
  can source the helpers without triggering `--rows` or the main entry.
  Direct execution path is unchanged.
- Stubs live under `test/fixtures/git_repo_picker/stubs/` with one-line
  headers per the issue's acceptance criteria. They aren't lint-scoped
  by the existing pre-commit shellcheck regex (`executable_` /
  `.sh.tmpl$`); manual `shellcheck` against them is clean.

## Verification

- `bats test/` — 30 tests green (12 new for the picker, prior 18 still
  pass).
- `pre-commit run --all-files` — clean.