### PR TITLE
zellij: correct btime workaround attribution

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -8,12 +8,11 @@
 // anyway. The pair layout adds a zjstatus line for PR-aware status; default
 // stays minimal.
 
-// Sessions never serialize. On filesystems where btime isn't exposed
-// (Crostini's ext4 path through 9p), the resurrection-file scan logs
-// "creation time is not available" twice a second per saved session and
-// eventually saturates the screen/plugin threads — see zellij-org/zellij#4165
-// and PR #5057. Until the fix lands upstream, keep the cache empty so the
-// loop has nothing to iterate.
+// Sessions never serialize. Before Rust 1.87, std::fs::Metadata::created()
+// returns "creation time is not available" on Linux even on filesystems
+// that store btime — zellij's resurrection scan logs the error twice a
+// second per saved session and eventually saturates the screen/plugin
+// threads (zellij-org/zellij#4165, PR #5057). Empty cache → empty loop.
 session_serialization false
 
 plugins {


### PR DESCRIPTION
## Summary

The comment explaining `session_serialization false` in `config.kdl` now
correctly attributes the resurrection-file log spam to pre-Rust-1.87 stdlib
behaviour on Linux, replacing the fabricated "Crostini ext4 via 9p" framing.
Comment-only change; behaviour unchanged.

## Gotchas

Whether the workaround itself still earns its keep on the current
rustc-1.89-built zellij 0.43.1 pin is open — tracked in #199 (verify on
current pin → drop), not addressed here.

## Verification

- Ran `script/checks/zellij-config`, KDL parses clean.
- Ran `pre-commit run --files dot_config/zellij/config.kdl`, applicable
  hooks pass.