### PR TITLE
Add adr skill for architecture decision records

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -159,6 +159,11 @@ and examples that don't disambiguate.
 - `CHANGELOG.md` work (bootstrap, review against commits) following
   Keep a Changelog 1.1.0: `changelog` skill.
 
+## ADRs
+
+- Architecture Decision Record work (warranted/not, Nygard or MADR
+  template detection, scaffolding): `adr` skill.
+
 ## Issue relationships
 
 - Linking GitHub issues/PRs (blocked-by via GraphQL, parent/sub-issue,

--- a/dot_claude/skills/adr/SKILL.md
+++ b/dot_claude/skills/adr/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: adr
+description: Audit, write, or revise Architecture Decision Records (ADRs), including the decision of whether one is warranted. Use when an architecturally significant decision needs recording, when reviewing an existing ADR collection, or when adding ADRs to a project that has none. Detects existing template (Nygard or MADR) and defaults to Nygard for new repos.
+---
+
+# ADR
+
+References:
+
+- <https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions> — Nygard, original.
+- <https://adr.github.io/madr/> — MADR, structured variant.
+- <https://adr.github.io/> — umbrella, organisational guidance.
+
+## Is one warranted?
+
+- Yes: architecturally significant *and* hard to reverse — sets
+  precedent others will follow, locks in a dependency, shapes a public
+  API, picks between non-trivial alternatives.
+- No: tactical implementation choice, easily reversed, personal style,
+  framework-default behaviour. A commit message or PR description
+  carries it better.
+- If not warranted, say so and stop. ADR sprawl makes the collection
+  worth less.
+
+## Template
+
+Detect, don't impose:
+
+1. If the repo already has ADRs (`docs/adr/`, `doc/adr/`,
+   `docs/decisions/`, `docs/explanation/adr/`), read one and match
+   shape.
+2. If repo-local `CLAUDE.md` names a template ("ADRs use MADR"),
+   respect it.
+3. Otherwise: **Nygard** for a single decision; escalate to **MADR**
+   only when alternatives analysis is genuinely load-bearing (3+
+   options worth comparing across multiple drivers).
+
+### Nygard skeleton
+
+- **Title** — `# N. <imperative phrase>` (e.g. "Use PostgreSQL").
+- **Status** — `Proposed` initially; user promotes to `Accepted`,
+  `Superseded by NNNN`, or `Deprecated`. Don't pre-mark `Accepted`.
+- **Context** — forces in play, constraints, what made this a
+  decision.
+- **Decision** — `We will <do X>`. Active voice.
+- **Consequences** — what becomes easier *and* harder; positive,
+  negative, neutral.
+
+### MADR
+
+Use the upstream template at <https://adr.github.io/madr/>; don't
+re-derive it here. Sections that earn their weight: Decision Drivers,
+Considered Options (with pros/cons), Decision Outcome.
+
+## Location and filename
+
+- Default `docs/adr/` for new repos. Match existing layout if present.
+- Filename: `NNNN-kebab-title.md`, NNNN is the next 4-digit sequence
+  (`0001`, `0002`, ...).
+- If no ADRs exist yet, scaffold `0000-record-architecture-decisions.md`
+  first (the meta-ADR establishing the practice itself).
+
+## Procedure
+
+1. Decide warranted vs. not. If not, stop.
+2. Detect template and location from existing ADRs or repo `CLAUDE.md`.
+3. Compute next sequence number. If first ADR, scaffold the meta-ADR
+   too.
+4. Surface chosen template, location, and a one-line decision summary
+   before drafting full content. Apply after agreement.
+5. Default Status to `Proposed`. The team promotes it after the
+   decision is actually made.


### PR DESCRIPTION
## Summary

Architecture Decision Record work now has a dedicated skill: warranted/not gate, Nygard or MADR template detection, and light scaffolding (next sequence number, default `docs/adr/`, meta-ADR bootstrap on first use). Pointer added in `dot_claude/CLAUDE.md` alongside the other doc-artifact skills.

Template selection is detection-driven so projects override implicitly: existing ADRs in the repo win, repo-local `CLAUDE.md` is the escape hatch, and Nygard is the default for new repos. MADR section links upstream rather than re-deriving the template.

## Gotchas

- Skill won't activate on the host until this lands on `main` and `chezmoi apply` runs against the apply clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)