### PR TITLE
git-worktree-poi: prune gone-upstream merged PRs

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -195,7 +195,18 @@ classify() {
     ahead=
     if [[ "$branch" != '(detached HEAD)' ]]; then
         if ! git -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
-            upstream_reason="no upstream"
+            # @{upstream} fails in two distinct situations:
+            #   - branch.<name>.merge unset: truly never-pushed work; keep.
+            #   - branch.<name>.merge set but remote-tracking ref pruned
+            #     ("[gone]"): was pushed, then deleted remote-side (typical
+            #     auto-delete-on-merge). Safe to remove when a merged/closed
+            #     PR proves the push happened.
+            # %(upstream:track) returns [gone] only in the second case.
+            if [[ "$(git -C "$wt" for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null)" == "[gone]" ]]; then
+                upstream_reason="upstream gone"
+            else
+                upstream_reason="no upstream"
+            fi
         elif [[ -n "$(git -C "$wt" log '@{upstream}..HEAD' --oneline 2>/dev/null)" ]]; then
             upstream_reason="unpushed"
         fi
@@ -225,7 +236,12 @@ classify() {
             fi
             ;;
         MERGED | CLOSED)
-            [[ -n "$upstream_reason" ]] && reasons+=("$upstream_reason")
+            # "upstream gone" isn't a blocker here: the PR's terminal state
+            # proves the work was pushed; the remote ref was just pruned.
+            # "no upstream" / "unpushed" still block — those mean we have
+            # no proof the work made it off the local clone.
+            [[ -n "$upstream_reason" && "$upstream_reason" != "upstream gone" ]] \
+                && reasons+=("$upstream_reason")
             if [[ ${#reasons[@]} -eq 0 ]]; then
                 printf 'remove\t%s\t%s\t%s\t%s\n' \
                     "$rel" "$branch" "PR #${pr_num} ${pr_state_lc}" "$wt"

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -99,6 +99,44 @@ _mkworktree() {
   [[ "$output" == *"PR #99 merged"* ]]
 }
 
+# --- classify: gone vs. never-pushed upstreams ---
+
+@test "classify: merged PR with gone upstream is removed" {
+  # Simulates post-merge auto-prune: branch.<name>.remote/.merge stay set,
+  # but refs/remotes/origin/<branch> is gone. The PR's merged state proves
+  # the work was pushed, so the missing remote ref must not block removal.
+  _mkworktree
+  git -C "$WT" update-ref -d refs/remotes/origin/feature
+  run bash -c '
+    source "$1"
+    PR_STATE_BY_WT[$2]=MERGED
+    PR_NUM_BY_WT[$2]=42
+    IN_USE_CWDS=()
+    classify "$2"
+  ' _ "$POI" "$WT"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == remove$'\t'* ]]
+  [[ "$output" == *"PR #42 merged"* ]]
+}
+
+@test "classify: merged PR with no upstream config is kept" {
+  # Regression guard against the gone-upstream fix: when branch.<name>.merge
+  # is unset, there's no proof the work was ever pushed — keep, even if a
+  # merged PR happens to share the branch name.
+  _mkworktree
+  git -C "$WT" branch --unset-upstream
+  run bash -c '
+    source "$1"
+    PR_STATE_BY_WT[$2]=MERGED
+    PR_NUM_BY_WT[$2]=42
+    IN_USE_CWDS=()
+    classify "$2"
+  ' _ "$POI" "$WT"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == keep$'\t'* ]]
+  [[ "$output" == *"no upstream"* ]]
+}
+
 # --- batch_fetch_pr_states: one query per repo ---
 
 @test "batch fetch: one graphql call serves three same-repo worktrees" {


### PR DESCRIPTION
## Summary

`git worktree-poi` now removes worktrees whose branch was pushed,
PR-merged, and then auto-pruned remote-side — instead of refusing
because the remote-tracking ref is gone. Picks up the typical
auto-delete-on-merge post-merge state that previously needed `git
worktree remove` by hand.

`classify()` previously treated any `@{upstream}` failure as "no
upstream" and blocked the MERGED|CLOSED removal path. Now it splits
that into "no upstream" (config absent — truly never pushed; still
blocks) and "upstream gone" (`%(upstream:track) == "[gone]"` —
config recorded, ref pruned; doesn't block when the PR proves the
push happened).

## Gotchas

- Behaviour change for previously-kept worktrees: anything that used
  to read `no upstream, PR #N merged` in the keep list will now
  remove on next run. Run `git worktree-poi -n` once if there's a
  worktree you wanted to retain post-merge for any reason.
- Scope: the relaxation only fires in MERGED|CLOSED. OPEN/UNKNOWN
  with `[gone]` still report "no upstream" in their detail string —
  flag if you want symmetric wording, otherwise leaving it minimal.

## Verification

- `bats test/git_worktree_poi.bats` — 10/10 pass (two new tests:
  gone-upstream + merged PR → remove; no-upstream config + merged PR
  → keep, as the regression guard distinguishing the two cases).
- `pre-commit run --files dot_local/bin/executable_git-worktree-poi
  test/git_worktree_poi.bats` — shellcheck + shfmt clean.
- `git worktree-poi --dry-run` against
  `$XDG_DATA_HOME/git-worktrees/`: `fitting-liger` now classifies
  "Would remove · PR #42 merged"; `humble-fly` and `real-osprey`
  correctly remain kept on uncommitted-changes alone.