### PR TITLE
Pin zellij to 0.43.1 to dodge plugin panic

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -11,7 +11,7 @@
 
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
-    zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.23.0/zjstatus.wasm"
+    zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.22.0/zjstatus.wasm"
 }
 
 keybinds {

--- a/renovate.json
+++ b/renovate.json
@@ -79,5 +79,12 @@
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Pinned: zellij 0.44.x panics in wasm_bridge.rs:903 under concurrent plugin instantiation (upstream zellij-org/zellij#4960). zjstatus 0.23+ requires zellij-tile 0.44.1, so it pins alongside zellij. Re-enable once #4960 is fixed.",
+      "matchPackageNames": ["zellij-org/zellij", "dj95/zjstatus"],
+      "enabled": false
+    }
   ]
 }

--- a/script/install/zellij
+++ b/script/install/zellij
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ZELLIJ_VERSION="v0.44.2"
+ZELLIJ_VERSION="v0.43.1"
 ARCH="x86_64-unknown-linux-musl"
 
 # shellcheck source-path=SCRIPTDIR source=lib.sh


### PR DESCRIPTION
## Summary

Spawning multiple pair tabs no longer wedges the zellij server. Pins zellij to 0.43.1 to avoid an upstream plugin-instantiation panic in 0.44.x's wasmi runtime ([zellij-org/zellij#4960](https://github.com/zellij-org/zellij/issues/4960)). Pinned alongside: zjstatus to v0.22.0, since v0.23.0 requires `zellij-tile = "0.44.1"`. zellaude v0.5.0 stays.

## Gotchas

- Reviewers: skim the zjstatus v0.22.0 → v0.23.0 changelog if you rely on any v0.23 features in the pair status bar — the downgrade is the part most likely to surprise.
- Renovate ignore covers both `zellij-org/zellij` and `dj95/zjstatus`. Drop the rule when #4960 lands.

## Verification

- pre-commit run --all-files: all hooks passed (shellcheck, shfmt, check-json, detect-private-key).
- bats test/: 38 tests pass.
- script/checks/zellij-config: clean.
- Reproduced the panic in the active session: server PID 927 panicked at `wasm_bridge.rs:903:46` with plugin ID 28; subsequent zellij invocations hung as the wedged server returned "unknown message" disconnects. `kill -9` cleared it; matches upstream #4960 reporter's recovery path.