### PR TITLE
Add in-use guard to git-worktree-poi

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -3,33 +3,42 @@
 # or been closed upstream, leaving dirty/unpushed/active ones alone. Walks
 # $XDG_DATA_HOME/git-worktrees/ — the picker's worktree root.
 #
+# In-use guard: any worktree containing a process cwd (zellij pane, editor,
+# tmux, dev server, ...) is annotated `in-use` and never removed. Detection
+# reads /proc/*/cwd, so it generalises beyond zellij's CLI surface.
+#
 # Usage:
-#   git worktree-poi              # remove safe worktrees (merged|closed PR + clean + pushed)
+#   git worktree-poi              # remove safe worktrees (merged|closed PR + clean + pushed + idle)
 #   git worktree-poi -n|--dry-run # preview without removing
 
 set -euo pipefail
 
 die() { printf 'git-worktree-poi: %s\n' "$*" >&2; exit 1; }
 
-for cmd in git gh; do
-    command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
-done
-
-dry_run=0
-case "${1:-}" in
-    -n | --dry-run) dry_run=1 ;;
-    -h | --help)
-        sed -n '2,8p' "$0" | sed 's|^# \?||'
-        exit 0
-        ;;
-    "") ;;
-    *) die "unknown argument: $1" ;;
-esac
-
 WORKTREE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/git-worktrees"
-[[ -d "$WORKTREE_ROOT" ]] || die "no worktrees under $WORKTREE_ROOT"
 
-CWD="$(pwd -P)"
+# Process cwds whose target lives under $WORKTREE_ROOT. Populated once before
+# classification; every classify() call consults this set via is_in_use.
+declare -a IN_USE_CWDS=()
+
+collect_in_use_cwds() {
+    local cwd_link target
+    for cwd_link in /proc/*/cwd; do
+        target=$(readlink "$cwd_link" 2>/dev/null) || continue
+        [[ "$target" == "$WORKTREE_ROOT"/* ]] && printf '%s\n' "$target"
+    done
+}
+
+# is_in_use <wt>: succeeds if any IN_USE_CWDS entry is the worktree itself or
+# nested under it. Boundary check uses "$wt"/* so /foo/bar2 doesn't count as
+# inside /foo/bar.
+is_in_use() {
+    local wt=$1 cwd
+    for cwd in "${IN_USE_CWDS[@]}"; do
+        [[ "$cwd" == "$wt" || "$cwd" == "$wt"/* ]] && return 0
+    done
+    return 1
+}
 
 # classify <wt>: emits TAB-separated:
 #   verdict\trel\tbranch\tdetail\twt
@@ -37,7 +46,7 @@ CWD="$(pwd -P)"
 # verdict ∈ {remove, keep}
 # rel     = "<repo>/<slug>" (org elided; <wt> sits at <root>/<org>/<repo>/<slug>)
 # detail  = human-readable reason — "PR #N merged" for remove, comma-joined
-#           blockers ("no PR, unpushed", "PR #N open", ...) for keep
+#           blockers ("no PR, unpushed", "in-use, PR #N merged", ...) for keep
 classify() {
     local wt=$1
     local rel branch pr_info pr_state pr_num pr_state_lc dirty
@@ -50,6 +59,8 @@ classify() {
         branch='(detached HEAD)'
         reasons+=("detached HEAD")
     fi
+
+    is_in_use "$wt" && reasons+=("in-use")
 
     pr_state=NONE
     pr_num=
@@ -128,6 +139,31 @@ print_section() {
     fi
     printf '\n'
 }
+
+# Tests source this script to exercise helpers above without running the
+# main flow.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
+
+for cmd in git gh; do
+    command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
+done
+
+dry_run=0
+case "${1:-}" in
+    -n | --dry-run) dry_run=1 ;;
+    -h | --help)
+        sed -n '2,12p' "$0" | sed 's|^# \?||'
+        exit 0
+        ;;
+    "") ;;
+    *) die "unknown argument: $1" ;;
+esac
+
+[[ -d "$WORKTREE_ROOT" ]] || die "no worktrees under $WORKTREE_ROOT"
+
+CWD="$(pwd -P)"
+
+mapfile -t IN_USE_CWDS < <(collect_in_use_cwds)
 
 rows=$(gather)
 [[ -n "$rows" ]] || { printf 'no worktrees found\n'; exit 0; }

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  POI="$REPO_ROOT/dot_local/bin/executable_git-worktree-poi"
+
+  TMPROOT="$(mktemp -d)"
+  export HOME="$TMPROOT/home"
+  export XDG_DATA_HOME="$TMPROOT/xdg-data"
+  mkdir -p "$HOME" "$XDG_DATA_HOME/git-worktrees"
+}
+
+teardown() {
+  rm -rf "$TMPROOT"
+}
+
+# --- is_in_use: boundary semantics ---
+
+@test "is_in_use: exact match succeeds" {
+  run bash -c 'source "$1"; IN_USE_CWDS=("$2"); is_in_use "$2"' \
+    _ "$POI" /foo/bar
+  [ "$status" -eq 0 ]
+}
+
+@test "is_in_use: nested cwd succeeds" {
+  run bash -c 'source "$1"; IN_USE_CWDS=("$3"); is_in_use "$2"' \
+    _ "$POI" /foo/bar /foo/bar/sub/dir
+  [ "$status" -eq 0 ]
+}
+
+@test "is_in_use: prefix without path boundary fails" {
+  run bash -c 'source "$1"; IN_USE_CWDS=("$3"); is_in_use "$2"' \
+    _ "$POI" /foo/bar /foo/bar2
+  [ "$status" -eq 1 ]
+}
+
+@test "is_in_use: unrelated cwd fails" {
+  run bash -c 'source "$1"; IN_USE_CWDS=("$3"); is_in_use "$2"' \
+    _ "$POI" /foo/bar /elsewhere
+  [ "$status" -eq 1 ]
+}
+
+@test "is_in_use: empty IN_USE_CWDS fails" {
+  run bash -c 'source "$1"; IN_USE_CWDS=(); is_in_use "$2"' \
+    _ "$POI" /foo/bar
+  [ "$status" -eq 1 ]
+}
+
+# --- classify: in-use override ---
+
+# Build a worktree under $WORKTREE_ROOT with upstream tracking, plus a `gh`
+# stub reporting the requested PR state. Sets $WT and prepends the stub to
+# PATH in the caller's scope (no subshell).
+_mkworktree() {
+  local pr_state=$1
+  local wtroot="$XDG_DATA_HOME/git-worktrees/me/repo"
+  local canonical="$HOME/me/repo"
+  local bare="$TMPROOT/remote.git"
+
+  mkdir -p "$wtroot" "$(dirname "$canonical")"
+  git init --quiet --bare --initial-branch=main "$bare"
+  git init --quiet --initial-branch=main "$canonical"
+  git -C "$canonical" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  git -C "$canonical" remote add origin "$bare"
+  git -C "$canonical" push --quiet -u origin main
+  git -C "$canonical" worktree add -B feature "$wtroot/feature" >/dev/null 2>&1
+  git -C "$wtroot/feature" push --quiet -u origin feature
+
+  local stub_dir="$TMPROOT/stubs"
+  mkdir -p "$stub_dir"
+  cat >"$stub_dir/gh" <<STUB
+#!/usr/bin/env bash
+# Stub: report '$pr_state' as TSV for any 'pr list --head' query.
+printf '%s\t99\n' '$pr_state'
+STUB
+  chmod +x "$stub_dir/gh"
+
+  WT="$wtroot/feature"
+  PATH="$stub_dir:$PATH"
+}
+
+@test "classify: idle worktree with merged PR is removed" {
+  _mkworktree MERGED
+  run bash -c 'source "$1"; IN_USE_CWDS=(); classify "$2"' \
+    _ "$POI" "$WT"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == remove$'\t'* ]]
+  [[ "$output" == *"PR #99 merged"* ]]
+}
+
+@test "classify: in-use worktree with merged PR is kept" {
+  _mkworktree MERGED
+  run bash -c 'source "$1"; IN_USE_CWDS=("$3"); classify "$2"' \
+    _ "$POI" "$WT" "$WT/nested/subdir"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == keep$'\t'* ]]
+  [[ "$output" == *"in-use"* ]]
+  [[ "$output" == *"PR #99 merged"* ]]
+}


### PR DESCRIPTION
## Summary

`git worktree-poi` now keeps any worktree with a process cwd (zellij
pane, editor, tmux, dev server, …) sitting inside it, surfacing
`in-use` as a keep reason. Closes #136.

## Gotchas

Detection is `/proc/*/cwd` only — Linux-specific. The script's
existing `XDG_DATA_HOME` defaulting and bootstrap pin it to Linux
already, so this doesn't narrow portability.

The boundary check is `$cwd == $wt || $cwd == $wt/*`, so a sibling
worktree like `feature2` doesn't match `feature` by string prefix.

## Verification

- Ran `bats test/` — all 38 tests pass, including 7 new ones covering
  `is_in_use` boundary semantics and the merged-PR override in
  `classify`.
- Ran `pre-commit run --all-files` — shellcheck, shfmt, json, secret
  scan all pass.
- Ran `git worktree-poi --dry-run` against the live worktree tree and
  confirmed the current worktree plus eleven other zellij-pane
  worktrees were marked `in-use`; no false positives on idle
  worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)