### PR TITLE
git-repo-picker: dim worktree rows with open tabs

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -46,7 +46,7 @@ fmt_tab() {
 }
 
 open_tabs() {
-    zellij action list-tabs --json 2>/dev/null | jq -r '.[].name' 2>/dev/null || true
+    zellij action query-tab-names 2>/dev/null || true
 }
 
 # Walk $HOME for git checkouts and map each to its github.com <org>/<repo> via
@@ -167,7 +167,7 @@ on_exit() {
 }
 trap on_exit EXIT
 
-for cmd in fzf zellij gh git jq golang-petname; do
+for cmd in fzf zellij gh git golang-petname; do
     command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
 done
 

--- a/test/fixtures/git_repo_picker/stubs/zellij
+++ b/test/fixtures/git_repo_picker/stubs/zellij
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# zellij stub: appends "$@" to $ZELLIJ_RECORDER; emits $ZELLIJ_TABS_JSON for action list-tabs.
+# zellij stub: appends "$@" to $ZELLIJ_RECORDER; emits $ZELLIJ_TAB_NAMES
+# (newline-delimited) for `action query-tab-names`, matching real CLI output.
 printf '%s\n' "$*" >>"$ZELLIJ_RECORDER"
-if [[ "${1:-}" == "action" && "${2:-}" == "list-tabs" ]]; then
-  printf '%s' "${ZELLIJ_TABS_JSON:-[]}"
+if [[ "${1:-}" == "action" && "${2:-}" == "query-tab-names" ]]; then
+  printf '%s' "${ZELLIJ_TAB_NAMES:-}"
 fi

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -21,7 +21,16 @@ setup() {
   export ZELLIJ_RECORDER="$TMPROOT/zellij.log"
   : >"$ZELLIJ_RECORDER"
   export GH_USER=me
-  unset FZF_OUTPUT ZELLIJ_TABS_JSON GH_CLONE_SRC GH_REPO_LIST PETNAME
+  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME
+}
+
+# Seed a worktree under $WORKTREE_ROOT/<org>/<repo>/<petname> so
+# `print_worktrees` walks find it the same way the real picker does.
+mkworktree() {
+  local org="$1" repo="$2" petname="$3"
+  local dir="$XDG_DATA_HOME/git-worktrees/$org/$repo/$petname"
+  mkdir -p "$dir"
+  : >"$dir/.git"
 }
 
 teardown() {
@@ -106,6 +115,27 @@ mkcanonical() {
   run bash -c 'source "$1"; ME=me fmt_tab grafana k6 kind-newt' _ "$PICKER"
   [ "$status" -eq 0 ]
   [ "$output" = "grafana/k6 (kind-newt)" ]
+}
+
+# --- print_worktrees: dim when a tab is already open ---
+
+@test "print_worktrees: open tab emits dimmed focus row" {
+  mkworktree me hello kind-newt
+  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '\033[2mworktree:hello (kind-newt)\033[0m\tfocus\thello (kind-newt)')" ]
+}
+
+@test "print_worktrees: closed tab emits undimmed spawn row" {
+  mkworktree me hello kind-newt
+  export ZELLIJ_TAB_NAMES=""
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  local petdir="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
+  [ "$output" = "$(printf 'worktree:hello (kind-newt)\tspawn\t%s\thello (kind-newt)' "$petdir")" ]
 }
 
 # --- TSV dispatch (end-to-end) ---


### PR DESCRIPTION
## Summary

Worktree rows whose tab is already open in this zellij session now render dimmed and route to `go-to-tab-name`, instead of silently spawning a duplicate tab. `open_tabs()` was calling `zellij action list-tabs --json` — a subcommand that doesn't exist in zellij 0.43.1 — with the error swallowed by `2>/dev/null || true`. Replaced with `zellij action query-tab-names` (newline-delimited, no jq).

## Gotchas

- The bats stub previously mocked `action list-tabs` returning `$ZELLIJ_TABS_JSON`, matching the picker's broken call rather than the real CLI surface. Worth a second look — it's the exact mock-vs-reality drift that hid the bug. The new stub answers `query-tab-names` from `$ZELLIJ_TAB_NAMES`, but if you can think of a way to keep the stub honest against future zellij CLI shifts, I'm open to it.
- `jq` is dropped from the picker's required-cmd check. It's still installed (other scripts use it), but if you'd prefer to keep it listed defensively, say the word.

## Verification

- `bats test/git_repo_picker.bats` — 14/14 pass, including two new `print_worktrees` tests covering the dim/focus and undimmed/spawn branches.
- `pre-commit run --all-files` — clean (shellcheck, shfmt, check-json).
- `zellij action list-tabs --help` → `subcommand 'list-tabs' wasn't recognized`; `zellij action query-tab-names --help` → exists and matches the new call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)