### PR TITLE
git-repo-picker: pr:<N> tags worktree rows for cross-repo lookup

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -18,6 +18,12 @@
 #                              Selection clones (no fork), then takes the
 #                              local: path above.
 #
+# A `pr:<N>` query short-circuits the three sets above: it resolves <N> to a
+# head ref via `gh pr view` (in the cwd's repo) and emits at most one row —
+# the existing worktree whose checked-out branch matches. No match yields a
+# non-actionable hint; an unknown PR yields a non-actionable error. Strictly
+# re-open — pr: never creates a worktree.
+#
 # Worktree and local rows are built upfront (cheap: filesystem + zellij).
 # Remotes require a `gh repo list` round-trip per org, so they are deferred
 # until the query length reaches REMOTE_THRESHOLD characters and then cached
@@ -88,6 +94,53 @@ print_worktrees() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
+# Resolve a pr:<N> query to a single worktree row, if one exists. Each
+# distinct N is resolved at most once per picker invocation: the head ref (or
+# the empty file marking "no such PR") is cached under $PR_CACHE_DIR so fzf's
+# per-keystroke reload doesn't re-hit `gh pr view` for digits the user has
+# already typed past.
+print_pr_rows() {
+    local n=$1 cache head_ref
+    cache="$PR_CACHE_DIR/$n"
+    if [[ ! -f "$cache" ]]; then
+        if head_ref=$(gh pr view "$n" --json headRefName -q .headRefName 2>/dev/null); then
+            printf '%s' "$head_ref" >"$cache"
+        else
+            : >"$cache"
+        fi
+    fi
+    head_ref=$(<"$cache")
+    if [[ -z "$head_ref" ]]; then
+        printf 'pr:%s → \033[2mno such PR\033[0m\tnoop\n' "$n"
+        return 0
+    fi
+
+    [[ -d "$WORKTREE_ROOT" ]] || {
+        printf 'pr:%s → \033[2m%s\033[0m\tnoop\n' "$n" "no matching worktree ($head_ref)"
+        return 0
+    }
+
+    local opens petdir petname repo org tab branch
+    opens=$(open_tabs)
+    while IFS= read -r petdir; do
+        [[ -e "$petdir/.git" ]] || continue
+        branch=$(git -C "$petdir" branch --show-current 2>/dev/null) || continue
+        [[ "$branch" == "$head_ref" ]] || continue
+        petname=$(basename "$petdir")
+        repo=$(basename "$(dirname "$petdir")")
+        org=$(basename "$(dirname "$(dirname "$petdir")")")
+        tab=$(fmt_tab "$org" "$repo" "$petname")
+        if grep -Fxq "$tab" <<<"$opens"; then
+            printf 'pr:%s → \033[2mworktree:%s\033[0m\tfocus\t%s\n' "$n" "$tab" "$tab"
+        else
+            printf 'pr:%s → worktree:%s\tspawn\t%s\t%s\n' "$n" "$tab" "$petdir" "$tab"
+        fi
+        return 0
+    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+
+    printf 'pr:%s → \033[2m%s\033[0m\tnoop\n' "$n" "no matching worktree ($head_ref)"
+}
+
 print_local() {
     local org repo dir
     while IFS=$'\t' read -r org repo dir; do
@@ -128,8 +181,17 @@ if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
 # REMOTE_THRESHOLD characters and stay for the rest of this invocation via
 # REMOTES_FILE.
 if [[ "${1:-}" == "--rows" ]]; then
-    cat "$STATIC_FILE" 2>/dev/null || true
     query=${2:-}
+    if [[ "$query" == pr:* ]]; then
+        n=${query#pr:}
+        if [[ "$n" =~ ^[0-9]+$ ]]; then
+            print_pr_rows "$n"
+        else
+            printf 'pr:%s → \033[2mtype a PR number\033[0m\tnoop\n' "$n"
+        fi
+        exit 0
+    fi
+    cat "$STATIC_FILE" 2>/dev/null || true
     if ((${#query} >= REMOTE_THRESHOLD)); then
         if [[ ! -s "$REMOTES_FILE" ]]; then
             # Atomic fill: write to .tmp and rename, so a fzf-killed reload
@@ -157,6 +219,7 @@ exec 2> >(tee "$LOG" >&2)
 on_exit() {
     local rc=$?
     [[ -n "${STATIC_FILE:-}" ]] && rm -f "$STATIC_FILE" "$REMOTES_FILE" "${REMOTES_FILE}.tmp"
+    [[ -n "${PR_CACHE_DIR:-}" ]] && rm -rf "$PR_CACHE_DIR"
     if (( rc == 0 )); then
         rm -f "$LOG"
     elif [[ -n "${ZELLIJ:-}" ]]; then
@@ -175,7 +238,8 @@ ME=$(gh api user -q .login)
 
 STATIC_FILE=$(mktemp)
 REMOTES_FILE=$(mktemp)
-export ME WORKTREE_ROOT STATIC_FILE REMOTES_FILE
+PR_CACHE_DIR=$(mktemp -d)
+export ME WORKTREE_ROOT STATIC_FILE REMOTES_FILE PR_CACHE_DIR
 
 { print_worktrees; print_local; } >"$STATIC_FILE"
 : >"$REMOTES_FILE"
@@ -250,7 +314,7 @@ selection=$(fzf \
     --with-nth=1 \
     --nth=1 \
     --prompt "repo> " \
-    --header "type ${REMOTE_THRESHOLD}+ chars to load remotes · worktree: dim = open tab" \
+    --header "type ${REMOTE_THRESHOLD}+ chars to load remotes · worktree: dim = open tab · pr:<N> = re-open by PR" \
     --bind "change:reload($SCRIPT --rows {q})" \
     <"$STATIC_FILE") || exit 0
 
@@ -272,6 +336,8 @@ case "$verb" in
         wt_dir="$WORKTREE_ROOT/$a1/$a2/$petname"
         make_worktree "$canonical" "$wt_dir" "$petname"
         spawn_pair_tab "$wt_dir" "$(fmt_tab "$a1" "$a2" "$petname")"
+        ;;
+    noop)
         ;;
     *)
         die "unknown verb: $verb"

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -18,17 +18,21 @@
 #                              Selection clones (no fork), then takes the
 #                              local: path above.
 #
-# A `pr:<N>` query short-circuits the three sets above: it resolves <N> to a
-# head ref via `gh pr view` (in the cwd's repo) and emits at most one row —
-# the existing worktree whose checked-out branch matches. No match yields a
-# non-actionable hint; an unknown PR yields a non-actionable error. Strictly
-# re-open — pr: never creates a worktree.
+# A `pr:` query prefix swaps the worktree set for a PR-enriched variant —
+# rows look like `worktree:<repo> (petname) pr:<N>` so fzf's substring filter
+# resolves `pr:174` to whichever local worktree is on PR 174's head ref, in
+# any repo. Strictly re-open: worktrees without an open/merged/closed PR for
+# their branch are omitted from the pr: set, so this view is "find an
+# existing worktree by PR", never "make one."
 #
 # Worktree and local rows are built upfront (cheap: filesystem + zellij).
 # Remotes require a `gh repo list` round-trip per org, so they are deferred
 # until the query length reaches REMOTE_THRESHOLD characters and then cached
-# for the lifetime of this picker invocation. fzf re-runs this script via
-# `change:reload` to refresh the candidate set on every keystroke.
+# for the lifetime of this picker invocation. PR-enriched worktree rows are
+# deferred the same way: populated on the first `pr:` query via one
+# `gh pr list --repo <org>/<repo>` per distinct repo, then cached. fzf
+# re-runs this script via `change:reload` to refresh the candidate set on
+# every keystroke.
 #
 # Tabs are named "<repo-or-org/repo> (petname)" so go-to-tab-name round-trips.
 # Worktrees are durable — closing a tab does not remove them; that is
@@ -94,55 +98,59 @@ print_worktrees() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
-# Resolve a pr:<N> query to a single worktree row, if one exists. `gh pr view`
-# is repo-scoped (cwd's repo), so we constrain the worktree scan to the same
-# base repo — otherwise pr:1 in repo A could false-match a worktree in repo B
-# that happens to share a branch name. Each distinct N is resolved at most
-# once per picker invocation: the TSV record (or the empty file marking "no
-# such PR") is cached under $PR_CACHE_DIR so fzf's per-keystroke reload
-# doesn't re-hit `gh pr view` for digits the user has already typed past.
-print_pr_rows() {
-    local n=$1 cache record org_scope repo_scope head_ref scope_root
-    cache="$PR_CACHE_DIR/$n"
-    if [[ ! -f "$cache" ]]; then
-        if record=$(gh pr view "$n" --json baseRepository,headRefName \
-            -q '[.baseRepository.owner.login, .baseRepository.name, .headRefName] | @tsv' \
-            2>/dev/null); then
-            printf '%s' "$record" >"$cache"
-        else
-            : >"$cache"
-        fi
-    fi
-    record=$(<"$cache")
-    if [[ -z "$record" ]]; then
-        printf 'pr:%s → \033[2mno such PR\033[0m\tnoop\n' "$n"
-        return 0
-    fi
-    IFS=$'\t' read -r org_scope repo_scope head_ref <<<"$record"
+# Worktree rows enriched with their associated PR number. Walks
+# $WORKTREE_ROOT, batches one `gh pr list --repo <org>/<repo>` per distinct
+# repo into a (branch → pr#) map, then re-walks emitting `worktree:<tab>
+# pr:<N>` for each worktree whose current branch matches a known PR head.
+# Worktrees without an associated PR are omitted (this view is "find by PR";
+# the unenriched STATIC_FILE rows cover the other cases). Slow — gated to
+# pr:* queries by the --rows handler and cached in WORKTREE_PR_FILE per
+# invocation.
+print_worktrees_with_prs() {
+    [[ -d "$WORKTREE_ROOT" ]] || return 0
 
-    scope_root="$WORKTREE_ROOT/$org_scope/$repo_scope"
-    [[ -d "$scope_root" ]] || {
-        printf 'pr:%s → \033[2mno matching worktree (%s)\033[0m\tnoop\n' "$n" "$head_ref"
-        return 0
-    }
-
-    local opens petdir petname tab branch
-    opens=$(open_tabs)
+    local petdir
+    local -a petdirs=()
     while IFS= read -r petdir; do
-        [[ -e "$petdir/.git" ]] || continue
-        branch=$(git -C "$petdir" branch --show-current 2>/dev/null) || continue
-        [[ "$branch" == "$head_ref" ]] || continue
-        petname=$(basename "$petdir")
-        tab=$(fmt_tab "$org_scope" "$repo_scope" "$petname")
-        if grep -Fxq "$tab" <<<"$opens"; then
-            printf 'pr:%s → \033[2mworktree:%s\033[0m\tfocus\t%s\n' "$n" "$tab" "$tab"
-        else
-            printf 'pr:%s → worktree:%s\tspawn\t%s\t%s\n' "$n" "$tab" "$petdir" "$tab"
-        fi
-        return 0
-    done < <(find "$scope_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+        [[ -e "$petdir/.git" ]] && petdirs+=("$petdir")
+    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+    ((${#petdirs[@]})) || return 0
 
-    printf 'pr:%s → \033[2mno matching worktree (%s)\033[0m\tnoop\n' "$n" "$head_ref"
+    local -A pr_for=()
+    local -A seen_repo=()
+    local repo org repo_key branch num
+    for petdir in "${petdirs[@]}"; do
+        repo=$(basename "$(dirname "$petdir")")
+        org=$(basename "$(dirname "$(dirname "$petdir")")")
+        repo_key="$org/$repo"
+        [[ -n "${seen_repo[$repo_key]:-}" ]] && continue
+        seen_repo[$repo_key]=1
+        while IFS=$'\t' read -r branch num; do
+            [[ -n "$branch" && -n "$num" ]] || continue
+            pr_for["$repo_key:$branch"]=$num
+        done < <(gh pr list --repo "$repo_key" --state all --limit 1000 \
+            --json number,headRefName -q '.[] | [.headRefName, .number] | @tsv' \
+            2>/dev/null)
+    done
+
+    local opens petname tab display pr_n
+    opens=$(open_tabs)
+    for petdir in "${petdirs[@]}"; do
+        petname=$(basename "$petdir")
+        repo=$(basename "$(dirname "$petdir")")
+        org=$(basename "$(dirname "$(dirname "$petdir")")")
+        branch=$(git -C "$petdir" branch --show-current 2>/dev/null) || continue
+        pr_n=${pr_for["$org/$repo:$branch"]:-}
+        [[ -n "$pr_n" ]] || continue
+        tab=$(fmt_tab "$org" "$repo" "$petname")
+        if grep -Fxq "$tab" <<<"$opens"; then
+            display=$(printf '\033[2mworktree:%s pr:%s\033[0m' "$tab" "$pr_n")
+            printf '%s\tfocus\t%s\n' "$display" "$tab"
+        else
+            display="worktree:$tab pr:$pr_n"
+            printf '%s\tspawn\t%s\t%s\n' "$display" "$petdir" "$tab"
+        fi
+    done
 }
 
 print_local() {
@@ -187,19 +195,20 @@ if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
 if [[ "${1:-}" == "--rows" ]]; then
     query=${2:-}
     if [[ "$query" == pr:* ]]; then
-        n=${query#pr:}
-        if [[ "$n" =~ ^[0-9]+$ ]]; then
-            print_pr_rows "$n"
-        else
-            printf 'pr:%s → \033[2mtype a PR number\033[0m\tnoop\n' "$n"
+        # Atomic fill: write to .tmp and rename, so a fzf-killed reload
+        # mid-fetch never leaves a partial file the next reload would read.
+        # `! -e` (not `-s`) guards the empty-on-purpose case where the user
+        # has no PR-tagged worktrees — we still want to skip the refill.
+        if [[ ! -e "$WORKTREE_PR_FILE" ]]; then
+            print_worktrees_with_prs >"${WORKTREE_PR_FILE}.tmp" 2>/dev/null \
+                && mv "${WORKTREE_PR_FILE}.tmp" "$WORKTREE_PR_FILE" 2>/dev/null
         fi
+        cat "$WORKTREE_PR_FILE" 2>/dev/null || true
         exit 0
     fi
     cat "$STATIC_FILE" 2>/dev/null || true
     if ((${#query} >= REMOTE_THRESHOLD)); then
         if [[ ! -s "$REMOTES_FILE" ]]; then
-            # Atomic fill: write to .tmp and rename, so a fzf-killed reload
-            # mid-fetch never leaves a partial file the next reload would read.
             print_remotes >"${REMOTES_FILE}.tmp" 2>/dev/null \
                 && mv "${REMOTES_FILE}.tmp" "$REMOTES_FILE" 2>/dev/null
         fi
@@ -223,7 +232,7 @@ exec 2> >(tee "$LOG" >&2)
 on_exit() {
     local rc=$?
     [[ -n "${STATIC_FILE:-}" ]] && rm -f "$STATIC_FILE" "$REMOTES_FILE" "${REMOTES_FILE}.tmp"
-    [[ -n "${PR_CACHE_DIR:-}" ]] && rm -rf "$PR_CACHE_DIR"
+    [[ -n "${WORKTREE_PR_FILE:-}" ]] && rm -f "$WORKTREE_PR_FILE" "${WORKTREE_PR_FILE}.tmp"
     if (( rc == 0 )); then
         rm -f "$LOG"
     elif [[ -n "${ZELLIJ:-}" ]]; then
@@ -242,8 +251,11 @@ ME=$(gh api user -q .login)
 
 STATIC_FILE=$(mktemp)
 REMOTES_FILE=$(mktemp)
-PR_CACHE_DIR=$(mktemp -d)
-export ME WORKTREE_ROOT STATIC_FILE REMOTES_FILE PR_CACHE_DIR
+# -u so the file only exists after the first pr:* query populates it; the
+# --rows handler uses `! -e` to gate the fill, which keeps the "user has 0
+# PR-tagged worktrees" case from re-fetching on every keystroke.
+WORKTREE_PR_FILE=$(mktemp -u)
+export ME WORKTREE_ROOT STATIC_FILE REMOTES_FILE WORKTREE_PR_FILE
 
 { print_worktrees; print_local; } >"$STATIC_FILE"
 : >"$REMOTES_FILE"
@@ -318,7 +330,7 @@ selection=$(fzf \
     --with-nth=1 \
     --nth=1 \
     --prompt "repo> " \
-    --header "type ${REMOTE_THRESHOLD}+ chars to load remotes · worktree: dim = open tab · pr:<N> = re-open by PR" \
+    --header "type ${REMOTE_THRESHOLD}+ chars for remotes · worktree: dim = open tab · pr:<N> filters worktrees by PR" \
     --bind "change:reload($SCRIPT --rows {q})" \
     <"$STATIC_FILE") || exit 0
 
@@ -340,8 +352,6 @@ case "$verb" in
         wt_dir="$WORKTREE_ROOT/$a1/$a2/$petname"
         make_worktree "$canonical" "$wt_dir" "$petname"
         spawn_pair_tab "$wt_dir" "$(fmt_tab "$a1" "$a2" "$petname")"
-        ;;
-    noop)
         ;;
     *)
         die "unknown verb: $verb"

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -94,51 +94,55 @@ print_worktrees() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
-# Resolve a pr:<N> query to a single worktree row, if one exists. Each
-# distinct N is resolved at most once per picker invocation: the head ref (or
-# the empty file marking "no such PR") is cached under $PR_CACHE_DIR so fzf's
-# per-keystroke reload doesn't re-hit `gh pr view` for digits the user has
-# already typed past.
+# Resolve a pr:<N> query to a single worktree row, if one exists. `gh pr view`
+# is repo-scoped (cwd's repo), so we constrain the worktree scan to the same
+# base repo — otherwise pr:1 in repo A could false-match a worktree in repo B
+# that happens to share a branch name. Each distinct N is resolved at most
+# once per picker invocation: the TSV record (or the empty file marking "no
+# such PR") is cached under $PR_CACHE_DIR so fzf's per-keystroke reload
+# doesn't re-hit `gh pr view` for digits the user has already typed past.
 print_pr_rows() {
-    local n=$1 cache head_ref
+    local n=$1 cache record org_scope repo_scope head_ref scope_root
     cache="$PR_CACHE_DIR/$n"
     if [[ ! -f "$cache" ]]; then
-        if head_ref=$(gh pr view "$n" --json headRefName -q .headRefName 2>/dev/null); then
-            printf '%s' "$head_ref" >"$cache"
+        if record=$(gh pr view "$n" --json baseRepository,headRefName \
+            -q '[.baseRepository.owner.login, .baseRepository.name, .headRefName] | @tsv' \
+            2>/dev/null); then
+            printf '%s' "$record" >"$cache"
         else
             : >"$cache"
         fi
     fi
-    head_ref=$(<"$cache")
-    if [[ -z "$head_ref" ]]; then
+    record=$(<"$cache")
+    if [[ -z "$record" ]]; then
         printf 'pr:%s → \033[2mno such PR\033[0m\tnoop\n' "$n"
         return 0
     fi
+    IFS=$'\t' read -r org_scope repo_scope head_ref <<<"$record"
 
-    [[ -d "$WORKTREE_ROOT" ]] || {
-        printf 'pr:%s → \033[2m%s\033[0m\tnoop\n' "$n" "no matching worktree ($head_ref)"
+    scope_root="$WORKTREE_ROOT/$org_scope/$repo_scope"
+    [[ -d "$scope_root" ]] || {
+        printf 'pr:%s → \033[2mno matching worktree (%s)\033[0m\tnoop\n' "$n" "$head_ref"
         return 0
     }
 
-    local opens petdir petname repo org tab branch
+    local opens petdir petname tab branch
     opens=$(open_tabs)
     while IFS= read -r petdir; do
         [[ -e "$petdir/.git" ]] || continue
         branch=$(git -C "$petdir" branch --show-current 2>/dev/null) || continue
         [[ "$branch" == "$head_ref" ]] || continue
         petname=$(basename "$petdir")
-        repo=$(basename "$(dirname "$petdir")")
-        org=$(basename "$(dirname "$(dirname "$petdir")")")
-        tab=$(fmt_tab "$org" "$repo" "$petname")
+        tab=$(fmt_tab "$org_scope" "$repo_scope" "$petname")
         if grep -Fxq "$tab" <<<"$opens"; then
             printf 'pr:%s → \033[2mworktree:%s\033[0m\tfocus\t%s\n' "$n" "$tab" "$tab"
         else
             printf 'pr:%s → worktree:%s\tspawn\t%s\t%s\n' "$n" "$tab" "$petdir" "$tab"
         fi
         return 0
-    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+    done < <(find "$scope_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
-    printf 'pr:%s → \033[2m%s\033[0m\tnoop\n' "$n" "no matching worktree ($head_ref)"
+    printf 'pr:%s → \033[2mno matching worktree (%s)\033[0m\tnoop\n' "$n" "$head_ref"
 }
 
 print_local() {

--- a/test/fixtures/git_repo_picker/stubs/gh
+++ b/test/fixtures/git_repo_picker/stubs/gh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # gh stub: returns $GH_USER for `api user`, empty for memberships, clones $GH_CLONE_SRC for `repo clone`.
+# `pr view <N>` resolves via $GH_PR_VIEW (semicolon-delimited N=branch pairs);
+# unknown N exits nonzero so the picker treats it as a missing PR.
 case "${1:-} ${2:-}" in
   "api user")
     printf '%s' "${GH_USER:-test-user}"
@@ -12,5 +14,16 @@ case "${1:-} ${2:-}" in
     ;;
   "repo clone")
     git clone --quiet "${GH_CLONE_SRC:?GH_CLONE_SRC must be set}" "$4"
+    ;;
+  "pr view")
+    n="$3"
+    IFS=';' read -ra pairs <<<"${GH_PR_VIEW:-}"
+    for pair in "${pairs[@]}"; do
+      [[ "${pair%%=*}" == "$n" ]] || continue
+      printf '%s\n' "${pair#*=}"
+      exit 0
+    done
+    printf 'no such PR: %s\n' "$n" >&2
+    exit 1
     ;;
 esac

--- a/test/fixtures/git_repo_picker/stubs/gh
+++ b/test/fixtures/git_repo_picker/stubs/gh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # gh stub: returns $GH_USER for `api user`, empty for memberships, clones $GH_CLONE_SRC for `repo clone`.
-# `pr view <N>` resolves via $GH_PR_VIEW (semicolon-delimited N=branch pairs);
-# unknown N exits nonzero so the picker treats it as a missing PR.
+# `pr view <N>` returns the TSV in $GH_PR_VIEW_<N> ("<org>\t<repo>\t<head>")
+# verbatim, ignoring --json/-q args. Unknown N exits nonzero so the picker
+# treats it as a missing PR.
 case "${1:-} ${2:-}" in
   "api user")
     printf '%s' "${GH_USER:-test-user}"
@@ -16,14 +17,12 @@ case "${1:-} ${2:-}" in
     git clone --quiet "${GH_CLONE_SRC:?GH_CLONE_SRC must be set}" "$4"
     ;;
   "pr view")
-    n="$3"
-    IFS=';' read -ra pairs <<<"${GH_PR_VIEW:-}"
-    for pair in "${pairs[@]}"; do
-      [[ "${pair%%=*}" == "$n" ]] || continue
-      printf '%s\n' "${pair#*=}"
-      exit 0
-    done
-    printf 'no such PR: %s\n' "$n" >&2
-    exit 1
+    var="GH_PR_VIEW_$3"
+    val="${!var:-}"
+    if [[ -z "$val" ]]; then
+      printf 'no such PR: %s\n' "$3" >&2
+      exit 1
+    fi
+    printf '%s\n' "$val"
     ;;
 esac

--- a/test/fixtures/git_repo_picker/stubs/gh
+++ b/test/fixtures/git_repo_picker/stubs/gh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # gh stub: returns $GH_USER for `api user`, empty for memberships, clones $GH_CLONE_SRC for `repo clone`.
-# `pr view <N>` returns the TSV in $GH_PR_VIEW_<N> ("<org>\t<repo>\t<head>")
-# verbatim, ignoring --json/-q args. Unknown N exits nonzero so the picker
-# treats it as a missing PR.
+# `pr list --repo <org>/<repo>` returns the TSV in
+# $GH_PR_LIST_<org>_<repo> ("<branch>\t<number>" per line) verbatim,
+# ignoring --json/-q args. Missing var yields empty output (no PRs).
 case "${1:-} ${2:-}" in
   "api user")
     printf '%s' "${GH_USER:-test-user}"
@@ -16,13 +16,17 @@ case "${1:-} ${2:-}" in
   "repo clone")
     git clone --quiet "${GH_CLONE_SRC:?GH_CLONE_SRC must be set}" "$4"
     ;;
-  "pr view")
-    var="GH_PR_VIEW_$3"
+  "pr list")
+    shift
+    repo=""
+    while (( $# )); do
+      if [[ "$1" == "--repo" ]]; then repo="$2"; shift 2; else shift; fi
+    done
+    var="GH_PR_LIST_${repo//[!a-zA-Z0-9_]/_}"
     val="${!var:-}"
-    if [[ -z "$val" ]]; then
-      printf 'no such PR: %s\n' "$3" >&2
-      exit 1
-    fi
-    printf '%s\n' "$val"
+    # Real `gh pr list -q ... | @tsv` terminates each row with a newline;
+    # mirror that so the picker's `read -r branch num` loop doesn't drop the
+    # final line.
+    [[ -n "$val" ]] && printf '%s\n' "$val"
     ;;
 esac

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -23,7 +23,9 @@ setup() {
   export GH_USER=me
   export PR_CACHE_DIR="$TMPROOT/pr_cache"
   mkdir -p "$PR_CACHE_DIR"
-  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME GH_PR_VIEW
+  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME
+  # Drop any GH_PR_VIEW_* leakage from prior tests.
+  while IFS= read -r var; do unset "$var"; done < <(compgen -e | grep '^GH_PR_VIEW_' || true)
 }
 
 # Seed a worktree under $WORKTREE_ROOT/<org>/<repo>/<petname> so
@@ -188,7 +190,7 @@ mkcanonical() {
 
 @test "print_pr_rows: matching worktree emits spawn row" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW="123=feature/x"
+  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
@@ -198,7 +200,7 @@ mkcanonical() {
 
 @test "print_pr_rows: matching worktree with open tab emits focus row" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW="123=feature/x"
+  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
   export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
@@ -208,13 +210,25 @@ mkcanonical() {
 
 @test "print_pr_rows: no matching worktree emits noop hint with head ref" {
   mkpr_worktree me hello kind-newt feature/unrelated
-  export GH_PR_VIEW="123=feature/missing"
+  export GH_PR_VIEW_123=$'me\thello\tfeature/missing'
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
   [[ "$output" == *"noop"* ]]
   [[ "$output" == *"no matching worktree"* ]]
   [[ "$output" == *"feature/missing"* ]]
+}
+
+@test "print_pr_rows: ignores same-branch worktree in a different repo" {
+  # Branch name collision across repos: only the one under the PR's base repo
+  # should match. Without the scope guard this test would false-positive.
+  mkpr_worktree other hello kind-newt feature/x
+  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"noop"* ]]
+  [[ "$output" == *"no matching worktree"* ]]
 }
 
 @test "print_pr_rows: unknown PR emits noop error row" {
@@ -227,12 +241,12 @@ mkcanonical() {
 
 @test "print_pr_rows: caches resolution to avoid repeated gh calls" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW="123=feature/x"
+  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
   # First call populates the cache.
   bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123 >/dev/null' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
-  # Drop GH_PR_VIEW so a re-fetch would fail with "no such PR".
-  unset GH_PR_VIEW
+  # Drop the fixture so a re-fetch would fail with "no such PR".
+  unset GH_PR_VIEW_123
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -21,7 +21,9 @@ setup() {
   export ZELLIJ_RECORDER="$TMPROOT/zellij.log"
   : >"$ZELLIJ_RECORDER"
   export GH_USER=me
-  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME
+  export PR_CACHE_DIR="$TMPROOT/pr_cache"
+  mkdir -p "$PR_CACHE_DIR"
+  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME GH_PR_VIEW
 }
 
 # Seed a worktree under $WORKTREE_ROOT/<org>/<repo>/<petname> so
@@ -44,6 +46,18 @@ mklocal() {
   local dir="$1" url="$2"
   git init --quiet "$dir"
   git -C "$dir" remote add origin "$url"
+}
+
+# Build a worktree under $WORKTREE_ROOT on a named branch, backed by a real
+# canonical clone — so `git -C <wt> branch --show-current` returns the branch
+# print_pr_rows compares against the PR's head ref.
+mkpr_worktree() {
+  local org="$1" repo="$2" petname="$3" branch="$4"
+  local canonical="$TMPROOT/canonicals/$repo"
+  mkcanonical "$canonical" "$repo" >/dev/null
+  local petdir="$XDG_DATA_HOME/git-worktrees/$org/$repo/$petname"
+  mkdir -p "$(dirname "$petdir")"
+  git -C "$canonical" worktree add --quiet "$petdir" -b "$branch" >/dev/null
 }
 
 # Build a bare "remote" plus a canonical clone with origin/HEAD set up, so
@@ -168,6 +182,69 @@ mkcanonical() {
   [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "me/worktree/fresh-petname" ]
   grep -Fxq "action new-tab --layout pair --cwd $wt" "$ZELLIJ_RECORDER"
   grep -Fxq "action rename-tab hello (fresh-petname)" "$ZELLIJ_RECORDER"
+}
+
+# --- print_pr_rows: pr:<N> resolution ---
+
+@test "print_pr_rows: matching worktree emits spawn row" {
+  mkpr_worktree me hello kind-newt feature/x
+  export GH_PR_VIEW="123=feature/x"
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  local petdir="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
+  [ "$output" = "$(printf 'pr:123 → worktree:hello (kind-newt)\tspawn\t%s\thello (kind-newt)' "$petdir")" ]
+}
+
+@test "print_pr_rows: matching worktree with open tab emits focus row" {
+  mkpr_worktree me hello kind-newt feature/x
+  export GH_PR_VIEW="123=feature/x"
+  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'pr:123 → \033[2mworktree:hello (kind-newt)\033[0m\tfocus\thello (kind-newt)')" ]
+}
+
+@test "print_pr_rows: no matching worktree emits noop hint with head ref" {
+  mkpr_worktree me hello kind-newt feature/unrelated
+  export GH_PR_VIEW="123=feature/missing"
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"noop"* ]]
+  [[ "$output" == *"no matching worktree"* ]]
+  [[ "$output" == *"feature/missing"* ]]
+}
+
+@test "print_pr_rows: unknown PR emits noop error row" {
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 999' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"noop"* ]]
+  [[ "$output" == *"no such PR"* ]]
+}
+
+@test "print_pr_rows: caches resolution to avoid repeated gh calls" {
+  mkpr_worktree me hello kind-newt feature/x
+  export GH_PR_VIEW="123=feature/x"
+  # First call populates the cache.
+  bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123 >/dev/null' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  # Drop GH_PR_VIEW so a re-fetch would fail with "no such PR".
+  unset GH_PR_VIEW
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"worktree:hello (kind-newt)"* ]]
+}
+
+@test "dispatch noop: no zellij action fires beyond the upfront query" {
+  export FZF_OUTPUT=$'pr:123 → \033[2mno such PR\033[0m\tnoop'
+  run bash "$PICKER"
+  [ "$status" -eq 0 ]
+  # query-tab-names is fired upfront by print_worktrees; nothing else should run.
+  ! grep -v "action query-tab-names" "$ZELLIJ_RECORDER" | grep -q .
 }
 
 @test "dispatch clone-and-spawn: clones canonical, creates worktree, spawns tab" {

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -21,11 +21,9 @@ setup() {
   export ZELLIJ_RECORDER="$TMPROOT/zellij.log"
   : >"$ZELLIJ_RECORDER"
   export GH_USER=me
-  export PR_CACHE_DIR="$TMPROOT/pr_cache"
-  mkdir -p "$PR_CACHE_DIR"
   unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME
-  # Drop any GH_PR_VIEW_* leakage from prior tests.
-  while IFS= read -r var; do unset "$var"; done < <(compgen -e | grep '^GH_PR_VIEW_' || true)
+  # Drop any GH_PR_LIST_* leakage from prior tests.
+  while IFS= read -r var; do unset "$var"; done < <(compgen -e | grep '^GH_PR_LIST_' || true)
 }
 
 # Seed a worktree under $WORKTREE_ROOT/<org>/<repo>/<petname> so
@@ -186,79 +184,73 @@ mkcanonical() {
   grep -Fxq "action rename-tab hello (fresh-petname)" "$ZELLIJ_RECORDER"
 }
 
-# --- print_pr_rows: pr:<N> resolution ---
+# --- print_worktrees_with_prs: pr:<N>-tagged worktree rows ---
 
-@test "print_pr_rows: matching worktree emits spawn row" {
+@test "print_worktrees_with_prs: tags worktree with the branch's PR number" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+  export GH_PR_LIST_me_hello=$'feature/x\t174\nother-branch\t99'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees_with_prs' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
   local petdir="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
-  [ "$output" = "$(printf 'pr:123 → worktree:hello (kind-newt)\tspawn\t%s\thello (kind-newt)' "$petdir")" ]
+  [ "$output" = "$(printf 'worktree:hello (kind-newt) pr:174\tspawn\t%s\thello (kind-newt)' "$petdir")" ]
 }
 
-@test "print_pr_rows: matching worktree with open tab emits focus row" {
+@test "print_worktrees_with_prs: open tab dims the enriched row and dispatches focus" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
+  export GH_PR_LIST_me_hello=$'feature/x\t174'
   export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees_with_prs' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
-  [ "$output" = "$(printf 'pr:123 → \033[2mworktree:hello (kind-newt)\033[0m\tfocus\thello (kind-newt)')" ]
+  [ "$output" = "$(printf '\033[2mworktree:hello (kind-newt) pr:174\033[0m\tfocus\thello (kind-newt)')" ]
 }
 
-@test "print_pr_rows: no matching worktree emits noop hint with head ref" {
-  mkpr_worktree me hello kind-newt feature/unrelated
-  export GH_PR_VIEW_123=$'me\thello\tfeature/missing'
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+@test "print_worktrees_with_prs: omits worktrees with no PR for their branch" {
+  mkpr_worktree me hello kind-newt feature/no-pr
+  export GH_PR_LIST_me_hello=$'feature/x\t174'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees_with_prs' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"noop"* ]]
-  [[ "$output" == *"no matching worktree"* ]]
-  [[ "$output" == *"feature/missing"* ]]
+  [ -z "$output" ]
 }
 
-@test "print_pr_rows: ignores same-branch worktree in a different repo" {
-  # Branch name collision across repos: only the one under the PR's base repo
-  # should match. Without the scope guard this test would false-positive.
-  mkpr_worktree other hello kind-newt feature/x
-  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
-    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"noop"* ]]
-  [[ "$output" == *"no matching worktree"* ]]
-}
-
-@test "print_pr_rows: unknown PR emits noop error row" {
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 999' \
-    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"noop"* ]]
-  [[ "$output" == *"no such PR"* ]]
-}
-
-@test "print_pr_rows: caches resolution to avoid repeated gh calls" {
+@test "print_worktrees_with_prs: surfaces PRs across distinct repos" {
   mkpr_worktree me hello kind-newt feature/x
-  export GH_PR_VIEW_123=$'me\thello\tfeature/x'
-  # First call populates the cache.
-  bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123 >/dev/null' \
-    _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
-  # Drop the fixture so a re-fetch would fail with "no such PR".
-  unset GH_PR_VIEW_123
-  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_pr_rows 123' \
+  mkpr_worktree grafana k6 happy-mole feature/y
+  export GH_PR_LIST_me_hello=$'feature/x\t174'
+  export GH_PR_LIST_grafana_k6=$'feature/y\t88'
+  run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees_with_prs' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"worktree:hello (kind-newt)"* ]]
+  [[ "$output" == *"worktree:hello (kind-newt) pr:174"* ]]
+  [[ "$output" == *"worktree:grafana/k6 (happy-mole) pr:88"* ]]
 }
 
-@test "dispatch noop: no zellij action fires beyond the upfront query" {
-  export FZF_OUTPUT=$'pr:123 → \033[2mno such PR\033[0m\tnoop'
-  run bash "$PICKER"
+# --- --rows handler: pr:* gate and cache ---
+
+@test "--rows pr:174: lazily populates WORKTREE_PR_FILE and emits enriched rows" {
+  mkpr_worktree me hello kind-newt feature/x
+  export GH_PR_LIST_me_hello=$'feature/x\t174'
+  export WORKTREE_PR_FILE STATIC_FILE REMOTES_FILE
+  WORKTREE_PR_FILE="$TMPROOT/wt_pr"  # does not exist yet
+  STATIC_FILE="$TMPROOT/static.tsv"; : >"$STATIC_FILE"
+  REMOTES_FILE="$TMPROOT/remotes.tsv"; : >"$REMOTES_FILE"
+  ME=me run bash "$PICKER" --rows "pr:174"
   [ "$status" -eq 0 ]
-  # query-tab-names is fired upfront by print_worktrees; nothing else should run.
-  ! grep -v "action query-tab-names" "$ZELLIJ_RECORDER" | grep -q .
+  [[ "$output" == *"worktree:hello (kind-newt) pr:174"* ]]
+  [ -e "$WORKTREE_PR_FILE" ]  # gate file now exists; future reloads skip the fill
+}
+
+@test "--rows non-pr query: serves STATIC_FILE without touching WORKTREE_PR_FILE" {
+  export WORKTREE_PR_FILE STATIC_FILE REMOTES_FILE
+  WORKTREE_PR_FILE="$TMPROOT/wt_pr"
+  STATIC_FILE="$TMPROOT/static.tsv"; printf 'worktree:foo\tspawn\t/x\tfoo\n' >"$STATIC_FILE"
+  REMOTES_FILE="$TMPROOT/remotes.tsv"; : >"$REMOTES_FILE"
+  ME=me run bash "$PICKER" --rows "f"
+  [ "$status" -eq 0 ]
+  [ "$output" = "worktree:foo	spawn	/x	foo" ]
+  [ ! -e "$WORKTREE_PR_FILE" ]
 }
 
 @test "dispatch clone-and-spawn: clones canonical, creates worktree, spawns tab" {


### PR DESCRIPTION
## Summary

Typing `pr:174` into the repo picker filters to the worktree on PR 174's
head ref — across any of your repos, regardless of where the picker was
launched from. Each worktree row carries a `pr:<N>` suffix when its branch
has an associated PR, and fzf's own substring filter does the matching.

Closes #174.

## Gotchas

- First `pr:*` keystroke pays a one-shot fetch of `gh pr list --repo X`
  per distinct repo under `\$WORKTREE_ROOT`; subsequent keystrokes are
  free (cached for the picker's lifetime). Same pattern as REMOTES_FILE.
- Worktrees without an associated PR are omitted from the `pr:*` view
  on purpose — this mode is "find by PR", not a generic listing. They
  remain in the normal (non-`pr:`) STATIC_FILE rows.

## Verification

- `bats test/git_repo_picker.bats` — 20 tests, including new coverage for
  enrichment (tag/dim/omit/cross-repo) and the `--rows` lazy-fill gate
  (populates on `pr:*`, untouched otherwise).
- `pre-commit run --all-files` — shellcheck, shfmt, json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)