### PR TITLE
Recommend renovate-config-validator pre-commit hook

### DIFF
--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -42,6 +42,22 @@ For version pins inside scripts, KDL, etc.:
 - For URL-embedded versions, capture both `depName` and `currentValue` in `matchStrings` — no `depNameTemplate` needed.
 - One manager per `*_VERSION=` pattern; group only when the file shape is identical.
 
+## Validation
+
+Wire `renovate-config-validator` as a pre-commit hook so schema typos, deprecated fields, and malformed custom-manager regex fail at commit time instead of surfacing as Repository Problems on the next Renovate run.
+
+```yaml
+- repo: https://github.com/renovatebot/pre-commit-hooks
+  rev: <latest>
+  hooks:
+    - id: renovate-config-validator
+      args: [--strict, --no-global]
+```
+
+- `--strict` — fail on configs that need migration (e.g. `fileMatch` → `managerFilePatterns`), not only on outright errors. Neither flag is upstream default; both go in `args`.
+- `--no-global` — treat the file as repo-level config. Without it the validator interprets it as global self-hosted config and misreports repo-only fields.
+- Upstream docs: <https://docs.renovatebot.com/config-validation/>.
+
 ## Dashboard reading
 
 Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
@@ -55,6 +71,6 @@ Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
 
 1. Confirm any field name you plan to write against current docs at `https://docs.renovatebot.com/configuration-options/<field>/` before editing. Renames slip in regularly (`fileMatch` → `managerFilePatterns`, `baseBranches` → `baseBranchPatterns`); memory and prior commits are not authoritative.
 2. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
-3. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs.
-4. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins).
+3. **Greenfield** — write the Defaults block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs. Add the `renovate-config-validator` pre-commit hook (see Validation).
+4. **Audit existing** — walk the Defaults block and the custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins, missing `renovate-config-validator` pre-commit hook).
 5. Surface findings before editing. Apply only after scope is agreed.


### PR DESCRIPTION
## Summary

Renovate skill now points users at the `renovate-config-validator` pre-commit hook (with `--strict --no-global`) when writing or auditing a repo, so schema typos and deprecated fields fail at commit time instead of surfacing as Repository Problems on the next dashboard run.

Closes #129