### PR TITLE
Pass uptimerobot URL before --header to claude mcp add

### DIFF
--- a/run_onchange_after_07-register-uptimerobot-mcp.sh.tmpl
+++ b/run_onchange_after_07-register-uptimerobot-mcp.sh.tmpl
@@ -37,5 +37,5 @@ token="$(<"$token_file")"
 claude mcp remove uptimerobot --scope user >/dev/null 2>&1 || true
 log "uptimerobot: registering"
 claude mcp add uptimerobot --transport http --scope user \
-  --header "Authorization: Bearer ${token}" \
-  https://mcp.uptimerobot.com/mcp
+  https://mcp.uptimerobot.com/mcp \
+  --header "Authorization: Bearer ${token}"


### PR DESCRIPTION
## Summary

`chezmoi apply` no longer fails on the Uptime Robot MCP registration step — the URL now lands in the `commandOrUrl` positional slot instead of being eaten by the variadic `--header`.

## Gotchas

`claude mcp add`'s `--header` is declared variadic (`<header...>`), so any positional that follows it is treated as another header value rather than the URL. The fix is purely a flag-ordering swap; `claude mcp add --help`'s own example puts the URL before `--header`.

## Verification

- Reproduced the failure (`error: missing required argument 'commandOrUrl'`) with the old ordering against `https://example.com/mcp`.
- Confirmed the new ordering registers the server and writes the bearer header to `~/.claude.json`, then cleaned up the test entry.
- `pre-commit run --files run_onchange_after_07-register-uptimerobot-mcp.sh.tmpl` clean (shellcheck, shfmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)