### PR TITLE
Disable zellij session serialization to dodge resurrection log spam

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -8,6 +8,14 @@
 // anyway. The pair layout adds a zjstatus line for PR-aware status; default
 // stays minimal.
 
+// Sessions never serialize. On filesystems where btime isn't exposed
+// (Crostini's ext4 path through 9p), the resurrection-file scan logs
+// "creation time is not available" twice a second per saved session and
+// eventually saturates the screen/plugin threads — see zellij-org/zellij#4165
+// and PR #5057. Until the fix lands upstream, keep the cache empty so the
+// loop has nothing to iterate.
+session_serialization false
+
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
     zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.22.0/zjstatus.wasm"


### PR DESCRIPTION
## Summary

Zellij froze mid-pair-tab spawn. Root cause is upstream bug [#4165](https://github.com/zellij-org/zellij/issues/4165): on filesystems where `std::fs::Metadata::created()` returns `Unsupported` (Crostini's ext4-via-9p, ext4 on some kernels), zellij's resurrection-file scanner logs an error per saved session every poll. The fix is in open PR [zellij-org/zellij#5057](https://github.com/zellij-org/zellij/pull/5057), not yet merged in 0.43.x or 0.44.x. Symptoms match #5057's report exactly: screen/plugin threads saturate, IPC stops draining, `zellij action` calls block indefinitely.

Add `session_serialization false` to `dot_config/zellij/config.kdl` so the resurrection directory stays empty and the loop has nothing to stat.

## Gotchas

- Trades zellij `attach`-after-reboot resurrection for stability. Worktrees on disk are unaffected; pair tabs are recreated through `git-repo-picker` anyway, so the loss is small.
- Revisit when [zellij-org/zellij#5057](https://github.com/zellij-org/zellij/pull/5057) merges and a fixed zellij release ships — then drop this line and bump `script/install/zellij`.

## Verification

- `script/checks/zellij-config` passes against the modified config.
- Deployed via `chezmoi apply --source` on the live host; the wedged session was killed and `~/.cache/zellij/contract_version_1/session_info/` plus per-session UUID dirs pruned.
- Fresh-zellij smoke test (pair tab opens promptly, no `resurrection` lines in `/tmp/zellij-*/zellij-log/zellij.log`) deferred to next session start.