### PR TITLE
Pin zellaude to local build with CLI-pipe unblock fix

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -16,7 +16,12 @@
 session_serialization false
 
 plugins {
-    zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
+    // TEMP (alunduil-chezmoi#211): local build carrying the CLI-pipe unblock
+    // fix. Stock zellaude never unblocks CLI pipes, so each Claude-hook
+    // `zellij pipe` leaks a server connection until the server deadlocks.
+    // Verifying over a week-long session that the patched build holds; revert
+    // to a pinned release URL once the fix is upstreamed and tagged.
+    zellaude location="file:/home/alunduil/.local/share/zellij/plugins/zellaude.wasm"
     zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.22.0/zjstatus.wasm"
 }
 


### PR DESCRIPTION
## Summary

zellaude now runs from a local build that unblocks CLI pipes, so the zellij server stops leaking a `server_listener`/`server_router` thread pair per Claude-hook `zellij pipe` — the accumulation that drove it to ~1k threads, a `futex_wait` deadlock, and the recurring freeze. This is a temporary verification pin, not the permanent fix.

Root cause and evidence in #211; the fix is a one-liner in zellaude's `pipe()` (unblock `PipeSource::Cli` messages, mirroring zellij's own strider/fixture plugins).

## Gotchas

- **Merge to make it stick.** `chezmoi apply` reads the apply clone on `main`; until this lands there, any routine apply reverts zellaude to the release URL mid-test.
- **Host-specific.** The `file:` location is an absolute path to a local build artifact (`~/.local/share/zellij/plugins/zellaude.wasm`, not in this repo). Do **not** `chezmoi apply` on another host during the test — zellaude would fail to load there. Revert before this pin reaches any other machine.
- **Revert plan.** Once the fix is upstreamed and tagged, follow-up PR repoints `location` at a pinned release URL.

## Verification

- Built the patched plugin against `zellij-tile 0.43.1` (matches the pinned zellij); artifact loads as `zellaude.wasm`.
- `script/checks/zellij-config` passes with the new `file:` location (rc=0).
- Acceptance is the week-long session: server thread count stays bounded (tens), not climbing into the hundreds — `for p in \$(pgrep -x zellij); do echo \"\$p \$(ls /proc/\$p/task|wc -l)\"; done`.