### PR TITLE
Install nethack-console via bootstrap

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -27,6 +27,7 @@ lychee --version                           # markdown link checker (mirrors CI)
 yq --version                               # YAML processor (mikefarah/yq)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
+command -v nethack                         # roguelike (nethack-console)
 gh extension list                          # confirms gh-poi (squash-merge pruner)
 claude mcp list                            # confirms cloudflare-* MCP servers
 ```

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -51,6 +51,7 @@ APT_PACKAGES=(
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   golang-petname
   keybase signal-desktop
+  nethack-console
 )
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do


### PR DESCRIPTION
Crostini is Debian; the console build is in the main archive, so it
slots into the apt pass with no third-party repo or binary plumbing.
Bootstrap PATH check uses `command -v` since invoking `nethack` would
start the game.