### PR TITLE
Install yq via bootstrap

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -24,6 +24,7 @@ signal-cli -a +<phone> register            # SMS-verified, ~/.local/share/signal
 # PATH check for chezmoi-installed binaries:
 zellij --version && lazygit --version && act --version && rtk --version
 lychee --version                           # markdown link checker (mirrors CI)
+yq --version                               # YAML processor (mikefarah/yq)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 gh extension list                          # confirms gh-poi (squash-merge pruner)

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,13 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^script/install/yq$/"],
+      "matchStrings": ["YQ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "mikefarah/yq",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^run_once_before_05-install-standalone-tools\\.sh\\.tmpl$/"],
       "matchStrings": ["GH_POI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "seachicken/gh-poi",

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -5,6 +5,7 @@
 # gcx content:        {{ include "script/install/gcx" | sha256sum }}
 # lychee content:     {{ include "script/install/lychee" | sha256sum }}
 # signal-cli content: {{ include "script/install/signal-cli" | sha256sum }}
+# yq content:         {{ include "script/install/yq" | sha256sum }}
 # lib.sh content:     {{ include "script/install/lib.sh" | sha256sum }}
 # The hashes above embed the install scripts' content into this file's
 # rendered output so chezmoi re-runs this script when any of them change
@@ -19,6 +20,7 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/gcx" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/lychee" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/signal-cli" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/yq" --bin-dir "$HOME/.local/bin"
 
 # gcx ships its skill bundle inside the binary; `agent skills install
 # --all` extracts it to ~/.agents/skills (the cross-harness convention

--- a/script/install/yq
+++ b/script/install/yq
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+YQ_VERSION="v4.53.2"
+ARCH="linux_amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/yq"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "${YQ_VERSION#v}"; then
+  printf '==> yq: %s already installed at %s\n' "$YQ_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> yq: downloading %s\n' "$YQ_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# mikefarah/yq publishes the binary directly (no tarball needed) and a
+# wide-format `checksums` table indexed by `checksums_hashes_order`.
+# SHA-256 is one column among many, so resolve its column dynamically
+# instead of hard-coding a position that upstream could reorder.
+base="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}"
+asset="yq_${ARCH}"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums" "$base/checksums"
+curl -fsSL -o "$tmp/checksums_hashes_order" "$base/checksums_hashes_order"
+
+hash_row="$(awk '/^SHA-256$/ {print NR; exit}' "$tmp/checksums_hashes_order")"
+if [ -z "$hash_row" ]; then
+  echo "yq: SHA-256 missing from checksums_hashes_order" >&2
+  exit 1
+fi
+col=$((hash_row + 1))
+expected="$(awk -v f="$asset" -v c="$col" \
+  'BEGIN{FS="  "} $1 == f {print $c}' "$tmp/checksums")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/$asset" "$bin"


### PR DESCRIPTION
## Summary

`yq` (mikefarah/yq) is now installed on bootstrap and confirmed in the PATH-check line. It was already allowlisted in Claude permissions (`Bash(yq:*)`) but missing from the host install path.

## Gotchas

- mikefarah/yq's `checksums` file is a wide column table indexed by `checksums_hashes_order`, not the standard `<hash> <file>` layout. The install script resolves the SHA-256 column dynamically (so an upstream reorder won't silently shift hashes) rather than extending `lib.sh` for a one-off format. Focus review on that block.
- Renovate manager added with the same shape as `lazygit`/`act`/`lychee` — same `extractVersion` handling not needed because mikefarah/yq tags as plain `vX.Y.Z`.

## Verification

- Ran `script/install/yq --bin-dir <tmp>` in a temp dir: download + SHA-256 verification succeeded, `yq --version` reported `v4.53.2`.
- Re-ran into `~/.local/bin`: idempotent short-circuit fired on the second invocation; binary lands on PATH.
- `pre-commit run --all-files` passed (shellcheck, shfmt, check-json).
- `bats test/` passed (39/39).