### PR TITLE
Add `just check` aggregator for local sensors

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,6 +1,7 @@
 .lycheecache
 CLAUDE.md
 docs
+justfile
 LICENSE
 README.md
 lychee.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,13 @@ effect on `apply` until committed and pulled into the apply clone. Use
 
 ## Sensors
 
-CI is authoritative. Run locally before claiming done:
+CI is authoritative. Run all sensors locally before claiming done:
+
+```bash
+just check                     # runs every sensor below, fail-fast
+```
+
+Each runs in its own CI workflow and can be invoked alone:
 
 ```bash
 pre-commit run --all-files     # shellcheck, shfmt, check-json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ effect on `apply` until committed and pulled into the apply clone. Use
 CI is authoritative. Run all sensors locally before claiming done:
 
 ```bash
-just check                     # runs every sensor below, fail-fast
+just check                     # runs every sensor below, reports all failures
 ```
 
 Each runs in its own CI workflow and can be invoked alone:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# Local sensor entrypoint. CI runs each of these in its own workflow;
+# `just check` is the single command to run them all before claiming done.
+
+# List available recipes.
+default:
+    @just --list
+
+# Run every local sensor (fail-fast, in CLAUDE.md order).
+check: check-pre-commit check-bats check-zellij check-chezmoi
+
+# Lints and formatters across all files.
+check-pre-commit:
+    pre-commit run --all-files
+
+# Unit tests.
+check-bats:
+    bats test/
+
+# Zellij KDL validation (needs zellij on PATH).
+check-zellij:
+    script/checks/zellij-config
+
+# Apply round-trip (needs chezmoi + age on PATH).
+check-chezmoi:
+    script/checks/chezmoi-apply

--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
-# Local sensor entrypoint. CI runs each of these in its own workflow;
-# `just check` is the single command to run them all before claiming done.
+# Local sensor entrypoint: the fast pre-claim sweep. CI is the source of
+# truth — each sensor also runs in its own workflow, so a stale list here
+# can only cause a local false-pass that CI then catches, never a bad
+# merge. lychee (link-checking) runs in CI only; it's not a pre-claim
+# sensor and needs its own binary.
 
 # List available recipes.
 default:

--- a/justfile
+++ b/justfile
@@ -5,8 +5,20 @@
 default:
     @just --list
 
-# Run every local sensor (fail-fast, in CLAUDE.md order).
-check: check-pre-commit check-bats check-zellij check-chezmoi
+# Claude's primary use is a post-change sanity sweep, so this reports
+# every sensor's result in one run rather than stopping at the first
+# failure — full signal lets it batch fixes instead of finding them
+# serially across re-runs.
+
+# Run every local sensor; report all failures, not just the first.
+check:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
+    for c in check-pre-commit check-bats check-zellij check-chezmoi; do
+      just "$c" || rc=1
+    done
+    exit "$rc"
 
 # Lints and formatters across all files.
 check-pre-commit:


### PR DESCRIPTION
## Summary

`just check` now runs all four pre-claim sensors in one command and reports every failure (not just the first); each is also exposed as `check-<name>` to run alone. Removes the "did I remember all four" friction before claiming work done. CI stays the source of truth — the justfile is a fast local mirror, and its header records that a stale recipe list can only cause a local false-pass that CI catches, never a bad merge.

## Gotchas

- The run-all (vs fail-fast) default is tuned for the primary caller being Claude doing a post-change sweep: one edit often trips multiple sensors, so full signal in one run lets it batch fixes rather than rediscover them serially across re-runs (each paying for the slow `chezmoi-apply` round-trip). Sanity-check you agree that's the right default.
- CI is deliberately *not* routed through `just`: each workflow carries env setup and dedicated actions (pre-commit/bats caching, bats' api.github.com rate-limit handling) a `just` layer would displace. Drift is bounded to the 4-name enumeration — the check logic is already single-sourced in `script/checks/*` and the pre-commit/test config — and self-heals at the PR boundary since CI is authoritative.
- `lychee` (link-checking) is intentionally CI-only, noted in the justfile header: not a pre-claim sensor and needs its own binary.
- `justfile` is in `.chezmoiignore` so it isn't applied to `$HOME` — repo-local, not a deployed dotfile.

## Verification

- `just --list` parses with clean descriptions; `chezmoi diff --source-path .` confirms `justfile` is not in the apply set.
- Confirmed the aggregation runs all sensors and exits non-zero on any failure (the loop continues past a failing recipe and propagates `rc=1`).
- `pre-commit run --all-files` passes (shellcheck, shfmt, check-json, detect-private-key, vale, renovate validator).