### PR TITLE
Tighten issue-work and renovate skills against repeat drift

### DIFF
--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -8,9 +8,10 @@ description: Pick up an existing GitHub issue in the checked-out repo — implem
 ## Inspect
 
 ```bash
-gh issue view <N> --comments                     # body + comments + cross-refs
-gh issue develop <N> --list                      # branches linked to this issue
-gh pr list --search "<N> in:body" --state open   # open PR taking it forward?
+gh issue view <N> --comments                                # body + comments + cross-refs
+gh issue develop <N> --list                                 # branches linked to this issue
+gh pr list --search "<N> in:body" --state open              # open PR taking it forward?
+gh pr list --search "<keywords> in:title,body" --state merged --limit 20  # merged PR already covering same scope, even if unlinked?
 ```
 
 For recent commits in the area:
@@ -32,6 +33,7 @@ Any one fires a go/no-go before writing code:
 
 - A commit since the issue was filed already implements or supersedes the change.
 - A linked PR is already merged — the issue should close, not be re-implemented.
+- An *unlinked* merged PR covers the same scope (keyword/path search). Filers don't always cross-reference; check before duplicating work.
 - The issue assumes tooling/files that have since been replaced or removed.
 - The motivating dependency resolved differently (e.g. "waiting on upstream X" — X shipped via a different mechanism).
 - A maintainer comment narrows or vetoes the original scope and the body wasn't updated.

--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -53,7 +53,8 @@ Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
 
 ## Procedure
 
-1. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
-2. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
-3. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins).
-4. Surface findings before editing. Apply only after scope is agreed.
+1. Confirm any field name you plan to write against current docs at `https://docs.renovatebot.com/configuration-options/<field>/` before editing. Renames slip in regularly (`fileMatch` → `managerFilePatterns`, `baseBranches` → `baseBranchPatterns`); memory and prior commits are not authoritative.
+2. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
+3. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
+4. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins).
+5. Surface findings before editing. Apply only after scope is agreed.


### PR DESCRIPTION
## Summary

The `renovate` and `issue-work` skills now route Claude through doc verification and unlinked-PR search before editing, closing two recurring failure modes surfaced by `/insights` on 2026-05-09:

- Renovate edits made from memory drifted onto deprecated field names (`fileMatch`, `baseBranches`) and were only caught after CI failed.
- Issue work duplicated already-merged scope (#142 vs already-merged #146) because inspect commands only searched open PRs and linked refs.

## Gotchas

- The renovate change is a new step 1 in Procedure; the existing audit/greenfield steps shift down. Confirm reviewers see the renumbering as intentional.
- The unlinked-PR search uses `<keywords>` rather than the issue number. Skill leaves keyword choice to the operator — that's deliberate, since issues don't always name the implementation.

## Verification

- `pre-commit run --files dot_claude/skills/issue-work/SKILL.md dot_claude/skills/renovate/SKILL.md` — only `detect-private-key` ran (markdown isn't covered by shellcheck/shfmt/check-json). No content sensors apply here.