### PR TITLE
Ignore docs/ in chezmoi source

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,5 +1,6 @@
 .lycheecache
 CLAUDE.md
+docs
 LICENSE
 README.md
 lychee.toml


### PR DESCRIPTION
## Summary

Repo documentation under `docs/` no longer gets copied to `~/docs/` on `chezmoi apply`. The directory had no chezmoi naming prefix and wasn't in `.chezmoiignore`, so chezmoi was treating it as a managed target alongside the actual dotfile deployments.

## Gotchas

`chezmoi apply` will not remove `~/docs/` on hosts that have already applied — newly ignored entries become unmanaged, not deleted. `rm -rf ~/docs` is the manual cleanup.

## Verification

- `chezmoi managed --source-path "$PWD"` no longer lists any `docs/*` entries from this checkout (previously listed seven).
- Audited the rest of the top-level managed set; only `docs/` was leaking. Run-once scripts and the `.bash_profile`/`.bashrc`/`.claude`/`.claustre`/`.config`/`.gitconfig`/`.gnupg`/`.local`/`.profile`/`.ssh` deployments are intentional.
- `pre-commit run --files .chezmoiignore` passed.