### PR TITLE
Batch git-worktree-poi PR lookups into one GraphQL per repo

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -22,6 +22,14 @@ WORKTREE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/git-worktrees"
 # classification; every classify() call consults this set via is_in_use.
 declare -a IN_USE_CWDS=()
 
+# PR state per worktree, populated once by batch_fetch_pr_states before
+# classification. Keyed by absolute worktree path. Empty map entry → NONE
+# (no PR for that branch); UNKNOWN means the GraphQL query failed for the
+# whole repo group. Splitting state and number lets classify() drop straight
+# into the existing case "$pr_state" block.
+declare -A PR_STATE_BY_WT=()
+declare -A PR_NUM_BY_WT=()
+
 collect_in_use_cwds() {
     local cwd_link target
     for cwd_link in /proc/*/cwd; do
@@ -41,6 +49,110 @@ is_in_use() {
     return 1
 }
 
+# github_slug <remote-url>: emit "owner/repo" from a GitHub remote URL,
+# stripping any trailing .git. Returns non-zero for non-GitHub remotes so
+# the caller can fall back to UNKNOWN.
+github_slug() {
+    local url=$1
+    url=${url%.git}
+    case "$url" in
+    *github.com/*) printf '%s\n' "${url##*github.com/}" ;;
+    *github.com:*) printf '%s\n' "${url##*github.com:}" ;;
+    *) return 1 ;;
+    esac
+}
+
+# fetch_pr_states_for_repo <canonical> <newline-separated "wt\tbranch" pairs>:
+# resolve <canonical>'s GitHub slug, issue one aliased GraphQL query for every
+# branch in the group, and populate PR_STATE_BY_WT / PR_NUM_BY_WT. On any
+# failure (no origin, non-GitHub URL, query error) every wt in the group is
+# marked UNKNOWN — matching the previous per-call fallback.
+fetch_pr_states_for_repo() {
+    local canonical=$1 pairs=$2
+    local -a group_wts=() group_branches=()
+    local wt branch
+    while IFS=$'\t' read -r wt branch; do
+        [[ -z "$wt" ]] && continue
+        group_wts+=("$wt")
+        group_branches+=("$branch")
+    done <<<"$pairs"
+    ((${#group_wts[@]})) || return 0
+
+    local mark_unknown=0 url owner_name owner name
+    if ! url=$(git -C "$canonical" remote get-url origin 2>/dev/null); then
+        mark_unknown=1
+    elif ! owner_name=$(github_slug "$url"); then
+        mark_unknown=1
+    fi
+
+    if ((mark_unknown == 0)); then
+        owner=${owner_name%%/*}
+        name=${owner_name##*/}
+
+        local query="query(\$owner: String!, \$name: String!"
+        local -a args=(-f "owner=$owner" -f "name=$name")
+        local i
+        for i in "${!group_branches[@]}"; do
+            query+=", \$b$i: String!"
+            args+=(-f "b$i=${group_branches[i]}")
+        done
+        query+=") { repository(owner: \$owner, name: \$name) {"
+        for i in "${!group_branches[@]}"; do
+            query+=" pr$i: pullRequests(headRefName: \$b$i, first: 1, states: [OPEN, MERGED, CLOSED]) { nodes { number state } }"
+        done
+        query+=" } }"
+
+        local resp
+        if ! resp=$(gh api graphql "${args[@]}" -f "query=$query" \
+            -q '.data.repository | to_entries | map("\(.key)\t\(.value.nodes[0].number // "")\t\(.value.nodes[0].state // "NONE")") | join("\n")' \
+            2>/dev/null) || [[ -z "$resp" ]]; then
+            mark_unknown=1
+        fi
+    fi
+
+    if ((mark_unknown)); then
+        for wt in "${group_wts[@]}"; do
+            PR_STATE_BY_WT[$wt]=UNKNOWN
+        done
+        return
+    fi
+
+    local -A wt_for_alias=()
+    for i in "${!group_wts[@]}"; do
+        wt_for_alias[pr$i]=${group_wts[i]}
+    done
+
+    local alias num state
+    while IFS=$'\t' read -r alias num state; do
+        [[ -z "$alias" ]] && continue
+        wt=${wt_for_alias[$alias]:-}
+        [[ -n "$wt" ]] || continue
+        PR_STATE_BY_WT[$wt]=$state
+        PR_NUM_BY_WT[$wt]=$num
+    done <<<"$resp"
+}
+
+# batch_fetch_pr_states: walk every worktree under $WORKTREE_ROOT, group by
+# canonical (one canonical = one GitHub repo), and dispatch one GraphQL query
+# per group. Detached-HEAD worktrees are skipped — classify() leaves their
+# pr_state at NONE without consulting the maps.
+batch_fetch_pr_states() {
+    local wt canonical branch
+    declare -A by_canonical=()
+
+    while IFS= read -r wt; do
+        [[ -e "$wt/.git" ]] || continue
+        canonical=$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || continue
+        canonical=${canonical%/.git}
+        branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null) || continue
+        by_canonical[$canonical]+="$wt"$'\t'"$branch"$'\n'
+    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+
+    for canonical in "${!by_canonical[@]}"; do
+        fetch_pr_states_for_repo "$canonical" "${by_canonical[$canonical]}"
+    done
+}
+
 # classify <wt>: emits TAB-separated:
 #   verdict\trel\tbranch\tdetail\twt
 #
@@ -51,7 +163,7 @@ is_in_use() {
 #           PR #N merged", ...) for keep
 classify() {
     local wt=$1
-    local rel branch pr_info pr_state pr_num pr_state_lc dirty base ahead
+    local rel branch pr_state pr_num pr_state_lc dirty base ahead
     local upstream_reason=
     local reasons=()
 
@@ -68,17 +180,8 @@ classify() {
     pr_state=NONE
     pr_num=
     if [[ "$branch" != '(detached HEAD)' ]]; then
-        if pr_info=$(gh pr list --head "$branch" --state all \
-                         --json state,number \
-                         -q 'if length > 0 then "\(.[0].state)\t\(.[0].number)" else "" end' \
-                         2>/dev/null); then
-            if [[ -n "$pr_info" ]]; then
-                pr_state=${pr_info%%$'\t'*}
-                pr_num=${pr_info#*$'\t'}
-            fi
-        else
-            pr_state=UNKNOWN
-        fi
+        pr_state=${PR_STATE_BY_WT[$wt]:-NONE}
+        pr_num=${PR_NUM_BY_WT[$wt]:-}
     fi
 
     dirty=clean
@@ -188,6 +291,8 @@ esac
 CWD="$(pwd -P)"
 
 mapfile -t IN_USE_CWDS < <(collect_in_use_cwds)
+
+batch_fetch_pr_states
 
 rows=$(gather)
 [[ -n "$rows" ]] || { printf 'no worktrees found\n'; exit 0; }

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -49,11 +49,11 @@ teardown() {
 
 # --- classify: in-use override ---
 
-# Build a worktree under $WORKTREE_ROOT with upstream tracking, plus a `gh`
-# stub reporting the requested PR state. Sets $WT and prepends the stub to
-# PATH in the caller's scope (no subshell).
+# Build a worktree under $WORKTREE_ROOT with upstream tracking. PR state is
+# fed to classify() via PR_STATE_BY_WT in each test rather than a `gh` stub
+# — classify() no longer calls `gh` itself; batch_fetch_pr_states does. Sets
+# $WT in the caller's scope.
 _mkworktree() {
-  local pr_state=$1
   local wtroot="$XDG_DATA_HOME/git-worktrees/me/repo"
   local canonical="$HOME/me/repo"
   local bare="$TMPROOT/remote.git"
@@ -67,34 +67,96 @@ _mkworktree() {
   git -C "$canonical" worktree add -B feature "$wtroot/feature" >/dev/null 2>&1
   git -C "$wtroot/feature" push --quiet -u origin feature
 
-  local stub_dir="$TMPROOT/stubs"
-  mkdir -p "$stub_dir"
-  cat >"$stub_dir/gh" <<STUB
-#!/usr/bin/env bash
-# Stub: report '$pr_state' as TSV for any 'pr list --head' query.
-printf '%s\t99\n' '$pr_state'
-STUB
-  chmod +x "$stub_dir/gh"
-
   WT="$wtroot/feature"
-  PATH="$stub_dir:$PATH"
 }
 
 @test "classify: idle worktree with merged PR is removed" {
-  _mkworktree MERGED
-  run bash -c 'source "$1"; IN_USE_CWDS=(); classify "$2"' \
-    _ "$POI" "$WT"
+  _mkworktree
+  run bash -c '
+    source "$1"
+    PR_STATE_BY_WT[$2]=MERGED
+    PR_NUM_BY_WT[$2]=99
+    IN_USE_CWDS=()
+    classify "$2"
+  ' _ "$POI" "$WT"
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == remove$'\t'* ]]
   [[ "$output" == *"PR #99 merged"* ]]
 }
 
 @test "classify: in-use worktree with merged PR is kept" {
-  _mkworktree MERGED
-  run bash -c 'source "$1"; IN_USE_CWDS=("$3"); classify "$2"' \
-    _ "$POI" "$WT" "$WT/nested/subdir"
+  _mkworktree
+  run bash -c '
+    source "$1"
+    PR_STATE_BY_WT[$2]=MERGED
+    PR_NUM_BY_WT[$2]=99
+    IN_USE_CWDS=("$3")
+    classify "$2"
+  ' _ "$POI" "$WT" "$WT/nested/subdir"
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == keep$'\t'* ]]
   [[ "$output" == *"in-use"* ]]
   [[ "$output" == *"PR #99 merged"* ]]
+}
+
+# --- batch_fetch_pr_states: one query per repo ---
+
+@test "batch fetch: one graphql call serves three same-repo worktrees" {
+  local wtroot="$XDG_DATA_HOME/git-worktrees/me/repo"
+  local canonical="$HOME/me/repo"
+  local bare="$TMPROOT/remote.git"
+
+  mkdir -p "$wtroot" "$(dirname "$canonical")"
+  git init --quiet --bare --initial-branch=main "$bare"
+  git init --quiet --initial-branch=main "$canonical"
+  git -C "$canonical" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  git -C "$canonical" remote add origin "$bare"
+  git -C "$canonical" push --quiet -u origin main
+
+  local b
+  for b in alpha beta gamma; do
+    git -C "$canonical" worktree add -B "$b" "$wtroot/$b" >/dev/null 2>&1
+  done
+  # Push alpha and beta so MERGED→remove and OPEN→keep can fire on a clean
+  # worktree. Leave gamma unpushed so the NONE+ahead==0 path triggers on its
+  # "no commits, no PR" verdict.
+  git -C "$wtroot/alpha" push --quiet -u origin alpha
+  git -C "$wtroot/beta" push --quiet -u origin beta
+  # Swap origin to a GitHub URL so github_slug resolves; pushes are done.
+  git -C "$canonical" remote set-url origin "git@github.com:me/repo.git"
+
+  local stub_dir="$TMPROOT/stubs"
+  local count_file="$TMPROOT/gh_count"
+  local tsv_file="$TMPROOT/gh_tsv"
+  mkdir -p "$stub_dir"
+  : >"$count_file"
+  # find $WORKTREE_ROOT | sort emits alpha, beta, gamma → aliases pr0,pr1,pr2.
+  printf 'pr0\t1\tMERGED\npr1\t2\tOPEN\npr2\t\tNONE\n' >"$tsv_file"
+  cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub: count `gh api graphql` calls and replay canned post-jq TSV.
+if [[ "${1:-}" == api && "${2:-}" == graphql ]]; then
+    printf 'invoked\n' >>"$GH_STUB_COUNT_FILE"
+    cat "$GH_STUB_TSV_FILE"
+    exit 0
+fi
+exit 1
+STUB
+  chmod +x "$stub_dir/gh"
+
+  PATH="$stub_dir:$PATH" \
+    GH_STUB_COUNT_FILE="$count_file" \
+    GH_STUB_TSV_FILE="$tsv_file" \
+    run bash "$POI" -n
+  [ "$status" -eq 0 ]
+
+  local invocations
+  invocations=$(wc -l <"$count_file")
+  [ "$invocations" -eq 1 ]
+
+  [[ "$output" == *"Would remove (2)"* ]]
+  [[ "$output" == *"Would keep (1)"* ]]
+  [[ "$output" == *"PR #1 merged"* ]]
+  [[ "$output" == *"PR #2 open"* ]]
+  [[ "$output" == *"no commits, no PR"* ]]
 }


### PR DESCRIPTION
## Summary

`git worktree-poi` now issues one aliased `gh api graphql` per repo
instead of one `gh pr list --head` per worktree, cutting GraphQL
round-trips from N to 1 per repo group.

## Gotchas

- Focus on `fetch_pr_states_for_repo` (script) and the new bats case.
  classify() now reads from `PR_STATE_BY_WT` / `PR_NUM_BY_WT`; the
  existing case "$pr_state" block is unchanged so verdict logic
  (MERGED / CLOSED / OPEN / NONE / UNKNOWN, in-use, dirty, no-upstream,
  ahead, detached HEAD) is preserved.
- `github_slug` only handles GitHub remotes; non-GitHub origins fall
  through to UNKNOWN, matching the previous failure path.
- `gh api graphql -q '…'` runs the response through gh's built-in jq;
  no new external dep.

## Verification

- `bats test/` green (8/8, including the new 3-worktree case that
  stubs `gh api graphql` and asserts exactly one invocation).
- `pre-commit run --all-files` green.
- Smoke-tested `bash dot_local/bin/executable_git-worktree-poi -n`
  against the live worktree set: classifications match the pre-refactor
  output (merged → remove, in-use → keep, no-PR + no-upstream → keep,
  empty + ahead==0 → remove). Current worktree correctly tagged
  `(current)`.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)