### PR TITLE
Drop pinentry-curses override so gpg works in TTY-less Claude shells

### DIFF
--- a/private_dot_gnupg/gpg-agent.conf
+++ b/private_dot_gnupg/gpg-agent.conf
@@ -2,7 +2,3 @@
 # small exposure window for not retyping on every Claude-driven commit.
 default-cache-ttl 28800
 max-cache-ttl 86400
-
-# pinentry-curses: works in any TTY (zellij, ssh, headless containers)
-# without needing DISPLAY, which the gnome3 default doesn't.
-pinentry-program /usr/bin/pinentry-curses


### PR DESCRIPTION
## Summary

GPG signing now works on the first attempt from Claude-spawned shells that have no controlling TTY. Removes the explicit `pinentry-program /usr/bin/pinentry-curses` from `private_dot_gnupg/gpg-agent.conf` so gpg-agent falls through to `/usr/bin/pinentry`, which Debian's alternatives already points at `pinentry-gnome3` (priority 90 vs curses' 50). On Crostini, Sommelier carries the prompt to ChromeOS — no DISPLAY/`updatestartuptty` plumbing required.

## Verification

- Edited live `~/.gnupg/gpg-agent.conf`, ran `gpg-connect-agent reloadagent /bye`, then mirrored the change into `private_dot_gnupg/gpg-agent.conf`; `chezmoi diff` was clean.
- Confirmed `update-alternatives --display pinentry` resolves `/usr/bin/pinentry` → `pinentry-gnome3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)