### PR TITLE
Install lychee, keybase, signal-desktop, signal-cli on bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ gcx login                                  # ~/.config/gcx/
 readwise login                             # ~/.readwise-cli.json
 sudo tailscale up                          # tailnet auth
 claustre configure                         # wires up Claude Code permissions
+keybase login                              # ~/.config/keybase/ (devices, KBFS)
+signal-desktop                             # link to phone via QR scan
+signal-cli -a +<phone> register            # SMS-verified, ~/.local/share/signal-cli/
 
 # PATH check for chezmoi-installed binaries:
 zellij --version && lazygit --version && act --version && rtk --version
+lychee --version                           # markdown link checker (mirrors CI)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 gh extension list                          # confirms gh-poi (squash-merge pruner)

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,21 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^script/install/lychee$/"],
+      "matchStrings": ["LYCHEE_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "lycheeverse/lychee",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^lychee-(?<version>v[\\d.]+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^script/install/signal-cli$/"],
+      "matchStrings": ["SIGNAL_CLI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "AsamK/signal-cli",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^run_once_before_05-install-standalone-tools\\.sh\\.tmpl$/"],
       "matchStrings": ["GH_POI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "seachicken/gh-poi",

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -25,11 +25,32 @@ if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
     "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
 fi
 
+# ------------------------------------------------------------- signal-desktop
+if [ ! -f /usr/share/keyrings/signal-desktop-keyring.gpg ]; then
+  log "signal-desktop: adding apt repository"
+  curl -fsSL https://updates.signal.org/desktop/apt/keys.asc |
+    sudo gpg --dearmor -o /usr/share/keyrings/signal-desktop-keyring.gpg
+  printf 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main\n' |
+    sudo tee /etc/apt/sources.list.d/signal-xenial.list >/dev/null
+fi
+
+# -------------------------------------------------------------------- keybase
+# Keybase's apt repo is unsigned; their official install guide uses
+# `[trusted=yes]` to skip apt's signature check. Transport integrity
+# comes from HTTPS to prerelease.keybase.io. The keybase service
+# self-updates once installed, so versions track upstream regardless.
+if [ ! -f /etc/apt/sources.list.d/keybase.list ]; then
+  log "keybase: adding apt repository"
+  printf 'deb [trusted=yes] https://prerelease.keybase.io/deb stable main\n' |
+    sudo tee /etc/apt/sources.list.d/keybase.list >/dev/null
+fi
+
 # -------------------------------------------------------------------- apt pkgs
 APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   golang-petname
+  keybase signal-desktop
 )
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# zellij content:  {{ include "script/install/zellij" | sha256sum }}
-# lazygit content: {{ include "script/install/lazygit" | sha256sum }}
-# act content:     {{ include "script/install/act" | sha256sum }}
-# gcx content:     {{ include "script/install/gcx" | sha256sum }}
-# lib.sh content:  {{ include "script/install/lib.sh" | sha256sum }}
+# zellij content:     {{ include "script/install/zellij" | sha256sum }}
+# lazygit content:    {{ include "script/install/lazygit" | sha256sum }}
+# act content:        {{ include "script/install/act" | sha256sum }}
+# gcx content:        {{ include "script/install/gcx" | sha256sum }}
+# lychee content:     {{ include "script/install/lychee" | sha256sum }}
+# signal-cli content: {{ include "script/install/signal-cli" | sha256sum }}
+# lib.sh content:     {{ include "script/install/lib.sh" | sha256sum }}
 # The hashes above embed the install scripts' content into this file's
 # rendered output so chezmoi re-runs this script when any of them change
 # (e.g. version bumps). Without them, run_once would not re-fire.
@@ -15,6 +17,8 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/lazygit" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/act" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/gcx" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/lychee" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/signal-cli" --bin-dir "$HOME/.local/bin"
 
 # gcx ships its skill bundle inside the binary; `skills install --all`
 # extracts it to ~/.agents/skills (the cross-harness convention read by

--- a/script/install/lib.sh
+++ b/script/install/lib.sh
@@ -53,3 +53,29 @@ verify_sha256() {
     return 1
   fi
 }
+
+# Verify a detached GPG signature when upstream publishes .asc but no
+# .sha256 (e.g. AsamK/signal-cli). Imports KEY_URL into an ephemeral
+# GNUPGHOME under GPGHOME, asserts the imported fingerprint equals
+# EXPECTED_FPR (so a swapped key can't slip through), then verifies
+# ASC over FILE. The ephemeral keyring keeps the user's ~/.gnupg
+# untouched; caller is responsible for cleaning GPGHOME.
+verify_gpg() {
+  local file="$1" asc="$2" key_url="$3" expected_fpr="$4" gpghome="$5"
+  local actual_fpr
+
+  GNUPGHOME="$gpghome" gpg --quiet --batch --import \
+    <(curl -fsSL "$key_url") 2>/dev/null
+  actual_fpr="$(GNUPGHOME="$gpghome" gpg --list-keys --with-colons |
+    awk -F: '$1 == "fpr" {print $10; exit}')"
+  if [ "$actual_fpr" != "$expected_fpr" ]; then
+    printf '%s: gpg fingerprint mismatch on %s -- expected %s, got %s\n' \
+      "${0##*/}" "$key_url" "$expected_fpr" "$actual_fpr" >&2
+    return 1
+  fi
+  if ! GNUPGHOME="$gpghome" gpg --quiet --batch --verify "$asc" "$file" 2>/dev/null; then
+    printf '%s: gpg signature verification failed for %s\n' \
+      "${0##*/}" "${file##*/}" >&2
+    return 1
+  fi
+}

--- a/script/install/lychee
+++ b/script/install/lychee
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LYCHEE_VERSION="v0.24.2"
+ARCH="x86_64-unknown-linux-musl"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/lychee"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${LYCHEE_VERSION#v}"; then
+  printf '==> lychee: %s already installed at %s\n' "$LYCHEE_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> lychee: downloading %s\n' "$LYCHEE_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# lycheeverse/lychee tags binaries as `lychee-vX.Y.Z` (the cargo workspace
+# also publishes `lychee-lib-vX.Y.Z` from the same repo). Tarball nests
+# everything under `lychee-${ARCH}/`, with the binary at
+# `lychee-${ARCH}/lychee`.
+base="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}"
+asset="lychee-${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
+
+expected="$(expected_from_checksums "$tmp/$asset.sha256" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp" "lychee-${ARCH}/lychee"
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/lychee-${ARCH}/lychee" "$bin"

--- a/script/install/signal-cli
+++ b/script/install/signal-cli
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SIGNAL_CLI_VERSION="v0.14.3"
+ARCH="Linux-native"
+
+# AsamK's release signing key. Published at keys.openpgp.org with UID
+# `AsamK <asamk@gmx.de>`. Pinned here so a swap on the keyserver can't
+# silently authorise a forged release.
+KEY_URL="https://keys.openpgp.org/vks/v1/by-fingerprint/FA10826A74907F9EC6BBB7FC2BA2CD21B5B09570"
+KEY_FPR="FA10826A74907F9EC6BBB7FC2BA2CD21B5B09570"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/signal-cli"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${SIGNAL_CLI_VERSION#v}"; then
+  printf '==> signal-cli: %s already installed at %s\n' "$SIGNAL_CLI_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> signal-cli: downloading %s\n' "$SIGNAL_CLI_VERSION" >&2
+tmp="$(mktemp -d)"
+gpghome="$(mktemp -d)"
+chmod 700 "$gpghome"
+trap 'rm -rf "$tmp" "$gpghome"' EXIT
+
+# Releases ship `.asc` detached signatures, no checksums file -- so
+# verify_gpg replaces the verify_sha256 step used by other installers.
+base="https://github.com/AsamK/signal-cli/releases/download/${SIGNAL_CLI_VERSION}"
+asset="signal-cli-${SIGNAL_CLI_VERSION#v}-${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/$asset.asc" "$base/$asset.asc"
+
+verify_gpg "$tmp/$asset" "$tmp/$asset.asc" "$KEY_URL" "$KEY_FPR" "$gpghome"
+
+tar -xzf "$tmp/$asset" -C "$tmp" signal-cli
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/signal-cli" "$bin"


### PR DESCRIPTION
## Summary
Fresh-host bootstrap now provisions lychee (link checker), keybase, Signal Desktop, and signal-cli — closing the gap between what `chezmoi apply` sets up and the daily-driver toolset.

## Gotchas
- Keybase's apt repo entry uses `[trusted=yes]`. Their published install guide does this because `prerelease.keybase.io`'s apt metadata isn't signed; the keybase service self-updates once installed, so pinning here would be theatre. Documented inline in script 01.
- signal-cli's release artifacts ship `.asc` GPG signatures but no sha256 — the existing `expected_from_checksums` pattern doesn't apply. Added a `verify_gpg` helper in `lib.sh` that imports the key into an ephemeral `GNUPGHOME` and asserts the imported fingerprint equals the pinned `FA10826A74907F9EC6BBB7FC2BA2CD21B5B09570` before verifying. The fingerprint was cross-checked against `keys.openpgp.org` (UID `AsamK <asamk@gmx.de>`).
- Lychee's Renovate manager uses `extractVersionTemplate` to scope to `lychee-v*` tags; the `lycheeverse/lychee` repo also publishes `lychee-lib-v*` from the same workspace.

## Verification
- `pre-commit run --all-files`, `bats test/`, `script/checks/chezmoi-apply` — all green.
- `script/install/signal-cli` not run end-to-end yet; the GPG verification path lands on next `chezmoi apply` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)