### PR TITLE
git-worktree-poi: colour the report

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -14,6 +14,20 @@
 
 set -euo pipefail
 
+# NO_COLOR (https://no-color.org): any non-empty value disables colour.
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    RESET=$'\033[0m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    BOLD_YELLOW=$'\033[1;33m'
+    MAGENTA=$'\033[95m'
+else
+    BOLD='' DIM='' RESET='' RED='' GREEN='' YELLOW='' BOLD_YELLOW='' MAGENTA=''
+fi
+
 die() { printf 'git-worktree-poi: %s\n' "$*" >&2; exit 1; }
 
 WORKTREE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/git-worktrees"
@@ -251,17 +265,56 @@ gather() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
+# colour_reason <reason>: emit one comma-joined reason coloured by category.
+# Green = safe-remove signals, yellow = blockers worth attention, magenta =
+# in-use (work-loss risk), red = closed-without-merge, dim = informational.
+# Catch-all dims unknowns so future reasons render visibly without a code
+# change.
+colour_reason() {
+    local r=$1
+    case "$r" in
+        in-use)                     printf '%s%s%s' "$MAGENTA" "$r" "$RESET" ;;
+        "PR #"*" merged")           printf '%s%s%s' "$GREEN" "$r" "$RESET" ;;
+        "no commits, no PR")        printf '%s%s%s' "$GREEN" "$r" "$RESET" ;;
+        "PR #"*" closed")           printf '%s%s%s' "$RED" "$r" "$RESET" ;;
+        "PR #"*" open")             printf '%s%s%s' "$YELLOW" "$r" "$RESET" ;;
+        "PR state unknown")         printf '%s%s%s' "$YELLOW" "$r" "$RESET" ;;
+        "uncommitted changes" | unpushed | "no upstream")
+                                    printf '%s%s%s' "$YELLOW" "$r" "$RESET" ;;
+        *)                          printf '%s%s%s' "$DIM" "$r" "$RESET" ;;
+    esac
+}
+
 # print_section <heading> <tsv-rows>
 print_section() {
     local heading=$1 data=$2 count=0
     [[ -n "$data" ]] && count=$(printf '%s\n' "$data" | wc -l)
-    printf '%s (%d)\n' "$heading" "$count"
+    printf '%s%s%s %s(%d)%s\n' "$BOLD" "$heading" "$RESET" "$DIM" "$count" "$RESET"
     if [[ -n "$data" ]]; then
-        while IFS=$'\t' read -r _verdict rel branch detail wt; do
-            local current=
-            [[ "$wt" == "$CWD" ]] && current=' (current)'
-            printf '  %s%s\n' "$rel" "$current"
-            printf '    └─ %s · %s\n' "$branch" "$detail"
+        while IFS=$'\t' read -r verdict rel branch detail wt; do
+            local current=''
+            [[ "$wt" == "$CWD" ]] && current=" ${BOLD_YELLOW}(current)${RESET}"
+            printf '  %s%s%s%s\n' "$BOLD" "$rel" "$RESET" "$current"
+
+            # Remove-row details are single atoms (some, like "no commits, no
+            # PR", contain commas). Keep-row details are comma-joined and
+            # need splitting.
+            local coloured=''
+            if [[ "$verdict" == remove ]]; then
+                coloured=$(colour_reason "$detail")
+            else
+                local rest=$detail sep='' part
+                while [[ "$rest" == *", "* ]]; do
+                    part=${rest%%, *}
+                    coloured+="${sep}$(colour_reason "$part")"
+                    sep="${DIM}, ${RESET}"
+                    rest=${rest#*, }
+                done
+                coloured+="${sep}$(colour_reason "$rest")"
+            fi
+
+            printf '    %s└─%s %s%s%s %s·%s %s\n' \
+                "$DIM" "$RESET" "$DIM" "$branch" "$RESET" "$DIM" "$RESET" "$coloured"
         done <<<"$data"
     fi
     printf '\n'

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -160,3 +160,23 @@ STUB
   [[ "$output" == *"PR #2 open"* ]]
   [[ "$output" == *"no commits, no PR"* ]]
 }
+
+# --- print_section: verdict-branched splitter ---
+
+# The keep-row detail is comma-joined, so print_section splits on ", " to
+# colour each reason. The "no commits, no PR" remove-row detail contains an
+# embedded comma; without the verdict branch the splitter would shred it into
+# two atoms and lose the green wrap. Forces colour vars on since bats stdout
+# isn't a tty.
+@test "print_section: remove-row detail with embedded comma stays one coloured atom" {
+  run bash -c "
+    source '$POI'
+    BOLD=\$'\\033[1m' DIM=\$'\\033[2m' RESET=\$'\\033[0m'
+    GREEN=\$'\\033[32m' BOLD_YELLOW=\$'\\033[1;33m'
+    CWD=/tmp
+    row=\$(printf 'remove\\tx/y\\tbranch\\tno commits, no PR\\t/tmp/wt')
+    print_section 'Would remove' \"\$row\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'\033[32m'"no commits, no PR"$'\033[0m'* ]]
+}


### PR DESCRIPTION
## Summary

Bold section headings, dim structural glyphs and informational metadata, and per-reason colouring (green for safe-remove signals, yellow for blockers, magenta for in-use, red for closed-without-merge) make a many-worktree report scannable instead of a wall of grey text. Colour gates on `[[ -t 1 && -z "${NO_COLOR:-}" ]]`, so pipes and `NO_COLOR=1` consumers see unchanged plain output.

Direction comes from [ADR 0001](docs/adr/0001-keep-git-worktree-poi-in-bash.md): UX work lives in `print_section` plus terminal-capability helpers, with no classifier changes.

## Gotchas

- The verdict-branched splitter in `print_section` is the only non-cosmetic addition — keep-row details are comma-joined and need splitting before per-reason colouring; remove-row details are single atoms, one of which ("no commits, no PR" from #141) contains an embedded comma and would be shredded by the splitter. The new bats test pins this — it forces colour vars on (bats stdout isn't a tty) and asserts the whole phrase stays green-wrapped.

## Verification

- `pre-commit run --files <changed>` clean
- `bats test/git_worktree_poi.bats` — 9/9 pass (1 new)
- Ran `script -qec 'bash ./dot_local/bin/executable_git-worktree-poi --dry-run' …` to capture a pty typescript; confirmed `^[[1m` / `^[[2m` / `^[[33m` / `^[[95m` / `^[[32m` / `^[[1;33m` fire on the expected fields across remove and keep sections.
- Confirmed `NO_COLOR=1` path produces byte-identical output to pre-change script (no ANSI escapes; same content and layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)