### PR TITLE
Pin @readwise/cli version in node-ecosystem bootstrap

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,13 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
+      "matchStrings": ["READWISE_CLI_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "@readwise/cli",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"

--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -50,11 +50,21 @@ else
 fi
 
 # ----------------------------------------------------------- Readwise CLI
-if ! command -v readwise >/dev/null 2>&1; then
-  log "readwise-cli: npm install -g @readwise/cli"
-  npm install -g @readwise/cli
+# Pin enforced (mirrors gh-poi in script 05): if a different version is
+# already installed, npm replaces it so renovate-tracked bumps actually
+# take effect. `npm ls -g` is the local query, no network round-trip.
+READWISE_CLI_VERSION="0.5.6"
+installed="$(npm ls -g --depth=0 --parseable=false @readwise/cli 2>/dev/null |
+  sed -n 's,.*@readwise/cli@\([0-9][0-9.]*\).*,\1,p' | head -1)"
+if [ "$installed" != "$READWISE_CLI_VERSION" ]; then
+  if [ -n "$installed" ]; then
+    log "readwise-cli: replacing $installed with $READWISE_CLI_VERSION"
+  else
+    log "readwise-cli: installing $READWISE_CLI_VERSION"
+  fi
+  npm install -g "@readwise/cli@$READWISE_CLI_VERSION"
 else
-  log "readwise-cli: already installed"
+  log "readwise-cli: $READWISE_CLI_VERSION already installed"
 fi
 
 log "node ecosystem complete"


### PR DESCRIPTION
## Summary

Readwise CLI now installs at a pinned version on fresh hosts, so a
DR rebuild lands on the same `@readwise/cli` the host was running
rather than whatever's current at rebuild time. Renovate tracks the
pin via a new npm-datasource customManager.

The other AC items in #124 turned out to already be satisfied —
install step exists in `run_once_before_03-install-node-ecosystem.sh.tmpl`
(added in #6/#10/#13, relocated by #18), README lists `readwise login`
in the Interactive logins block, and the `command -v` guard provided
idempotence. The remaining gap was the version pin.

## Gotchas

The install pattern intentionally diverges from `script/install/<tool>`.
Those scripts download GitHub Release tarballs into `--bin-dir` and
verify checksums or GPG; npm globals have none of that and need
nvm sourced first. The closest precedent is `GH_POI_VERSION` in
`run_once_before_05-install-standalone-tools.sh.tmpl:27` — inline
constant, replace-on-mismatch via the tool's native list query
(`npm ls -g` here, `gh extension list` there). Renovate keys the
manager on the file path so bumps target this script specifically.

## Verification

- `pre-commit run --all-files` (shellcheck, shfmt, check-json) — passed
- `bats test/` — 31/31 passed
- `script/checks/chezmoi-apply` — passed

Closes #124.