### PR TITLE
Add NAME targeting and --force to git-worktree-poi

### DIFF
--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -7,7 +7,7 @@ set -euo pipefail
 # description, then an aligned Options block.
 usage() {
     cat <<'EOF'
-Usage: git worktree-poi [OPTIONS]
+Usage: git worktree-poi [OPTIONS] [NAME]
 
   gh-poi for local worktrees: removes worktrees whose work has already
   merged or been closed upstream, plus empty worktrees with no PR (misclicks
@@ -18,7 +18,13 @@ Usage: git worktree-poi [OPTIONS]
   tmux, dev server, ...) is annotated `in-use` and never removed. Detection
   reads /proc/*/cwd, so it generalises beyond zellij's CLI surface.
 
+  NAME scopes the run to a single worktree, matched by petname (the leaf
+  dir), <repo>/<petname>, or absolute path. --force then removes it even
+  when it would otherwise be kept (in-use, dirty, unpushed, open PR),
+  force-deleting its branch too. Safe to run from inside the target.
+
 Options:
+  -f, --force    Remove NAME even if classified keep. Requires NAME.
   -n, --dry-run  Preview without removing.
   -h, --help     Show this message and exit.
 EOF
@@ -41,6 +47,11 @@ fi
 die() { printf 'git-worktree-poi: %s\n' "$*" >&2; exit 1; }
 
 WORKTREE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/git-worktrees"
+
+# Set by resolve_target when a NAME is given on the command line; empty means
+# "operate on every worktree". candidate_worktrees() narrows the PR-state pass
+# and classification to this single path when set.
+TARGET_WT=
 
 # Process cwds whose target lives under $WORKTREE_ROOT. Populated once before
 # classification; every classify() call consults this set via is_in_use.
@@ -168,6 +179,50 @@ walk_worktrees() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
+# candidate_worktrees: the worktree set every pass operates on. Just the
+# resolved target when a NAME narrowed the run, else the full walk. Routing
+# both the PR-state pass and classification through this keeps a NAME run from
+# querying GitHub for unrelated repos.
+candidate_worktrees() {
+    if [[ -n "$TARGET_WT" ]]; then
+        printf '%s\n' "$TARGET_WT"
+    else
+        walk_worktrees
+    fi
+}
+
+# resolve_target <name>: set TARGET_WT to the single worktree NAME identifies,
+# matched by absolute path, <repo>/<petname>, or bare petname (leaf dir). Dies
+# with the candidate list when a bare name is ambiguous across repos, or when
+# nothing matches.
+resolve_target() {
+    local name=$1 wt rel
+    local -a matches=()
+    while IFS= read -r wt; do
+        rel="${wt#"$WORKTREE_ROOT"/}"
+        rel="${rel#*/}"
+        if [[ "$wt" == "$name" || "$rel" == "$name" || "${wt##*/}" == "$name" ]]; then
+            matches+=("$wt")
+        fi
+    done < <(walk_worktrees)
+
+    ((${#matches[@]})) || die "no worktree matches '$name' under $WORKTREE_ROOT"
+
+    if ((${#matches[@]} > 1)); then
+        {
+            printf "git-worktree-poi: '%s' matches multiple worktrees:\n" "$name"
+            for wt in "${matches[@]}"; do
+                rel="${wt#"$WORKTREE_ROOT"/}"
+                printf '  %s\n' "${rel#*/}"
+            done
+            printf 'disambiguate with <repo>/<name>\n'
+        } >&2
+        exit 1
+    fi
+
+    TARGET_WT=${matches[0]}
+}
+
 # batch_fetch_pr_states: walk every worktree under $WORKTREE_ROOT, group by
 # canonical (one canonical = one GitHub repo), and dispatch one GraphQL query
 # per group. Detached-HEAD worktrees are skipped — classify() leaves their
@@ -181,7 +236,7 @@ batch_fetch_pr_states() {
         canonical=${canonical%/.git}
         branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null) || continue
         by_canonical[$canonical]+="$wt"$'\t'"$branch"$'\n'
-    done < <(walk_worktrees)
+    done < <(candidate_worktrees)
 
     for canonical in "${!by_canonical[@]}"; do
         fetch_pr_states_for_repo "$canonical" "${by_canonical[$canonical]}"
@@ -299,7 +354,7 @@ gather() {
     local wt
     while IFS= read -r wt; do
         classify "$wt"
-    done < <(walk_worktrees)
+    done < <(candidate_worktrees)
 }
 
 # colour_reason <reason>: emit one comma-joined reason coloured by category.
@@ -428,19 +483,43 @@ for cmd in git gh; do
 done
 
 dry_run=0
-case "${1:-}" in
-    -n | --dry-run) dry_run=1 ;;
-    -h | --help)
-        usage
-        exit 0
-        ;;
-    "") ;;
-    *) die "unknown argument: $1" ;;
-esac
+force=0
+target_name=
+while (($#)); do
+    case "$1" in
+        -n | --dry-run) dry_run=1 ;;
+        -f | --force) force=1 ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*) die "unknown option: $1" ;;
+        *)
+            [[ -z "$target_name" ]] || die "unexpected extra argument: $1"
+            target_name=$1
+            ;;
+    esac
+    shift
+done
+while (($#)); do
+    [[ -z "$target_name" ]] || die "unexpected extra argument: $1"
+    target_name=$1
+    shift
+done
+
+if ((force)) && [[ -z "$target_name" ]]; then
+    die "--force requires a worktree NAME"
+fi
 
 [[ -d "$WORKTREE_ROOT" ]] || die "no worktrees under $WORKTREE_ROOT"
 
 CWD="$(pwd -P)"
+
+[[ -n "$target_name" ]] && resolve_target "$target_name"
 
 mapfile -t IN_USE_CWDS < <(collect_in_use_cwds)
 
@@ -452,36 +531,56 @@ rows=$(gather)
 remove_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="remove"')
 keep_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="keep"')
 
+# --force overrides the keep verdict for the scoped target: act on every
+# gathered row (the single resolved worktree) and escalate git to remove
+# dirty/in-use trees and delete unmerged branches. Without it, only the
+# classifier's remove verdicts act, and -d/worktree-remove stay gentle.
+if ((force)); then
+    act_rows=$rows
+    del_flag=-D
+    remove_force=(--force)
+else
+    act_rows=$remove_rows
+    del_flag=-d
+    remove_force=()
+fi
+
 if ((dry_run)); then
     printf '%s== DRY RUN ==%s\n\n' "$BOLD" "$RESET"
-    print_section 'Would remove' "$remove_rows"
-    print_section 'Would keep' "$keep_rows"
+    if ((force)); then
+        print_section 'Would remove (forced)' "$act_rows"
+    else
+        print_section 'Would remove' "$remove_rows"
+        print_section 'Would keep' "$keep_rows"
+    fi
     exit 0
 fi
 
 removed_rows=""
 failed_rows=""
-if [[ -n "$remove_rows" ]]; then
+if [[ -n "$act_rows" ]]; then
     while IFS=$'\t' read -r verdict rel branch detail wt; do
         # Ask git for the canonical's path rather than reconstructing it from
         # $wt: canonicals don't always live at $HOME/<org>/<repo> (own-org
         # repos live at $HOME/<repo>, and the picker honors origin-URL hints
         # for arbitrary checkout locations). --git-common-dir resolves through
         # the worktree's .git file regardless. Capture before removal — once
-        # $wt is gone, branch -d needs somewhere else to operate from.
+        # $wt is gone, branch deletion needs somewhere else to operate from.
         canonical=$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
         canonical=${canonical%/.git}
         row=$(printf '%s\t%s\t%s\t%s\t%s' "$verdict" "$rel" "$branch" "$detail" "$wt")
-        if git -C "$wt" worktree remove "$wt" 2>/dev/null; then
-            # branch -d is best-effort: refuses unmerged, which we don't force
-            # since the safety gate already required MERGED|CLOSED upstream
+        if git -C "$wt" worktree remove "${remove_force[@]}" "$wt" 2>/dev/null; then
+            # Branch deletion is best-effort. Unforced, -d refuses unmerged —
+            # but the remove gate already required MERGED|CLOSED upstream, so
+            # that never bites. Forced, -D deletes regardless, matching the
+            # caller's explicit intent to discard the worktree wholesale.
             [[ "$branch" != '(detached HEAD)' && -n "$canonical" ]] \
-                && git -C "$canonical" branch -d "$branch" 2>/dev/null || true
+                && git -C "$canonical" branch "$del_flag" "$branch" 2>/dev/null || true
             removed_rows+="${row}"$'\n'
         else
             failed_rows+="${row}"$'\n'
         fi
-    done <<<"$remove_rows"
+    done <<<"$act_rows"
 fi
 removed_rows=${removed_rows%$'\n'}
 failed_rows=${failed_rows%$'\n'}
@@ -489,4 +588,6 @@ failed_rows=${failed_rows%$'\n'}
 print_section 'Removed' "$removed_rows"
 # shellcheck disable=SC2016 # backticks in heading are literal display text
 [[ -n "$failed_rows" ]] && print_section 'Failed (use `git worktree remove --force` if intended)' "$failed_rows"
-print_section 'Kept' "$keep_rows"
+# Forced runs target one worktree and just removed it; a "Kept" section would
+# only ever echo the verdict we deliberately overrode.
+((force)) || print_section 'Kept' "$keep_rows"

--- a/dot_local/bin/executable_git-worktree-poi
+++ b/dot_local/bin/executable_git-worktree-poi
@@ -7,7 +7,7 @@ set -euo pipefail
 # description, then an aligned Options block.
 usage() {
     cat <<'EOF'
-Usage: git worktree-poi [OPTIONS] [NAME]
+Usage: git worktree-poi [OPTIONS] [NAME...]
 
   gh-poi for local worktrees: removes worktrees whose work has already
   merged or been closed upstream, plus empty worktrees with no PR (misclicks
@@ -18,13 +18,15 @@ Usage: git worktree-poi [OPTIONS] [NAME]
   tmux, dev server, ...) is annotated `in-use` and never removed. Detection
   reads /proc/*/cwd, so it generalises beyond zellij's CLI surface.
 
-  NAME scopes the run to a single worktree, matched by petname (the leaf
-  dir), <repo>/<petname>, or absolute path. --force then removes it even
-  when it would otherwise be kept (in-use, dirty, unpushed, open PR),
-  force-deleting its branch too. Safe to run from inside the target.
+  NAME args scope the run to those worktrees, each matched by petname (the
+  leaf dir), <repo>/<petname>, or absolute path. --force then removes them
+  even when they would otherwise be kept (in-use, dirty, unpushed, open PR),
+  force-deleting their branches too. Names that don't resolve are reported
+  after the run; the rest still act. Safe to run from inside a target.
 
 Options:
-  -f, --force    Remove NAME even if classified keep. Requires NAME.
+  -f, --force    Remove the named worktrees even if classified keep.
+                 Requires at least one NAME.
   -n, --dry-run  Preview without removing.
   -h, --help     Show this message and exit.
 EOF
@@ -46,12 +48,27 @@ fi
 
 die() { printf 'git-worktree-poi: %s\n' "$*" >&2; exit 1; }
 
+# report_resolve_errors: emit accumulated NAME-resolution failures to stderr
+# and exit 1. No-op (returns) when none — so callers can invoke it
+# unconditionally at each exit point. Exit status flags the partial run even
+# when some worktrees were removed successfully.
+report_resolve_errors() {
+    ((${#resolve_errors[@]})) || return 0
+    local e
+    for e in "${resolve_errors[@]}"; do
+        printf 'git-worktree-poi: %s\n' "$e" >&2
+    done
+    exit 1
+}
+
 WORKTREE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/git-worktrees"
 
-# Set by resolve_target when a NAME is given on the command line; empty means
-# "operate on every worktree". candidate_worktrees() narrows the PR-state pass
-# and classification to this single path when set.
-TARGET_WT=
+# Worktrees the NAME args resolved to; empty means "operate on every
+# worktree". candidate_worktrees() narrows the PR-state pass and
+# classification to this set. resolve_errors collects per-name resolution
+# failures so a batch reports them after acting on what did resolve.
+declare -a TARGET_WTS=()
+declare -a resolve_errors=()
 
 # Process cwds whose target lives under $WORKTREE_ROOT. Populated once before
 # classification; every classify() call consults this set via is_in_use.
@@ -179,22 +196,23 @@ walk_worktrees() {
     done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
 }
 
-# candidate_worktrees: the worktree set every pass operates on. Just the
-# resolved target when a NAME narrowed the run, else the full walk. Routing
-# both the PR-state pass and classification through this keeps a NAME run from
+# candidate_worktrees: the worktree set every pass operates on. The resolved
+# targets when NAME args narrowed the run, else the full walk. Routing both
+# the PR-state pass and classification through this keeps a NAME run from
 # querying GitHub for unrelated repos.
 candidate_worktrees() {
-    if [[ -n "$TARGET_WT" ]]; then
-        printf '%s\n' "$TARGET_WT"
+    if ((${#TARGET_WTS[@]})); then
+        printf '%s\n' "${TARGET_WTS[@]}"
     else
         walk_worktrees
     fi
 }
 
-# resolve_target <name>: set TARGET_WT to the single worktree NAME identifies,
-# matched by absolute path, <repo>/<petname>, or bare petname (leaf dir). Dies
-# with the candidate list when a bare name is ambiguous across repos, or when
-# nothing matches.
+# resolve_target <name>: print the absolute path of the single worktree NAME
+# identifies, matched by absolute path, <repo>/<petname>, or bare petname
+# (leaf dir). On no match or a bare name ambiguous across repos, print a
+# diagnostic to stdout and return non-zero — the caller collects these so a
+# multi-name batch can report all failures after acting on what resolved.
 resolve_target() {
     local name=$1 wt rel
     local -a matches=()
@@ -206,21 +224,22 @@ resolve_target() {
         fi
     done < <(walk_worktrees)
 
-    ((${#matches[@]})) || die "no worktree matches '$name' under $WORKTREE_ROOT"
-
-    if ((${#matches[@]} > 1)); then
-        {
-            printf "git-worktree-poi: '%s' matches multiple worktrees:\n" "$name"
-            for wt in "${matches[@]}"; do
-                rel="${wt#"$WORKTREE_ROOT"/}"
-                printf '  %s\n' "${rel#*/}"
-            done
-            printf 'disambiguate with <repo>/<name>\n'
-        } >&2
-        exit 1
+    if ((${#matches[@]} == 0)); then
+        printf "no worktree matches '%s'\n" "$name"
+        return 1
     fi
 
-    TARGET_WT=${matches[0]}
+    if ((${#matches[@]} > 1)); then
+        printf "'%s' matches multiple worktrees:\n" "$name"
+        for wt in "${matches[@]}"; do
+            rel="${wt#"$WORKTREE_ROOT"/}"
+            printf '  %s\n' "${rel#*/}"
+        done
+        printf 'disambiguate with <repo>/<name>\n'
+        return 1
+    fi
+
+    printf '%s\n' "${matches[0]}"
 }
 
 # batch_fetch_pr_states: walk every worktree under $WORKTREE_ROOT, group by
@@ -484,7 +503,7 @@ done
 
 dry_run=0
 force=0
-target_name=
+declare -a target_names=()
 while (($#)); do
     case "$1" in
         -n | --dry-run) dry_run=1 ;;
@@ -498,28 +517,46 @@ while (($#)); do
             break
             ;;
         -*) die "unknown option: $1" ;;
-        *)
-            [[ -z "$target_name" ]] || die "unexpected extra argument: $1"
-            target_name=$1
-            ;;
+        *) target_names+=("$1") ;;
     esac
     shift
 done
 while (($#)); do
-    [[ -z "$target_name" ]] || die "unexpected extra argument: $1"
-    target_name=$1
+    target_names+=("$1")
     shift
 done
 
-if ((force)) && [[ -z "$target_name" ]]; then
-    die "--force requires a worktree NAME"
+if ((force)) && ((${#target_names[@]} == 0)); then
+    die "--force requires at least one worktree NAME"
 fi
 
 [[ -d "$WORKTREE_ROOT" ]] || die "no worktrees under $WORKTREE_ROOT"
 
 CWD="$(pwd -P)"
 
-[[ -n "$target_name" ]] && resolve_target "$target_name"
+# Resolve each NAME independently, collecting failures rather than aborting:
+# act on what resolved, report the rest at the end. Dedup so the same worktree
+# named twice (or via two spellings) is removed once.
+if ((${#target_names[@]})); then
+    for name in "${target_names[@]}"; do
+        if resolved=$(resolve_target "$name"); then
+            dup=0
+            for existing in "${TARGET_WTS[@]}"; do
+                [[ "$existing" == "$resolved" ]] && {
+                    dup=1
+                    break
+                }
+            done
+            ((dup)) || TARGET_WTS+=("$resolved")
+        else
+            resolve_errors+=("$resolved")
+        fi
+    done
+    # Every NAME failed → nothing to scope to. Bailing here is load-bearing:
+    # an empty TARGET_WTS makes candidate_worktrees fall back to the full
+    # walk, which under --force would remove every worktree.
+    ((${#TARGET_WTS[@]})) || report_resolve_errors
+fi
 
 mapfile -t IN_USE_CWDS < <(collect_in_use_cwds)
 
@@ -531,10 +568,10 @@ rows=$(gather)
 remove_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="remove"')
 keep_rows=$(printf '%s\n' "$rows" | awk -F'\t' '$1=="keep"')
 
-# --force overrides the keep verdict for the scoped target: act on every
-# gathered row (the single resolved worktree) and escalate git to remove
-# dirty/in-use trees and delete unmerged branches. Without it, only the
-# classifier's remove verdicts act, and -d/worktree-remove stay gentle.
+# --force overrides the keep verdict for the scoped targets: act on every
+# gathered row (the resolved worktrees) and escalate git to remove dirty/
+# in-use trees and delete unmerged branches. Without it, only the classifier's
+# remove verdicts act, and -d/worktree-remove stay gentle.
 if ((force)); then
     act_rows=$rows
     del_flag=-D
@@ -553,6 +590,7 @@ if ((dry_run)); then
         print_section 'Would remove' "$remove_rows"
         print_section 'Would keep' "$keep_rows"
     fi
+    report_resolve_errors
     exit 0
 fi
 
@@ -588,6 +626,8 @@ failed_rows=${failed_rows%$'\n'}
 print_section 'Removed' "$removed_rows"
 # shellcheck disable=SC2016 # backticks in heading are literal display text
 [[ -n "$failed_rows" ]] && print_section 'Failed (use `git worktree remove --force` if intended)' "$failed_rows"
-# Forced runs target one worktree and just removed it; a "Kept" section would
-# only ever echo the verdict we deliberately overrode.
+# Forced runs target named worktrees and just removed them; a "Kept" section
+# would only ever echo the verdict we deliberately overrode.
 ((force)) || print_section 'Kept' "$keep_rows"
+
+report_resolve_errors

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -275,3 +275,96 @@ STUB
   [ "$status" -eq 0 ]
   [[ "$output" == *$'\033[32m'"no commits, no PR"$'\033[0m'* ]]
 }
+
+# --- resolve_target: NAME → single worktree ---
+
+# Bare directories with a .git file are enough: walk_worktrees and
+# resolve_target only test names, never invoke git on the path.
+_mk_stub_wt() {
+  local p="$XDG_DATA_HOME/git-worktrees/$1"
+  mkdir -p "$p"
+  : >"$p/.git"
+}
+
+@test "resolve_target: bare petname across two repos errors with candidates" {
+  _mk_stub_wt me/alpha/dup
+  _mk_stub_wt me/beta/dup
+  run bash -c 'source "$1"; resolve_target dup' _ "$POI"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"alpha/dup"* ]]
+  [[ "$output" == *"beta/dup"* ]]
+}
+
+@test "resolve_target: <repo>/<name> disambiguates the collision" {
+  _mk_stub_wt me/alpha/dup
+  _mk_stub_wt me/beta/dup
+  run bash -c 'source "$1"; resolve_target alpha/dup; printf %s "$TARGET_WT"' _ "$POI"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/me/alpha/dup" ]]
+}
+
+@test "resolve_target: unique petname resolves to its path" {
+  _mk_stub_wt me/repo/solo
+  run bash -c 'source "$1"; resolve_target solo; printf %s "$TARGET_WT"' _ "$POI"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/me/repo/solo" ]]
+}
+
+@test "resolve_target: no match errors" {
+  _mk_stub_wt me/repo/solo
+  run bash -c 'source "$1"; resolve_target nope' _ "$POI"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no worktree matches 'nope'"* ]]
+}
+
+# --- --force: override the keep verdict for a named worktree ---
+
+# Real gh is absent in CI (other tests stub it), so the binary-presence check
+# at the top of the script needs something on PATH. The forced paths below
+# classify UNKNOWN — origin is a file:// bare repo, so github_slug bails and
+# no gh call is made — leaving this stub uninvoked.
+_stub_gh_absent() {
+  local d="$TMPROOT/stubs"
+  mkdir -p "$d"
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$d/gh"
+  chmod +x "$d/gh"
+  printf '%s' "$d"
+}
+
+@test "force without NAME is rejected" {
+  run bash "$POI" -f
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--force requires a worktree NAME"* ]]
+}
+
+@test "force removes a kept worktree and force-deletes its branch" {
+  _mkworktree  # non-GitHub origin → PR state UNKNOWN → classifier keeps it
+  local stub; stub=$(_stub_gh_absent)
+
+  # Without force the target is kept, not removed.
+  PATH="$stub:$PATH" run bash "$POI" -n feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would keep"* ]]
+  [[ "$output" == *"PR state unknown"* ]]
+  [ -e "$WT" ]
+
+  # With force it goes, branch and all.
+  PATH="$stub:$PATH" run bash "$POI" -f feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Removed"* ]]
+  [ ! -e "$WT" ]
+  run git -C "$HOME/me/repo" rev-parse --verify --quiet refs/heads/feature
+  [ "$status" -ne 0 ]
+}
+
+@test "NAME scopes the run to the matched worktree" {
+  _mkworktree
+  git -C "$HOME/me/repo" worktree add -B other \
+    "$XDG_DATA_HOME/git-worktrees/me/repo/other" >/dev/null 2>&1
+  local stub; stub=$(_stub_gh_absent)
+
+  PATH="$stub:$PATH" run bash "$POI" -n feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"repo/feature"* ]]
+  [[ "$output" != *"repo/other"* ]]
+}

--- a/test/git_worktree_poi.bats
+++ b/test/git_worktree_poi.bats
@@ -276,7 +276,7 @@ STUB
   [[ "$output" == *$'\033[32m'"no commits, no PR"$'\033[0m'* ]]
 }
 
-# --- resolve_target: NAME → single worktree ---
+# --- resolve_target: NAME → worktree path ---
 
 # Bare directories with a .git file are enough: walk_worktrees and
 # resolve_target only test names, never invoke git on the path.
@@ -298,26 +298,26 @@ _mk_stub_wt() {
 @test "resolve_target: <repo>/<name> disambiguates the collision" {
   _mk_stub_wt me/alpha/dup
   _mk_stub_wt me/beta/dup
-  run bash -c 'source "$1"; resolve_target alpha/dup; printf %s "$TARGET_WT"' _ "$POI"
+  run bash -c 'source "$1"; resolve_target alpha/dup' _ "$POI"
   [ "$status" -eq 0 ]
   [[ "$output" == *"/me/alpha/dup" ]]
 }
 
 @test "resolve_target: unique petname resolves to its path" {
   _mk_stub_wt me/repo/solo
-  run bash -c 'source "$1"; resolve_target solo; printf %s "$TARGET_WT"' _ "$POI"
+  run bash -c 'source "$1"; resolve_target solo' _ "$POI"
   [ "$status" -eq 0 ]
   [[ "$output" == *"/me/repo/solo" ]]
 }
 
-@test "resolve_target: no match errors" {
+@test "resolve_target: no match returns nonzero with a diagnostic" {
   _mk_stub_wt me/repo/solo
   run bash -c 'source "$1"; resolve_target nope' _ "$POI"
   [ "$status" -ne 0 ]
   [[ "$output" == *"no worktree matches 'nope'"* ]]
 }
 
-# --- --force: override the keep verdict for a named worktree ---
+# --- --force: override the keep verdict for named worktrees ---
 
 # Real gh is absent in CI (other tests stub it), so the binary-presence check
 # at the top of the script needs something on PATH. The forced paths below
@@ -334,7 +334,7 @@ _stub_gh_absent() {
 @test "force without NAME is rejected" {
   run bash "$POI" -f
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--force requires a worktree NAME"* ]]
+  [[ "$output" == *"--force requires at least one worktree NAME"* ]]
 }
 
 @test "force removes a kept worktree and force-deletes its branch" {
@@ -367,4 +367,54 @@ _stub_gh_absent() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"repo/feature"* ]]
   [[ "$output" != *"repo/other"* ]]
+}
+
+@test "force removes every named worktree in one run" {
+  _mkworktree
+  git -C "$HOME/me/repo" worktree add -B other \
+    "$XDG_DATA_HOME/git-worktrees/me/repo/other" >/dev/null 2>&1
+  local stub; stub=$(_stub_gh_absent)
+
+  PATH="$stub:$PATH" run bash "$POI" -f feature other
+  [ "$status" -eq 0 ]
+  [ ! -e "$XDG_DATA_HOME/git-worktrees/me/repo/feature" ]
+  [ ! -e "$XDG_DATA_HOME/git-worktrees/me/repo/other" ]
+  run git -C "$HOME/me/repo" rev-parse --verify --quiet refs/heads/feature
+  [ "$status" -ne 0 ]
+  run git -C "$HOME/me/repo" rev-parse --verify --quiet refs/heads/other
+  [ "$status" -ne 0 ]
+}
+
+@test "force acts on resolvable names and reports the unresolvable ones" {
+  _mkworktree
+  local stub; stub=$(_stub_gh_absent)
+
+  PATH="$stub:$PATH" run bash "$POI" -f feature bogus
+  # Partial run: feature removed, but a bad name makes the run a failure.
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Removed"* ]]
+  [[ "$output" == *"no worktree matches 'bogus'"* ]]
+  [ ! -e "$WT" ]
+}
+
+@test "force with only unresolvable names removes nothing" {
+  # Guards the load-bearing bail: an all-failed resolve must not fall through
+  # to the full walk and force-remove every worktree.
+  _mkworktree
+  local stub; stub=$(_stub_gh_absent)
+
+  PATH="$stub:$PATH" run bash "$POI" -f bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no worktree matches 'bogus'"* ]]
+  [ -e "$WT" ]
+}
+
+@test "duplicate names resolve to one removal" {
+  _mkworktree
+  local stub; stub=$(_stub_gh_absent)
+
+  PATH="$stub:$PATH" run bash "$POI" -n feature feature
+  [ "$status" -eq 0 ]
+  # One row, not two: dedup collapsed the repeated name.
+  [ "$(grep -c 'repo/feature' <<<"$output")" -eq 1 ]
 }


### PR DESCRIPTION
## Summary

`git worktree-poi NAME...` now scopes the run to one or more worktrees, and `-f/--force` removes worktrees the classifier wanted to keep (in-use, dirty, unpushed, open PR) — closing the gap where an incorrectly-kept worktree could only be cleared with a manual `git worktree remove --force` plus branch cleanup. Each NAME matches by petname leaf, `<repo>/<petname>`, or absolute path; force escalates to `git worktree remove --force` and `git branch -D`.

## Gotchas

- `--force` deletes branches with `-D` (drops unmerged commits) — a deliberate call over best-effort `-d`; confirm that's the cleanup semantics you want when forcing.
- Resolution is do-as-much-as-possible: a bad name doesn't abort the run, the others still act, and the run exits non-zero with the failures reported after. The one place this is *not* lenient is when **every** name fails — it bails before acting, because an empty target set would otherwise fall through to the full walk and (under `--force`) remove everything. Worth a look at that bail.
- `--force` requires at least one NAME, and a forced run suppresses the "Kept" section — check those guardrails read right.
- A forced run works from inside a targeted worktree (canonical path captured before removal); the only artifact is a stale shell cwd afterward, same as plain `git worktree remove`.
- Stays well under ADR-0001's ~100-line "revisit the Go rewrite" trigger, and it's report-and-act, not the interactive-selection case that ADR flags.

## Verification

- `bats test/` — 26 pass, including resolve_target matching/ambiguity/no-match, `-f`-requires-NAME, single + multi-name force removal with branch `-D`, partial-failure (act + report + nonzero), the all-failed bail (removes nothing), and duplicate-name dedup.
- `pre-commit run` — shellcheck/shfmt/vale clean.
- Smoked live: `-n alpha bogus` previews alpha and reports bogus (exit 1); `-f alpha bogus` removes alpha + its branch, reports bogus, leaves the unrelated beta untouched (exit 1); a from-inside `-f` run removed an in-use/no-upstream/unknown-PR worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)