### PR TITLE
Add Alt . to fan out a pair tab per worktree

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -31,6 +31,16 @@ keybinds {
                 close_on_exit true
             }
         }
+        // Non-interactive sibling: fan out a pair tab for every worktree at
+        // once (idempotent — open tabs are skipped). Alt . neighbours Alt /;
+        // it shadows readline's yank-last-arg in unlocked panes, which `!$`
+        // covers.
+        bind "Alt ." {
+            Run "git-repo-picker" "--all" {
+                floating true
+                close_on_exit true
+            }
+        }
         // Pure tab navigation. Default `MoveFocusOrTab` switches panes when
         // one exists in the direction, which surprises during tab-hopping.
         bind "Alt Left"  { GoToPreviousTab; }

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -36,7 +36,7 @@ keybinds {
         // it shadows readline's yank-last-arg in unlocked panes, which `!$`
         // covers.
         bind "Alt ." {
-            Run "git-repo-picker" "--all" {
+            Run "git-repo-picker" "--all-worktrees" {
                 floating true
                 close_on_exit true
             }

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -236,6 +236,13 @@ fi
 # one. print_worktrees emits spawn rows only for worktrees whose tab is closed,
 # so consuming just those rows makes re-running idempotent for free.
 if [[ "${1:-}" == "--all-worktrees" ]]; then
+    # close_on_exit closes the floating pane regardless of exit code, so a
+    # failure would vanish before it could be read. Pause on error under
+    # zellij to keep the stderr on screen until dismissed.
+    trap 'rc=$?; (( rc )) && [[ -n "${ZELLIJ:-}" ]] && {
+        printf "\ngit-repo-picker --all-worktrees: failed (exit %d). Press Enter to dismiss..." "$rc" >&2
+        read -r _ </dev/tty 2>/dev/null || sleep 10
+    }' EXIT
     for cmd in zellij gh git; do
         command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
     done

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -37,6 +37,11 @@
 # Tabs are named "<repo-or-org/repo> (petname)" so go-to-tab-name round-trips.
 # Worktrees are durable — closing a tab does not remove them; that is
 # git-worktree-poi's job.
+#
+# `--all` is a non-interactive fan-out: instead of prompting, it opens a pair
+# tab for every worktree that lacks one, reusing print_worktrees' spawn/focus
+# split so already-open worktrees are skipped (idempotent). Bound to Alt . for
+# rehydrating the full set after a fresh session.
 
 set -euo pipefail
 
@@ -188,6 +193,12 @@ print_remotes() {
     done
 }
 
+spawn_pair_tab() {
+    local cwd=$1 tab=$2
+    zellij action new-tab --layout pair --cwd "$cwd"
+    zellij action rename-tab "$tab"
+}
+
 # Tests source this script to exercise helpers above without triggering the
 # --rows handler or main entry below.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
@@ -218,6 +229,21 @@ if [[ "${1:-}" == "--rows" ]]; then
         fi
         cat "$REMOTES_FILE" 2>/dev/null || true
     fi
+    exit 0
+fi
+
+# Non-interactive fan-out (Alt .): open a pair tab for every worktree without
+# one. print_worktrees emits spawn rows only for worktrees whose tab is closed,
+# so consuming just those rows makes re-running idempotent for free.
+if [[ "${1:-}" == "--all" ]]; then
+    for cmd in zellij gh git; do
+        command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
+    done
+    ME=$(gh api user -q .login)
+    while IFS=$'\t' read -r _display verb petdir tab; do
+        [[ "$verb" == spawn ]] || continue
+        spawn_pair_tab "$petdir" "$tab"
+    done < <(print_worktrees)
     exit 0
 fi
 
@@ -317,12 +343,6 @@ make_worktree() {
     fi
     mkdir -p "$(dirname "$wt_dir")"
     git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname" "$default_branch"
-}
-
-spawn_pair_tab() {
-    local cwd=$1 tab=$2
-    zellij action new-tab --layout pair --cwd "$cwd"
-    zellij action rename-tab "$tab"
 }
 
 # fzf reads its initial candidates from STATIC_FILE — no upstream pipeline

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -38,10 +38,10 @@
 # Worktrees are durable — closing a tab does not remove them; that is
 # git-worktree-poi's job.
 #
-# `--all` is a non-interactive fan-out: instead of prompting, it opens a pair
-# tab for every worktree that lacks one, reusing print_worktrees' spawn/focus
-# split so already-open worktrees are skipped (idempotent). Bound to Alt . for
-# rehydrating the full set after a fresh session.
+# `--all-worktrees` is a non-interactive fan-out: instead of prompting, it opens
+# a pair tab for every worktree that lacks one, reusing print_worktrees'
+# spawn/focus split so already-open worktrees are skipped (idempotent). Bound to
+# Alt . for rehydrating the full set after a fresh session.
 
 set -euo pipefail
 
@@ -235,7 +235,7 @@ fi
 # Non-interactive fan-out (Alt .): open a pair tab for every worktree without
 # one. print_worktrees emits spawn rows only for worktrees whose tab is closed,
 # so consuming just those rows makes re-running idempotent for free.
-if [[ "${1:-}" == "--all" ]]; then
+if [[ "${1:-}" == "--all-worktrees" ]]; then
     for cmd in zellij gh git; do
         command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
     done

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -21,7 +21,9 @@ setup() {
   export ZELLIJ_RECORDER="$TMPROOT/zellij.log"
   : >"$ZELLIJ_RECORDER"
   export GH_USER=me
-  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME
+  # Unset ZELLIJ so the --all-worktrees pause-on-error trap takes its
+  # outside-zellij path regardless of where bats itself runs.
+  unset FZF_OUTPUT ZELLIJ_TAB_NAMES GH_CLONE_SRC GH_REPO_LIST PETNAME ZELLIJ
   # Drop any GH_PR_LIST_* leakage from prior tests.
   while IFS= read -r var; do unset "$var"; done < <(compgen -e | grep '^GH_PR_LIST_' || true)
 }
@@ -298,4 +300,13 @@ mkcanonical() {
   grep -Fxq "action new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/world/busy-gnat" \
     "$ZELLIJ_RECORDER"
   grep -Fxq "action rename-tab world (busy-gnat)" "$ZELLIJ_RECORDER"
+}
+
+@test "--all-worktrees: failure outside zellij exits nonzero without hanging" {
+  # STUB_DIR lacks git, so the dependency check dies. ZELLIJ is unset, so the
+  # pause-on-error trap must stay quiet rather than block on /dev/tty. bash is
+  # absolute so only the picker's own dependency check sees the stripped PATH.
+  local bash_bin; bash_bin="$(command -v bash)"
+  run timeout 10 env PATH="$STUB_DIR" "$bash_bin" "$PICKER" --all-worktrees
+  [ "$status" -eq 1 ]    # die's exit, not 124 (timeout → the trap hung)
 }

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -268,3 +268,34 @@ mkcanonical() {
   grep -Fxq "action new-tab --layout pair --cwd $wt" "$ZELLIJ_RECORDER"
   grep -Fxq "action rename-tab hello (cloned-petname)" "$ZELLIJ_RECORDER"
 }
+
+# --- --all: non-interactive fan-out ---
+
+@test "--all: spawns a pair tab for every worktree without an open tab" {
+  mkworktree me hello kind-newt
+  mkworktree grafana k6 happy-mole
+  export ZELLIJ_TAB_NAMES=""
+  run bash "$PICKER" --all
+  [ "$status" -eq 0 ]
+  local h="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
+  local k="$XDG_DATA_HOME/git-worktrees/grafana/k6/happy-mole"
+  grep -Fxq "action new-tab --layout pair --cwd $h" "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab hello (kind-newt)" "$ZELLIJ_RECORDER"
+  grep -Fxq "action new-tab --layout pair --cwd $k" "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab grafana/k6 (happy-mole)" "$ZELLIJ_RECORDER"
+}
+
+@test "--all: skips worktrees that already have an open tab (idempotent)" {
+  mkworktree me hello kind-newt
+  mkworktree me world busy-gnat
+  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  run bash "$PICKER" --all
+  [ "$status" -eq 0 ]
+  # Open tab → no respawn for that worktree.
+  ! grep -Fq "new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/hello/kind-newt" \
+    "$ZELLIJ_RECORDER"
+  # Closed tab → spawned.
+  grep -Fxq "action new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/world/busy-gnat" \
+    "$ZELLIJ_RECORDER"
+  grep -Fxq "action rename-tab world (busy-gnat)" "$ZELLIJ_RECORDER"
+}

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -37,6 +37,18 @@ mkworktree() {
   : >"$dir/.git"
 }
 
+# Mark a worktree's pair tab as already open, the way print_worktrees sees it:
+# append the tab name it would render to ZELLIJ_TAB_NAMES. Reuses the picker's
+# own fmt_tab (sourced in a subshell, since the picker sets `set -e`) so the
+# org-elision format isn't re-derived here. Pairs with mkworktree.
+mark_tab_open() {
+  local name
+  name="$(ME="$GH_USER" bash -c 'source "$1"; fmt_tab "$2" "$3" "$4"' \
+    _ "$PICKER" "$@")"
+  ZELLIJ_TAB_NAMES+="$name"$'\n'
+  export ZELLIJ_TAB_NAMES
+}
+
 teardown() {
   rm -rf "$TMPROOT"
 }
@@ -137,7 +149,7 @@ mkcanonical() {
 
 @test "print_worktrees: open tab emits dimmed focus row" {
   mkworktree me hello kind-newt
-  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  mark_tab_open me hello kind-newt
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
@@ -201,7 +213,7 @@ mkcanonical() {
 @test "print_worktrees_with_prs: open tab dims the enriched row and dispatches focus" {
   mkpr_worktree me hello kind-newt feature/x
   export GH_PR_LIST_me_hello=$'feature/x\t174'
-  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  mark_tab_open me hello kind-newt
   run bash -c 'source "$1"; ME=me WORKTREE_ROOT="$2" print_worktrees_with_prs' \
     _ "$PICKER" "$XDG_DATA_HOME/git-worktrees"
   [ "$status" -eq 0 ]
@@ -290,11 +302,11 @@ mkcanonical() {
 @test "--all-worktrees: skips worktrees that already have an open tab (idempotent)" {
   mkworktree me hello kind-newt
   mkworktree me world busy-gnat
-  export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
+  mark_tab_open me hello kind-newt
   run bash "$PICKER" --all-worktrees
   [ "$status" -eq 0 ]
   # Open tab → no respawn for that worktree.
-  ! grep -Fq "new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/hello/kind-newt" \
+  ! grep -Fxq "action new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/hello/kind-newt" \
     "$ZELLIJ_RECORDER"
   # Closed tab → spawned.
   grep -Fxq "action new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/world/busy-gnat" \

--- a/test/git_repo_picker.bats
+++ b/test/git_repo_picker.bats
@@ -269,13 +269,13 @@ mkcanonical() {
   grep -Fxq "action rename-tab hello (cloned-petname)" "$ZELLIJ_RECORDER"
 }
 
-# --- --all: non-interactive fan-out ---
+# --- --all-worktrees: non-interactive fan-out ---
 
-@test "--all: spawns a pair tab for every worktree without an open tab" {
+@test "--all-worktrees: spawns a pair tab for every worktree without an open tab" {
   mkworktree me hello kind-newt
   mkworktree grafana k6 happy-mole
   export ZELLIJ_TAB_NAMES=""
-  run bash "$PICKER" --all
+  run bash "$PICKER" --all-worktrees
   [ "$status" -eq 0 ]
   local h="$XDG_DATA_HOME/git-worktrees/me/hello/kind-newt"
   local k="$XDG_DATA_HOME/git-worktrees/grafana/k6/happy-mole"
@@ -285,11 +285,11 @@ mkcanonical() {
   grep -Fxq "action rename-tab grafana/k6 (happy-mole)" "$ZELLIJ_RECORDER"
 }
 
-@test "--all: skips worktrees that already have an open tab (idempotent)" {
+@test "--all-worktrees: skips worktrees that already have an open tab (idempotent)" {
   mkworktree me hello kind-newt
   mkworktree me world busy-gnat
   export ZELLIJ_TAB_NAMES=$'hello (kind-newt)\n'
-  run bash "$PICKER" --all
+  run bash "$PICKER" --all-worktrees
   [ "$status" -eq 0 ]
   # Open tab → no respawn for that worktree.
   ! grep -Fq "new-tab --layout pair --cwd $XDG_DATA_HOME/git-worktrees/me/hello/kind-newt" \


### PR DESCRIPTION
## Summary

`Alt .` now opens a pair tab for every worktree in one shot — the non-interactive sibling to `git-repo-picker`'s `Alt /`, for rehydrating the full set of pair tabs after a fresh zellij session instead of invoking the picker once per worktree by hand. Closes #225.

The new `--all-worktrees` mode reuses `print_worktrees`, which already emits spawn rows only for worktrees whose tab is closed, so re-running skips already-open tabs and never duplicates — the idempotency requirement falls out of existing code rather than a new check.

## Gotchas

- **Keybind choice (`Alt .`)**: it lives in `shared_except "locked"`, so zellij intercepts it before the pane, shadowing readline's `yank-last-arg` in unlocked panes. Decided this is fine since `!$` covers that use; lock the pane if you ever need the readline binding. Confirmed `Alt .` collides with no zellij default. If you'd rather not shadow it, `Alt ?` was the runner-up.
- **Structure decision**: implemented as a flag on the picker rather than a standalone script or extracted helper — it matches the existing `--rows` internal-mode precedent and keeps `spawn_pair_tab` a single function with two call sites (no premature abstraction). `spawn_pair_tab` moved above the source guard so the flag path can call it.
- **Pause-on-error trap**: the bind runs `floating true` + `close_on_exit true`, and `close_on_exit` closes the pane regardless of exit code — so without a pause a failed fan-out would flash and vanish. The `--all-worktrees` block installs its own EXIT trap (gated on `$ZELLIJ`) that holds the pane open on failure, mirroring the picker's own failure-visibility. Worth a look: the trap sits in the early-intercept block, *before* the main-entry trap, since `--all-worktrees` exits before reaching it.
- **Discovered test cleanup**: the open-tab precondition was hand-written into `ZELLIJ_TAB_NAMES` in three tests, re-deriving `fmt_tab`'s format as a literal. Extracted `mark_tab_open` (reuses the real `fmt_tab` via subshell-source — no new `lib.sh`, since the picker is already sourceable) and retrofitted all three. The parallel cleanup for the *assertion* side (spawn/focus grep helpers) is larger and design-open, so it's filed as #231 rather than done here.

## Verification

- `bats test/` — 23/23, including three new `--all-worktrees` tests (fans out closed-tab worktrees; skips open ones; failure outside zellij exits nonzero without the trap hanging). `setup()` now unsets `ZELLIJ` so the trap's outside-zellij path is exercised hermetically regardless of where bats runs.
- `pre-commit run --all-files`, `script/checks/zellij-config` (validates the new `Alt .` bind), `script/checks/chezmoi-apply` — all pass.

## Follow-up

- #231 — spawn/focus assertion helpers for `git_repo_picker.bats` (discovered here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)