### PR TITLE
Revert zellaude local-build pin (#212)

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -16,12 +16,7 @@
 session_serialization false
 
 plugins {
-    // TEMP (alunduil-chezmoi#211): local build carrying the CLI-pipe unblock
-    // fix. Stock zellaude never unblocks CLI pipes, so each Claude-hook
-    // `zellij pipe` leaks a server connection until the server deadlocks.
-    // Verifying over a week-long session that the patched build holds; revert
-    // to a pinned release URL once the fix is upstreamed and tagged.
-    zellaude location="file:/home/alunduil/.local/share/zellij/plugins/zellaude.wasm"
+    zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
     zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.22.0/zjstatus.wasm"
 }
 


### PR DESCRIPTION
## Summary

Restores zellaude to the stock v0.5.0 release URL. #212 pinned it to a local build carrying an `unblock_cli_pipe_input` patch on the theory the freeze was un-unblocked CLI pipes — now disproven, so the pin (and its host-specific `file:` path) buys nothing.

## Why the patch was a dead end

In zellij 0.43.1 a CLI pipe unblocks only once **every** plugin it was dispatched to reports back (`PendingPipeInfo.currently_being_processed_by` empties); `unblock_cli_pipe_input` only clears `is_explicitly_blocked`, which is already false. So the call is a no-op for this hang — verified empirically with the sha-matched patched build loaded and `ReadCliPipes` granted: pipes still hung, threads still climbed. Full write-up in #167.

## Gotchas

- After merge + `chezmoi apply`, start a fresh zellij session so it loads stock zellaude from the URL (the running server still has the local build cached).
- The real fix is upstream zellij (reap connection threads / don't `unwrap`-panic on EAGAIN), tracked in #167 — not this revert.