### PR TITLE
Fix git-worktree-poi canonical path resolution

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -127,16 +127,21 @@ while IFS= read -r line; do
     wt=${plain##* }
     [[ -d "$wt" ]] || continue
 
-    canonical_repo=$(basename "$(dirname "$wt")")
-    canonical_org=$(basename "$(dirname "$(dirname "$wt")")")
-    canonical="$HOME/$canonical_org/$canonical_repo"
+    # Ask git for the canonical's path rather than reconstructing it from
+    # $wt: canonicals don't always live at $HOME/<org>/<repo> (own-org repos
+    # live at $HOME/<repo>, and the picker honors origin-URL hints for
+    # arbitrary checkout locations). --git-common-dir resolves through the
+    # worktree's .git file regardless.
     branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || true)
+    canonical=$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    canonical=${canonical%/.git}
 
-    if git -C "$canonical" worktree remove "$wt"; then
+    if git -C "$wt" worktree remove "$wt"; then
         # Branch delete is best-effort: -d (safe) refuses unmerged; we don't
         # force, since the picker only creates branches under <user>/worktree/
         # and the safety guard above gates merge state already.
-        [[ -n "$branch" ]] && git -C "$canonical" branch -d "$branch" 2>/dev/null || true
+        [[ -n "$branch" && -n "$canonical" ]] \
+            && git -C "$canonical" branch -d "$branch" 2>/dev/null || true
         removed=$((removed + 1))
     else
         printf 'failed to remove %s (use git worktree remove --force if intended)\n' "$wt" >&2


### PR DESCRIPTION
## Summary

`git worktree-poi --prune` now actually removes selected worktrees and deletes their branches. The canonical-clone lookup used to point at a non-existent directory (`$HOME/<org>/<repo>`), so every `git worktree remove` call exited 128 silently.

## Gotchas

The post-removal `branch -d` runs from `$canonical`, not `$wt`, because `$wt` no longer exists once `worktree remove` returns. `--git-common-dir` is captured before the removal for that reason.

## Verification

- Reproduced on the default branch: `git -C /home/alunduil/alunduil/alunduil-chezmoi worktree list` → exit 128, "No such file or directory".
- Confirmed `git rev-parse --path-format=absolute --git-common-dir` resolves the right canonical for own-org repos (`zfs-replicate`) and otherwise (`woodland-generators`) as well as the picker's `<org>/<repo>/<petname>` layout.
- End-to-end test against an isolated temp canonical+worktree: worktree directory and canonical branch both gone after the script's removal sequence.
- `pre-commit run --all-files` and `bats test/` pass.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)