### PR TITLE
git-worktree-poi: match gh poi layout (drop counts, inline detail, banner)

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -302,6 +302,13 @@ colour_reason() {
 }
 
 # print_section <heading> <tsv-rows>
+#
+# Inline single-row layout. `gh poi`'s tree glyphs (`├─`/`└─`) carry meaning
+# because branches can have multiple PRs attached (cardinality ≥ 1). Here
+# every worktree produces exactly one detail row, so the tree is degenerate
+# decoration — collapse to one line per worktree and reclaim the vertical
+# space. Two passes: collect coloured halves and visible widths, then emit
+# with `[detail]` aligned per section.
 print_section() {
     local heading=$1 data=$2
     printf '%s%s%s\n' "$BOLD" "$heading" "$RESET"
@@ -309,14 +316,41 @@ print_section() {
         printf '  %s(none)%s\n\n' "$DIM" "$RESET"
         return
     fi
+
+    local -a left_coloured=() right_coloured=() left_widths=()
+    local verdict rel branch detail wt
+
     while IFS=$'\t' read -r verdict rel branch detail wt; do
-        local current=''
-        [[ "$wt" == "$CWD" ]] && current=" ${BOLD_YELLOW}(current)${RESET}"
-        printf '  %s%s%s%s\n' "$BOLD" "$rel" "$RESET" "$current"
+        # Head marker lives in col 1 (gh poi convention). BOLD_YELLOW carries
+        # the same "you are here" signal the old `(current)` suffix did, but
+        # in a fixed column instead of a varying line-end position.
+        local marker_col marker_plain
+        if [[ "$wt" == "$CWD" ]]; then
+            marker_col="${BOLD_YELLOW}*${RESET} "
+            marker_plain='* '
+        else
+            marker_col='  '
+            marker_plain='  '
+        fi
+
+        # Petname branches encode rel's slug (`<user>/worktree/<slug>` vs
+        # `<repo>/<slug>`), so the branch reads off rel. Show it only when
+        # the slug differs — manual renames, custom checkouts. Detached HEAD
+        # already surfaces in detail; suppress the redundant `(branch)`.
+        local branch_col='' branch_plain=''
+        if [[ "$branch" != '(detached HEAD)' && "${branch##*/}" != "${rel##*/}" ]]; then
+            branch_col=" ${DIM}(${branch})${RESET}"
+            branch_plain=" (${branch})"
+        fi
+
+        local left="${marker_col}${rel}${branch_col}"
+        local plain="${marker_plain}${rel}${branch_plain}"
+        left_coloured+=("$left")
+        left_widths+=("${#plain}")
 
         # Remove-row details are single atoms (some, like "no commits, no
-        # PR", contain commas). Keep-row details are comma-joined and
-        # need splitting.
+        # PR", contain commas). Keep-row details are comma-joined and need
+        # splitting before per-reason colouring.
         local coloured=''
         if [[ "$verdict" == remove ]]; then
             coloured=$(colour_reason "$detail")
@@ -330,10 +364,32 @@ print_section() {
             done
             coloured+="${sep}$(colour_reason "$rest")"
         fi
-
-        printf '    %s└─%s %s%s%s %s·%s %s\n' \
-            "$DIM" "$RESET" "$DIM" "$branch" "$RESET" "$DIM" "$RESET" "$coloured"
+        right_coloured+=("${DIM}[${RESET}${coloured}${DIM}]${RESET}")
     done <<<"$data"
+
+    # Soft cap on the alignment column. Without it, one row with a long
+    # divergent-branch paren (e.g. an auto-generated issue branch) drags
+    # every other row's `[detail]` 60+ chars to the right and off most
+    # terminals. Rows over the cap are excluded from the max and just land
+    # with a 3-space gutter — ragged-right, gh-poi style — while the rest
+    # of the section stays aligned.
+    local soft_cap=50 max_left=0 i w
+    for i in "${!left_widths[@]}"; do
+        w=${left_widths[i]}
+        ((w > soft_cap)) && continue
+        ((w > max_left)) && max_left=$w
+    done
+
+    local pad
+    for i in "${!left_coloured[@]}"; do
+        w=${left_widths[i]}
+        if ((w > max_left)); then
+            pad=3
+        else
+            pad=$((max_left - w + 3))
+        fi
+        printf '%s%*s%s\n' "${left_coloured[i]}" "$pad" '' "${right_coloured[i]}"
+    done
     printf '\n'
 }
 

--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -303,36 +303,37 @@ colour_reason() {
 
 # print_section <heading> <tsv-rows>
 print_section() {
-    local heading=$1 data=$2 count=0
-    [[ -n "$data" ]] && count=$(printf '%s\n' "$data" | wc -l)
-    printf '%s%s%s %s(%d)%s\n' "$BOLD" "$heading" "$RESET" "$DIM" "$count" "$RESET"
-    if [[ -n "$data" ]]; then
-        while IFS=$'\t' read -r verdict rel branch detail wt; do
-            local current=''
-            [[ "$wt" == "$CWD" ]] && current=" ${BOLD_YELLOW}(current)${RESET}"
-            printf '  %s%s%s%s\n' "$BOLD" "$rel" "$RESET" "$current"
-
-            # Remove-row details are single atoms (some, like "no commits, no
-            # PR", contain commas). Keep-row details are comma-joined and
-            # need splitting.
-            local coloured=''
-            if [[ "$verdict" == remove ]]; then
-                coloured=$(colour_reason "$detail")
-            else
-                local rest=$detail sep='' part
-                while [[ "$rest" == *", "* ]]; do
-                    part=${rest%%, *}
-                    coloured+="${sep}$(colour_reason "$part")"
-                    sep="${DIM}, ${RESET}"
-                    rest=${rest#*, }
-                done
-                coloured+="${sep}$(colour_reason "$rest")"
-            fi
-
-            printf '    %s└─%s %s%s%s %s·%s %s\n' \
-                "$DIM" "$RESET" "$DIM" "$branch" "$RESET" "$DIM" "$RESET" "$coloured"
-        done <<<"$data"
+    local heading=$1 data=$2
+    printf '%s%s%s\n' "$BOLD" "$heading" "$RESET"
+    if [[ -z "$data" ]]; then
+        printf '  %s(none)%s\n\n' "$DIM" "$RESET"
+        return
     fi
+    while IFS=$'\t' read -r verdict rel branch detail wt; do
+        local current=''
+        [[ "$wt" == "$CWD" ]] && current=" ${BOLD_YELLOW}(current)${RESET}"
+        printf '  %s%s%s%s\n' "$BOLD" "$rel" "$RESET" "$current"
+
+        # Remove-row details are single atoms (some, like "no commits, no
+        # PR", contain commas). Keep-row details are comma-joined and
+        # need splitting.
+        local coloured=''
+        if [[ "$verdict" == remove ]]; then
+            coloured=$(colour_reason "$detail")
+        else
+            local rest=$detail sep='' part
+            while [[ "$rest" == *", "* ]]; do
+                part=${rest%%, *}
+                coloured+="${sep}$(colour_reason "$part")"
+                sep="${DIM}, ${RESET}"
+                rest=${rest#*, }
+            done
+            coloured+="${sep}$(colour_reason "$rest")"
+        fi
+
+        printf '    %s└─%s %s%s%s %s·%s %s\n' \
+            "$DIM" "$RESET" "$DIM" "$branch" "$RESET" "$DIM" "$RESET" "$coloured"
+    done <<<"$data"
     printf '\n'
 }
 
@@ -370,6 +371,7 @@ remove_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="remove"')
 keep_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="keep"')
 
 if ((dry_run)); then
+    printf '%s== DRY RUN ==%s\n\n' "$BOLD" "$RESET"
     print_section 'Would remove' "$remove_rows"
     print_section 'Would keep' "$keep_rows"
     exit 0

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -200,6 +200,8 @@ STUB
   [[ "$output" == *"PR #1 merged"* ]]
   [[ "$output" == *"PR #2 open"* ]]
   [[ "$output" == *"no commits, no PR"* ]]
+  # Inline layout: no second-line tree glyph (cardinality is always 1).
+  [[ "$output" != *"└─"* ]]
 }
 
 # --- print_section: verdict-branched splitter ---
@@ -219,6 +221,46 @@ STUB
   [ "$status" -eq 0 ]
   [[ "$output" == *"Would remove"* ]]
   [[ "$output" == *$'\033[2m'"(none)"$'\033[0m'* ]]
+}
+
+@test "print_section: row whose wt matches CWD gets BOLD_YELLOW asterisk marker" {
+  run bash -c "
+    source '$POI'
+    BOLD_YELLOW=\$'\\033[1;33m' DIM=\$'\\033[2m' RESET=\$'\\033[0m'
+    CWD=/tmp/wt
+    row=\$(printf 'keep\\trepo/feature\\tu/worktree/feature\\tin-use\\t/tmp/wt')
+    print_section 'Kept' \"\$row\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'\033[1;33m'"*"$'\033[0m'* ]]
+}
+
+@test "print_section: branch matching rel slug is elided" {
+  # Petname worktrees encode rel's slug in the branch name, so the branch
+  # adds no information and would just inflate the rel column.
+  run bash -c "
+    source '$POI'
+    DIM=\$'\\033[2m' RESET=\$'\\033[0m'
+    CWD=/tmp
+    row=\$(printf 'keep\\trepo/feature\\tu/worktree/feature\\tin-use\\t/tmp/wt')
+    print_section 'Kept' \"\$row\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"u/worktree/feature"* ]]
+}
+
+@test "print_section: branch with divergent slug is shown" {
+  # Manual rename or custom checkout — branch can't be read off rel, so
+  # show it (dim) to preserve the identifier.
+  run bash -c "
+    source '$POI'
+    DIM=\$'\\033[2m' RESET=\$'\\033[0m'
+    CWD=/tmp
+    row=\$(printf 'keep\\trepo/feature\\tunrelated-name\\tin-use\\t/tmp/wt')
+    print_section 'Kept' \"\$row\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(unrelated-name)"* ]]
 }
 
 @test "print_section: remove-row detail with embedded comma stays one coloured atom" {

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -192,8 +192,11 @@ STUB
   invocations=$(wc -l <"$count_file")
   [ "$invocations" -eq 1 ]
 
-  [[ "$output" == *"Would remove (2)"* ]]
-  [[ "$output" == *"Would keep (1)"* ]]
+  [[ "$output" == *"== DRY RUN =="* ]]
+  [[ "$output" == *"Would remove"* ]]
+  [[ "$output" == *"Would keep"* ]]
+  [[ "$output" != *"Would remove (2)"* ]]
+  [[ "$output" != *"Would keep (1)"* ]]
   [[ "$output" == *"PR #1 merged"* ]]
   [[ "$output" == *"PR #2 open"* ]]
   [[ "$output" == *"no commits, no PR"* ]]
@@ -206,6 +209,18 @@ STUB
 # embedded comma; without the verdict branch the splitter would shred it into
 # two atoms and lose the green wrap. Forces colour vars on since bats stdout
 # isn't a tty.
+@test "print_section: empty data renders dimmed (none) placeholder" {
+  run bash -c "
+    source '$POI'
+    DIM=\$'\\033[2m' RESET=\$'\\033[0m'
+    CWD=/tmp
+    print_section 'Would remove' ''
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would remove"* ]]
+  [[ "$output" == *$'\033[2m'"(none)"$'\033[0m'* ]]
+}
+
 @test "print_section: remove-row detail with embedded comma stays one coloured atom" {
   run bash -c "
     source '$POI'


### PR DESCRIPTION
## Summary

Closes #151. Three small parity fixes to `gh poi`'s output grammar plus an
inline collapse of the two-line `└─` layout, halving the report's row count
without losing information.

Spec drift note: #151 prescribed `✔`/`✕` per row and a "single-line target"
that reads as a `gh poi` faithful description. Reading `gh poi`'s `main.go`
at v0.17.1 against the current post-#177 output, those marker bullets were
the spec's own drift — `gh poi` paints `✔`/`✕` only on its fetch/delete
progress messages (which this script doesn't have, since there's no async
spinner), and its row layout is the same two-line `branch` / `└─ #N url
author` shape we already match for the wrong reason. The justified gap is
elsewhere; this PR closes the parts that actually carry signal.

## Gotchas

- The inline collapse changes how a row is constructed, not what it says.
  Verdict, rel, branch, detail, wt still flow through `classify()`
  unchanged; everything new lives in `print_section`. If the layout reads
  wrong, look there first.
- The soft 50-char alignment cap is the only judgement call. Without it,
  one worktree on an auto-generated issue branch (the kind GitHub names
  `224-packagesfoundry-module-scaffolded-with-manifest-and-build-pipeline`)
  pushed every other row's `[detail]` 70+ chars to the right and off
  most terminals. Cap excludes outliers from the max; they spill
  ragged-right while the rest of the section stays aligned.
- `*` head marker drops the `(current)` suffix from #177 and moves the
  same signal to col 1 in `BOLD_YELLOW`. Skip if you want to keep the
  English-prose suffix.
- Bold-on-every-rel is gone. Bold now means "heading or banner"
  exclusively. If the report reads as less emphasised, that's intentional
  — bold on every row in a list was inflation.

## Verification

- `bats test/git_worktree_poi.bats` — 15/15 (3 new: head marker, branch
  elision, branch shown when divergent; one new assertion in the existing
  batch-fetch test guards against tree-glyph regression).
- `pre-commit run --files <changed>` clean.
- Ran `bash dot_local/bin/executable_git-worktree-poi --dry-run` against
  this host's real worktree root (11 keeps + 4 removes across 5 repos);
  confirmed alignment, outlier spill, head marker, branch elision, and
  per-reason colours all render as designed.
- Read `gh poi` v0.17.1 `main.go` directly to validate the parity claims
  rather than relying on #151's spec text.