### PR TITLE
CLAUDE.md: forbid invented acronyms in writing

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -20,6 +20,10 @@ A per-repo `CLAUDE.md` overrides anything here.
 - End multi-step work with a 1-2 line summary naming any non-obvious
   choices made. "Revisit if you don't like it" doesn't substitute for
   surfacing the choice.
+- Avoid invented or domain-specific acronyms. Spell out terms like
+  "acceptance criteria" rather than introducing "AC". Only acronyms
+  unambiguous to a general technical reader (API, URL, CLI, PR, CI)
+  are safe.
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary

Adds a Communication bullet directing Claude to spell out terms like "acceptance criteria" instead of inventing in-context acronyms like "AC". A short whitelist (API, URL, CLI, PR, CI) covers acronyms unambiguous to a general technical reader so the rule applies without per-term judgment.