### PR TITLE
Track rust-analyzer LSP plugin in Claude settings

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -276,5 +276,8 @@
       "Read(/home/alunduil/.ssh/**)"
     ]
   },
-  "theme": "auto"
+  "theme": "auto",
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
+  }
 }


### PR DESCRIPTION
## Summary

`rust-analyzer-lsp` stays enabled across `chezmoi apply` now. It was enabled in the live `~/.claude/settings.json` via the plugin manager but absent from the chezmoi source, so the next apply would have silently disabled it. This ingests the `enabledPlugins` block into the source.

## Verification

- Confirmed source and live `settings.json` are now byte-identical after key-order normalization (`diff <(jq -S . source) <(jq -S . live)` → no output).
- `jq empty` validates the source JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)