### PR TITLE
Add fabrication, doc, and tool discovery rules

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -102,6 +102,11 @@ A per-repo `CLAUDE.md` overrides anything here.
 - Rule of three before extracting an abstraction. Exception: when a
   clean semantic concept is obvious upfront, name it early — shared
   vocabulary beats loose duplicates that resist extraction.
+- Before reaching for `curl`, manual API calls, or first-principles
+  scripts, check what's already on the host: chezmoi-managed
+  credentials under `~/.config/`, registered MCP servers
+  (`claude mcp list`), and pinned CLIs in the repo's install
+  scripts. One of these usually already covers the task.
 
 ## Scope
 
@@ -118,6 +123,9 @@ A per-repo `CLAUDE.md` overrides anything here.
   need a quick `grep`/`find`/`unzip -l`/WebFetch/devcontainer-exec
   first. When verifying is too expensive, say "I haven't checked, but
   I think..." rather than picking a side.
+- If a fetch, command, or tool call is denied or fails, stop and
+  surface it. Never fill in plausible-looking data to paper over a
+  missing source — fabricated content is worse than a gap.
 
 ## Comments
 
@@ -143,6 +151,13 @@ audience needs more:
 - Repo-local `CLAUDE.md` when the audience is Claude, not a human.
 - Promote to `~/.claude/CLAUDE.md` when the same friction shows up
   in more than one project.
+
+Document only what exists at current HEAD. No pre-announcements,
+forward-looking banners, or planned-feature notes in READMEs,
+CHANGELOGs, or docs — the diff and the issue tracker carry that.
+Never write pointers to where secrets live (e.g. "token in
+`~/.config/foo/token`") in committed files; they're prompt-injection
+bait for whatever reads the repo next.
 
 Human-read docs should be skimmable and earn their place.
 AI-targeted text (this file, repo-local `CLAUDE.md`, hooks, prompt


### PR DESCRIPTION
## Summary

After running `/insights`, three recurring friction patterns came
up across enough sessions to warrant codification in the user-level
`CLAUDE.md`:

- **Fabrication**: Claude has filled in plausible-looking data
  when a fetch or tool call was denied (the WebFetch-blocked
  weapon-stats incident).
- **Document-the-future drift**: pre-announcement banners in
  CHANGELOGs, planned-feature notes in READMEs, and a flagged
  prompt-injection case where committed docs pointed at where
  secrets live.
- **Reinventing local tooling**: reaching for `curl` or first-
  principles scripts instead of discovering chezmoi-managed
  credentials, registered MCP servers, or pinned CLIs already on
  the host.

Each rule slots into the section that already owns the surrounding
behaviour — no new top-level sections.

## Gotchas

Focus review on placement, not wording. The fabrication rule
piggybacks on `## Verify before claiming`, the head-only-docs and
no-secrets-pointer rules extend `## Documentation`, and the
tooling-discovery rule extends `## Approach`. If any of those
feel like they should live under a new heading instead (e.g. a
dedicated `## Security` section for the secrets-pointer rule),
flag it.

## Verification

- `pre-commit run --files dot_claude/CLAUDE.md` passed (no
  shell/JSON content; detect-private-key passed).
- Single-file diff, +15 lines, no unrelated edits.

Source: `/insights` report on 2026-05-17.