### PR TITLE
Install calibre via apt bootstrap pass

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -30,6 +30,7 @@ just --version                             # command runner (justfiles)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)
+command -v calibre                         # ebook library manager
 command -v truenas-mcp                     # TrueNAS MCP server binary
 trivy --version                            # vulnerability scanner (aquasecurity/trivy)
 gh extension list                          # confirms gh-poi (squash-merge pruner)

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -50,7 +50,7 @@ APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   golang-petname
-  keybase signal-desktop
+  keybase signal-desktop calibre
   nethack-console
 )
 missing=()


### PR DESCRIPTION
## Summary

A fresh `chezmoi apply` now installs calibre. Closes #226.

Added `calibre` to `APT_PACKAGES` in `run_once_before_01-install-system-packages.sh.tmpl`, grouped with the other desktop apps (keybase, signal-desktop). Calibre is in Debian main, so unlike Chrome and Signal it needs no keyring/source-list setup — it joins the package list and the existing `dpkg -s` loop guard keeps re-runs idempotent. The bootstrap tutorial's PATH-check verification block gets a `command -v calibre` line, matching the nethack precedent.

## Gotchas

The apt-vs-upstream-installer choice was the issue's open decision; went with apt to match the GUI-app precedent (confirmed with you). Revisit only if Debian's calibre lag bites in practice — it would then move to script 05 as an upstream-installer block.

No README block: per the `add-tool` skill, GUI apps (Chrome, Signal, now calibre) aren't PATH tools the user invokes, so they get no README entry. The issue's third acceptance criterion ("README lists calibre in the right block") is satisfied by the bootstrap-tutorial verification list instead, which is where non-dev apt apps like nethack already live.

## Verification

- `pre-commit run` on both changed files — passed (shellcheck, shfmt, vale, lychee).
- `bats test/` — 54/54 passed.
- `chezmoi execute-template --init` on the script — renders with `calibre` in the array.