### PR TITLE
Record ADR practice and defer git-worktree-poi rewrite

### DIFF
--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -20,8 +20,11 @@ Decision Records under `docs/adr/`, using the Nygard format (Title,
 Status, Context, Decision, Consequences). Files are named
 `NNNN-kebab-title.md`, numbered sequentially starting at `0000`.
 
-New ADRs default to `Status: Proposed`; promotion to `Accepted`,
-`Superseded by NNNN`, or `Deprecated` happens by edit.
+New ADRs land with `Status: Accepted` — the PR review that merges them
+is the acceptance step. Later transitions to `Superseded by NNNN` or
+`Deprecated` happen by edit. `Proposed` is reserved for the rare case
+where an ADR is published as a discussion artifact ahead of any
+implementing PR.
 
 We will not file ADRs for tactical implementation choices, framework
 defaults, or anything a commit message carries adequately. Sprawl makes

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,40 @@
+# 0. Record architecture decisions
+
+## Status
+
+Proposed
+
+## Context
+
+Architecturally significant choices (picking between non-trivial
+alternatives, locking in a dependency, accepting a one-way door) need a
+durable home. Commit messages cover *what* changed; PR bodies cover the
+merge state. Neither survives well as the rationale a future reader
+needs when challenging or revisiting the decision. `CLAUDE.md` files
+hold rules-for-AI, not project decisions.
+
+## Decision
+
+We will record architecturally significant decisions as Architecture
+Decision Records under `docs/adr/`, using the Nygard format (Title,
+Status, Context, Decision, Consequences). Files are named
+`NNNN-kebab-title.md`, numbered sequentially starting at `0000`.
+
+New ADRs default to `Status: Proposed`; promotion to `Accepted`,
+`Superseded by NNNN`, or `Deprecated` happens by edit.
+
+We will not file ADRs for tactical implementation choices, framework
+defaults, or anything a commit message carries adequately. Sprawl makes
+the collection worth less.
+
+## Consequences
+
+- Future readers can challenge a decision against the forces that were
+  in play when it was made, instead of inferring intent from diffs.
+- Adding an ADR is a small discipline cost on the proposer; reading the
+  set is a small load on anyone touching an area with prior decisions.
+- Deferred decisions (e.g. "stay bash for now, revisit when X fires")
+  have a place to record the trigger condition, so re-litigation starts
+  from the recorded state rather than from scratch.
+- Risk of sprawl if used for tactical choices. The warranted/not check
+  in the `adr` skill is the gate.

--- a/docs/adr/0001-keep-git-worktree-poi-in-bash.md
+++ b/docs/adr/0001-keep-git-worktree-poi-in-bash.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0001-keep-git-worktree-poi-in-bash.md
+++ b/docs/adr/0001-keep-git-worktree-poi-in-bash.md
@@ -1,0 +1,80 @@
+# 1. Keep git-worktree-poi in bash, port UX in place
+
+## Status
+
+Proposed
+
+## Context
+
+`dot_local/bin/executable_git-worktree-poi` started as a small
+classifier (#104) and has accreted: gh-poi-style report (#134),
+namespaced branches (#110), canonical-path resolution (#138), in-use
+guard (#140), empty-worktree safe path (#141). GraphQL batching (#147)
+is open.
+
+Two pressures motivate the question (#150):
+
+- **UX.** `gh poi`'s output — color, ✔/✕ progress, bold sections,
+  dimmed metadata, single line per branch — is denser and easier to
+  scan than the current two-line `└─` tree, especially with many
+  worktrees in flight.
+- **Complexity drift.** 234 lines of bash with more state, more
+  parsing, more places shell quoting and `mapfile` plumbing get in the
+  way. Each addition has been tractable; the trajectory is consistent.
+
+The natural reference point is `gh-poi` itself: Go, `fatih/color`,
+distributed via `gh extension install`. The host already runs it
+(pinned in `run_once_before_05-install-standalone-tools.sh.tmpl`), so a
+`gh-worktree-poi` rewrite would slot into the same install pass.
+
+Three options were considered: (a) stay bash and port the UX in place,
+(b) Go rewrite as `gh-worktree-poi`, (c) Rust rewrite. Option (c) is
+ruled out by ecosystem fit — Go is the de facto language for `gh`
+extensions, and a Rust binary buys little here.
+
+The reversibility asymmetry between (a) and (b) is the dominant force.
+Bash → rewrite is straightforward at any size. Rewrite → bash is rare
+in practice. Picking the irreversible direction earlier than necessary
+forfeits optionality. 234 lines sits below the threshold where bash
+becomes a tax: `classify`/`gather`/`print_section` are bounded helpers,
+and the next pending feature (#147 GraphQL batching) is awkward in
+bash but reachable with a `gh api graphql` heredoc and `jq`
+distribution. The motivating UX pain (color, tighter rows, dimmed
+metadata, progress markers) is reachable from `tput`/ANSI inside
+`print_section` without touching the classifier.
+
+## Decision
+
+We will keep `git-worktree-poi` in bash and port the `gh-poi`-style UX
+in place. The `gh-worktree-poi` Go rewrite (option b in #150) is
+deferred, not rejected.
+
+We will revisit when any of these triggers fire:
+
+- A feature needs more than roughly 100 lines of bash addition —
+  interactive selection, a real TUI, or anything beyond report-and-act.
+- Test scenarios start straining the PATH-shim stub model in
+  `test/git_worktree_poi.bats` past what `bats` handles cleanly.
+- GraphQL batching (#147) or any successor classifier change ends up
+  needing more `jq`/heredoc surgery than the equivalent Go rewrite
+  would cost.
+
+At any trigger, the reversibility argument no longer holds: the rewrite
+is paying for itself, and porting 234 lines is cheaper now than porting
+the post-trigger surface.
+
+## Consequences
+
+- Chezmoi-managed deployment via `dot_local/bin/` stays in place;
+  existing `bats` coverage and the small dependency surface are
+  preserved.
+- UX work (color, single-line rows, dimmed metadata, progress markers)
+  is unblocked and lives in `print_section` plus terminal-capability
+  helpers. No new repo, no publishing flow, no Go in CI.
+- #147 lands as bash. Future classifier additions continue paying the
+  shell-quoting and `mapfile` tax.
+- ANSI/`tput` in bash is awkward compared to `fatih/color`; struct-based
+  mocks remain unavailable; complexity drift continues, just bounded by
+  the re-evaluation triggers above.
+- The triggers are the load-bearing part: without them this becomes
+  "stay bash forever," which is not the decision being made.


### PR DESCRIPTION
## Summary

Adopts ADRs as the home for architecturally significant decisions
(`0000`) and records the call on #150: keep `git-worktree-poi` in bash
and port the `gh-poi`-style UX in place, deferring the `gh-extension`
rewrite (`0001`).

`0000` codifies the project's actual practice — ADRs land `Accepted`
on PR merge rather than entering `Proposed` first, since the PR review
*is* the acceptance step. Both ADRs in this PR follow that rule.

## Gotchas

- `0001`'s load-bearing piece is the **re-evaluation triggers**, not
  the "stay bash" verdict. Without them this becomes "stay bash
  forever," which is not the decision.
- Filename scheme is `NNNN-kebab-title.md` with `0000` reserved for
  the meta-ADR. Worth catching now if you'd rather use `0001` for the
  meta and start substantive ADRs at `0002`.

Closes #150