### PR TITLE
Observability: zellijstat census + Grafana/Alloy stack for the zellij freeze

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,5 @@
 .lycheecache
+**/__pycache__
 CLAUDE.md
 docs
 justfile

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -1,0 +1,58 @@
+name: Observability
+
+# Heavy: installs the ~400 MB telemetry binaries, so it only runs when the
+# observability stack itself changes. Validates every service config and
+# smoke-tests the live metrics path (zellijstat -> Alloy -> Prometheus).
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - 'dot_config/alloy/**'
+      - 'dot_config/prometheus/**'
+      - 'dot_config/loki/**'
+      - 'dot_config/tempo/**'
+      - 'dot_config/grafana/**'
+      - 'dot_config/systemd/user/**'
+      - 'dot_local/bin/executable_zellijstat'
+      - 'script/install/alloy'
+      - 'script/install/prometheus'
+      - 'script/install/loki'
+      - 'script/install/tempo'
+      - 'script/install/grafana'
+      - 'script/checks/observability-config'
+      - 'script/checks/observability-smoke'
+      - '.github/workflows/observability.yml'
+  pull_request:
+    paths: *paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.x'
+
+      - name: Install stack binaries
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          for t in prometheus alloy loki tempo; do
+            script/install/"$t" --bin-dir "$HOME/.local/bin"
+          done
+          echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+
+      - name: Validate configs
+        run: script/checks/observability-config
+
+      - name: Smoke the metrics path
+        run: script/checks/observability-smoke

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,27 @@
+name: Python
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.x'
+
+      - name: Test
+        run: python3 test/zellijstat_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .lycheecache
+__pycache__/
 key.txt
 .credentials.json
 **/id_rsa*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,31 @@ repos:
         # .tmpl files are Go templates, not valid YAML until chezmoi renders.
         exclude: \.tmpl$
       - id: detect-private-key
+      - id: debug-statements
+      - id: check-ast
+      - id: check-merge-conflict
+
+  # The Python hooks below also lint dot_local/bin/executable_zellijstat. It
+  # carries chezmoi's executable_ prefix, so it has no .py suffix and is stored
+  # non-executable; identify tags it only as `text`, so the default
+  # python-typed matching skips it. Match it by path instead.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+        types_or: [text]
+        files: (\.py$|/executable_zellijstat$)
+      - id: ruff-format
+        types_or: [text]
+        files: (\.py$|/executable_zellijstat$)
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks:
+      - id: mypy
+        types_or: [text]
+        files: (\.py$|/executable_zellijstat$)
 
   - repo: https://github.com/errata-ai/vale
     rev: v3.14.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
       - id: check-yaml
         # .tmpl files are Go templates, not valid YAML until chezmoi renders.
         exclude: \.tmpl$
+      - id: check-toml
       - id: detect-private-key
       - id: debug-statements
       - id: check-ast
@@ -54,6 +55,11 @@ repos:
       - id: mypy
         types_or: [text]
         files: (\.py$|/executable_zellijstat$)
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
 
   - repo: https://github.com/errata-ai/vale
     rev: v3.14.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,9 @@ repos:
         # malformed.json is intentionally invalid — a fixture for the
         # pr-draft-guard hook's fail-closed-on-bad-input test.
         exclude: ^test/fixtures/pr_draft_guard/malformed\.json$
+      - id: check-yaml
+        # .tmpl files are Go templates, not valid YAML until chezmoi renders.
+        exclude: \.tmpl$
       - id: detect-private-key
 
   - repo: https://github.com/errata-ai/vale

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ repos:
     hooks:
       - id: shellcheck
         files: (executable_|\.sh\.tmpl$)
+        # executable_zellijstat is Python, not shell; the executable_ glob
+        # would otherwise hand it to a shell linter.
+        exclude: ^dot_local/bin/executable_zellijstat$
         types: [text]
 
   - repo: https://github.com/scop/pre-commit-shfmt
@@ -12,6 +15,7 @@ repos:
       - id: shfmt
         args: ['-i', '2', '-ci']
         files: (executable_|\.sh\.tmpl$)
+        exclude: ^dot_local/bin/executable_zellijstat$
         types: [text]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,12 @@
+# Lint/format config for the repo's Python (currently dot_local/bin/zellijstat
+# and its test). Leading dot keeps chezmoi from deploying it as a dotfile.
+target-version = "py311"
+
+[lint]
+# A modern baseline covering what the old black/isort/flake8/pyupgrade stack
+# did: pycodestyle (E/W), pyflakes (F), isort (I), pyupgrade (UP), bugbear
+# (B), simplify (SIM), comprehensions (C4).
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "C4"]
+# ruff-format owns line length; E501 only adds noise on the long byte-string
+# literals in the test fixtures, which the formatter can't break.
+ignore = ["E501"]

--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -35,6 +35,10 @@ zellijstat
 zellaude
 OTLP
 systemd
+loopback
+substring
+wchan
+futex
 
 # Editors and OSes
 VSCode

--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -25,6 +25,17 @@ ghcup
 Keybase
 paperkey
 
+# Observability stack
+Grafana
+Prometheus
+Loki
+Tempo
+Alloy
+zellijstat
+zellaude
+OTLP
+systemd
+
 # Editors and OSes
 VSCode
 macOS

--- a/docs/explanation/zellij-freeze-observability.md
+++ b/docs/explanation/zellij-freeze-observability.md
@@ -1,10 +1,10 @@
-# Zellij-freeze observability stack
+# Zellij-freeze observability
 
 Background and rationale for the always-on telemetry stack that instruments
 the Zellij-freeze investigation. To operate it, see
-[../how-to/zellij-observability.md](../how-to/zellij-observability.md); for
-ports, storage, and metric names, see
-[../reference/zellij-observability.md](../reference/zellij-observability.md).
+[../how-to/viewing-zellij-freeze-data.md](../how-to/viewing-zellij-freeze-data.md);
+for ports, storage, and metric names, see
+[../reference/zellij-freeze-observability-reference.md](../reference/zellij-freeze-observability-reference.md).
 
 ## The problem
 

--- a/docs/explanation/zellij-observability.md
+++ b/docs/explanation/zellij-observability.md
@@ -10,8 +10,8 @@ ports, storage, and metric names, see
 
 Zellij becomes unresponsive under heavy real use, and the failure is emergent
 under the full workflow at scale, not in a single isolated pipe. Anything
-emitted from *inside* Zellij dies with it in a full deadlock, so the only
-thing that can record up to and through the wedge is an external observer.
+emitted from *inside* Zellij dies with it in a full deadlock, so the only thing
+that can record up to and through the wedge is an external observer.
 
 ## The shape
 
@@ -28,40 +28,26 @@ flowchart LR
     tempo --> graf
 ```
 
-`zellijstat` enumerates every Zellij server (a process whose `comm` is
-`zellij` *and* whose arguments include `--server`, never a substring match
-that would also catch the sampler's own shell) and samples each from `/proc`:
-thread count by name, per-thread kernel wait-channel, Unix-socket connections
-with their queue depths, file descriptors, CPU, and resident memory. Reading
-`/proc` never touches the Zellij IPC socket, so the sampler keeps reporting
-straight through a server wedge. It's a pull exporter: a scrape samples on
-demand, so the resolution is the scraper's interval (Alloy at roughly two
-seconds).
+`zellijstat` enumerates every Zellij server (a process whose `comm` is `zellij`
+*and* whose arguments include `--server`, never a substring match that would
+also catch the sampler's own shell) and samples each from `/proc`: threads by
+name, per-thread wait-channel, Unix-socket connections and queue depths, file
+descriptors, CPU, and memory. Reading `/proc` needs no privilege and never
+touches the Zellij IPC socket, so the sampler keeps reporting straight through a
+wedge.
 
-## Why the storage tier is native and always-on
+## Storage is separate from the viewer
 
-The capture services (`zellijstat`, Alloy, Prometheus, Loki, Tempo) run as
-always-on systemd user services that write to local disk continuously. The
-storage backends being always-on is what makes capture durable: Grafana, the
-viewer, can be down or never opened without losing data, because Prometheus,
-Loki, and Tempo on the host keep recording regardless. An Alloy buffer alone
-would not survive the viewer being absent: it's a forwarding queue, not a
-store.
+The capture services run as always-on systemd user services that write to local
+disk. The store is deliberately independent of Grafana: the viewer can be down,
+or never opened, without losing data, so capture never depends on someone
+watching.
 
-## Logs and traces
+## Logs and traces are complementary, not redundant
 
-The stack covers all three signal types, not just metrics. Alloy tails a
-diagnostics log directory (`$XDG_STATE_HOME/zellij-diag`) into Loki and accepts
-OTLP into Tempo, so any in-process instrumentation that writes those logs or
-emits OTLP is stored alongside the `/proc` metrics. The external sampler and
-in-process instrumentation are complementary: the sampler sees thread,
-connection, and resource state but not Zellij's internal connection and pipe
-lifecycle, which only instrumentation inside the process can record.
-
-## Why loopback OTLP rather than a Unix socket
-
-The OTLP receiver listens on loopback TCP (`4317`/`4318`) rather than a Unix
-socket. Using loopback is equally local and carries no external-network exposure,
-it's the documented Alloy configuration, and `4317`/`4318` are the OTLP
-defaults. None of these daemons support native systemd socket activation, so a
-`.socket` unit would not help without a `systemd-socket-proxyd` hop.
+Alloy also tails a diagnostics log directory (`$XDG_STATE_HOME/zellij-diag`)
+into Loki and accepts OTLP into Tempo, so the stack covers all three signal
+types. These come from instrumentation inside Zellij, which sees what the
+external sampler structurally can't: the `/proc` view has thread, connection,
+and resource state, but the internal connection and pipe lifecycle is only
+visible from within the process.

--- a/docs/explanation/zellij-observability.md
+++ b/docs/explanation/zellij-observability.md
@@ -19,7 +19,7 @@ thing that can record up to and through the wedge is an external observer.
 flowchart LR
     zj["zellijstat\n/proc sampler"] -->|/metrics| alloy[Alloy collector]
     logs["zellij-diag logs"] -->|tail| alloy
-    otlp["fork OTLP"] --> alloy
+    otlp["OTLP"] --> alloy
     alloy --> prom[Prometheus]
     alloy --> loki[Loki]
     alloy --> tempo[Tempo]
@@ -48,19 +48,20 @@ Loki, and Tempo on the host keep recording regardless. An Alloy buffer alone
 would not survive the viewer being absent: it's a forwarding queue, not a
 store.
 
-## Why metrics flow but logs and traces wait
+## Logs and traces
 
-Only the metrics path carries data today. `zellijstat` runs on stock Zellij,
-so it collects immediately. The log path (`zellij-diag` files into Loki) and
-the trace path (OTLP into Tempo) are wired but idle until the forks emit:
-Zellij native OTEL (#223) and zellaude structured logs (#224). Wiring them now
-means no re-plumbing when they land.
+The stack covers all three signal types, not just metrics. Alloy tails a
+diagnostics log directory (`$XDG_STATE_HOME/zellij-diag`) into Loki and accepts
+OTLP into Tempo, so any in-process instrumentation that writes those logs or
+emits OTLP is stored alongside the `/proc` metrics. The external sampler and
+in-process instrumentation are complementary: the sampler sees thread,
+connection, and resource state but not Zellij's internal connection and pipe
+lifecycle, which only instrumentation inside the process can record.
 
 ## Why loopback OTLP rather than a Unix socket
 
 The OTLP receiver listens on loopback TCP (`4317`/`4318`) rather than a Unix
-socket. Using loopback is equally local and carries no external-network
-exposure, it's the documented Alloy configuration, and it matches the endpoint the
-Zellij fork's OTLP exporter will target. None of these daemons support native
-systemd socket activation, so a `.socket` unit would not help without a
-`systemd-socket-proxyd` hop.
+socket. Using loopback is equally local and carries no external-network exposure,
+it's the documented Alloy configuration, and `4317`/`4318` are the OTLP
+defaults. None of these daemons support native systemd socket activation, so a
+`.socket` unit would not help without a `systemd-socket-proxyd` hop.

--- a/docs/explanation/zellij-observability.md
+++ b/docs/explanation/zellij-observability.md
@@ -1,0 +1,66 @@
+# Zellij-freeze observability stack
+
+Background and rationale for the always-on telemetry stack that instruments
+the Zellij-freeze investigation. To operate it, see
+[../how-to/zellij-observability.md](../how-to/zellij-observability.md); for
+ports, storage, and metric names, see
+[../reference/zellij-observability.md](../reference/zellij-observability.md).
+
+## The problem
+
+Zellij becomes unresponsive under heavy real use, and the failure is emergent
+under the full workflow at scale, not in a single isolated pipe. Anything
+emitted from *inside* Zellij dies with it in a full deadlock, so the only
+thing that can record up to and through the wedge is an external observer.
+
+## The shape
+
+```mermaid
+flowchart LR
+    zj["zellijstat\n/proc sampler"] -->|/metrics| alloy[Alloy collector]
+    logs["zellij-diag logs"] -->|tail| alloy
+    otlp["fork OTLP"] --> alloy
+    alloy --> prom[Prometheus]
+    alloy --> loki[Loki]
+    alloy --> tempo[Tempo]
+    prom --> graf[Grafana]
+    loki --> graf
+    tempo --> graf
+```
+
+`zellijstat` enumerates every Zellij server (a process whose `comm` is
+`zellij` *and* whose arguments include `--server`, never a substring match
+that would also catch the sampler's own shell) and samples each from `/proc`:
+thread count by name, per-thread kernel wait-channel, Unix-socket connections
+with their queue depths, file descriptors, CPU, and resident memory. Reading
+`/proc` never touches the Zellij IPC socket, so the sampler keeps reporting
+straight through a server wedge. It's a pull exporter: a scrape samples on
+demand, so the resolution is the scraper's interval (Alloy at roughly two
+seconds).
+
+## Why the storage tier is native and always-on
+
+The capture services (`zellijstat`, Alloy, Prometheus, Loki, Tempo) run as
+always-on systemd user services that write to local disk continuously. The
+storage backends being always-on is what makes capture durable: Grafana, the
+viewer, can be down or never opened without losing data, because Prometheus,
+Loki, and Tempo on the host keep recording regardless. An Alloy buffer alone
+would not survive the viewer being absent: it's a forwarding queue, not a
+store.
+
+## Why metrics flow but logs and traces wait
+
+Only the metrics path carries data today. `zellijstat` runs on stock Zellij,
+so it collects immediately. The log path (`zellij-diag` files into Loki) and
+the trace path (OTLP into Tempo) are wired but idle until the forks emit:
+Zellij native OTEL (#223) and zellaude structured logs (#224). Wiring them now
+means no re-plumbing when they land.
+
+## Why loopback OTLP rather than a Unix socket
+
+The OTLP receiver listens on loopback TCP (`4317`/`4318`) rather than a Unix
+socket. Using loopback is equally local and carries no external-network
+exposure, it's the documented Alloy configuration, and it matches the endpoint the
+Zellij fork's OTLP exporter will target. None of these daemons support native
+systemd socket activation, so a `.socket` unit would not help without a
+`systemd-socket-proxyd` hop.

--- a/docs/how-to/viewing-zellij-freeze-data.md
+++ b/docs/how-to/viewing-zellij-freeze-data.md
@@ -13,6 +13,6 @@ loginctl enable-linger
 ```
 
 For what the stack is and why, see
-[../explanation/zellij-observability.md](../explanation/zellij-observability.md);
+[../explanation/zellij-freeze-observability.md](../explanation/zellij-freeze-observability.md);
 for ports, storage paths, and the metrics it exposes, see
-[../reference/zellij-observability.md](../reference/zellij-observability.md).
+[../reference/zellij-freeze-observability-reference.md](../reference/zellij-freeze-observability-reference.md).

--- a/docs/how-to/zellij-observability.md
+++ b/docs/how-to/zellij-observability.md
@@ -1,68 +1,55 @@
-# Zellij-freeze observability stack
+# Running the observability stack
 
-An always-on, out-of-band telemetry stack for the Zellij-freeze
-investigation. `zellijstat` samples every Zellij server from `/proc`
-(thread count, per-thread wait-channel, Unix-socket connections and queue
-depth, file descriptors, CPU, RSS) and exposes Prometheus metrics; Alloy
-collects them into a local Prometheus, and Grafana draws the per-session
-curves. Because `zellijstat` only reads `/proc`, it keeps recording
-straight through a server wedge—the point of an *external* observer.
+The Zellij-freeze observability stack comes up on `chezmoi apply`: the
+binaries install, the units deploy, and `zellij-observability.target` is
+enabled and started. On a fresh host there's nothing to do but look. For what
+the stack is and why it's shaped this way, see
+[../explanation/zellij-observability.md](../explanation/zellij-observability.md);
+for ports, storage paths, and the metrics it exposes, see
+[../reference/zellij-observability.md](../reference/zellij-observability.md).
 
-```
-zellijstat ─/metrics─▶ Alloy ─▶ Prometheus ─┐
-zellij-diag logs ─────▶ Alloy ─▶ Loki ───────┼─▶ Grafana
-fork OTLP ────────────▶ Alloy ─▶ Tempo ──────┘
-```
+## View the dashboards
 
-It runs on stock Zellij. Today only the metrics path carries data; the log
-(Loki) and trace (Tempo) paths are wired but idle until the Zellij and
-zellaude forks emit (issues #223 and #224).
+Grafana runs as part of the stack, so open <http://127.0.0.1:3000> (default
+login `admin`/`admin`) and select the **Zellij freeze** dashboard. The Session
+variable filters to one or more sessions.
 
-## Bring up the capture stack
+## Keep capturing while logged out
 
-`chezmoi apply` installs the binaries, deploys the units, and enables the
-`zellij-observability.target` (a `run_onchange_after` script runs
-`daemon-reload` + `enable --now`). A fresh host comes up capturing with no
-manual steps. The equivalent by hand, if you ever need it:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now zellij-observability.target
-```
-
-To keep the stack running while you are logged out (so it captures an
-unattended wedge), enable lingering:
+The user services stop when your session ends. To capture an unattended wedge,
+enable lingering so they keep running:
 
 ```bash
 loginctl enable-linger
 ```
 
-## View the dashboards
+## Check what's being captured
 
-Grafana runs as part of the stack, so it's already up. Open
-<http://127.0.0.1:3000> (default login `admin`/`admin`) and find the
-provisioned **Zellij freeze** dashboard. The Session variable filters to one
-or more sessions.
-
-## Ports and storage
-
-| Service    | Address           | Data under `~/.local/state/`        |
-|------------|-------------------|-------------------------------------|
-| zellijstat | `127.0.0.1:9095`  | —                                   |
-| Prometheus | `127.0.0.1:9090`  | `zellij-observability/prometheus`   |
-| Loki       | `127.0.0.1:3100`  | `zellij-observability/loki`         |
-| Tempo      | `127.0.0.1:3200`  | `zellij-observability/tempo`        |
-| Alloy      | `127.0.0.1:12345` | `zellij-observability/alloy` (WAL)  |
-| Grafana    | `127.0.0.1:3000`  | `zellij-observability/grafana`      |
-
-The forks write logs to `~/.local/state/zellij-diag/*.log`, which Alloy
-tails into Loki, and send OTLP to Alloy on `127.0.0.1:4317`.
-
-## Stop or inspect
+Straight from the sampler, no stack required:
 
 ```bash
-systemctl --user stop zellij-observability.target   # stop the capture stack
-systemctl --user status alloy.service               # one service
-journalctl --user -u zellijstat.service -f          # follow its log
-curl -s 127.0.0.1:9095/metrics                       # raw sample, no stack needed
+curl -s 127.0.0.1:9095/metrics
+```
+
+Follow a service's log, or check its state:
+
+```bash
+journalctl --user -u zellijstat.service -f
+systemctl --user status alloy.service
+```
+
+## Stop or restart
+
+```bash
+systemctl --user stop zellij-observability.target
+systemctl --user restart zellij-observability.target
+```
+
+## Bring it up by hand
+
+The enable step that `chezmoi apply` runs, if you ever need it directly:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now zellij-observability.target
 ```

--- a/docs/how-to/zellij-observability.md
+++ b/docs/how-to/zellij-observability.md
@@ -1,55 +1,18 @@
-# Running the observability stack
+# Viewing the Zellij-freeze data
 
-The Zellij-freeze observability stack comes up on `chezmoi apply`: the
-binaries install, the units deploy, and `zellij-observability.target` is
-enabled and started. On a fresh host there's nothing to do but look. For what
-the stack is and why it's shaped this way, see
-[../explanation/zellij-observability.md](../explanation/zellij-observability.md);
-for ports, storage paths, and the metrics it exposes, see
-[../reference/zellij-observability.md](../reference/zellij-observability.md).
+`chezmoi apply` brings the observability stack up and keeps it running, so on a
+fresh host there's nothing to start. Open Grafana at <http://127.0.0.1:3000>
+(default login `admin`/`admin`) and select the **Zellij freeze** dashboard; the
+Session variable filters to one or more sessions.
 
-## View the dashboards
-
-Grafana runs as part of the stack, so open <http://127.0.0.1:3000> (default
-login `admin`/`admin`) and select the **Zellij freeze** dashboard. The Session
-variable filters to one or more sessions.
-
-## Keep capturing while logged out
-
-The user services stop when your session ends. To capture an unattended wedge,
-enable lingering so they keep running:
+For unattended capture (recording a wedge while you're logged out), enable
+lingering, since user services otherwise stop with your session:
 
 ```bash
 loginctl enable-linger
 ```
 
-## Check what's being captured
-
-Straight from the sampler, no stack required:
-
-```bash
-curl -s 127.0.0.1:9095/metrics
-```
-
-Follow a service's log, or check its state:
-
-```bash
-journalctl --user -u zellijstat.service -f
-systemctl --user status alloy.service
-```
-
-## Stop or restart
-
-```bash
-systemctl --user stop zellij-observability.target
-systemctl --user restart zellij-observability.target
-```
-
-## Bring it up by hand
-
-The enable step that `chezmoi apply` runs, if you ever need it directly:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now zellij-observability.target
-```
+For what the stack is and why, see
+[../explanation/zellij-observability.md](../explanation/zellij-observability.md);
+for ports, storage paths, and the metrics it exposes, see
+[../reference/zellij-observability.md](../reference/zellij-observability.md).

--- a/docs/how-to/zellij-observability.md
+++ b/docs/how-to/zellij-observability.md
@@ -1,0 +1,71 @@
+# Zellij-freeze observability stack
+
+An always-on, out-of-band telemetry stack for the Zellij-freeze
+investigation. `zellijstat` samples every Zellij server from `/proc`
+(thread count, per-thread wait-channel, Unix-socket connections and queue
+depth, file descriptors, CPU, RSS) and exposes Prometheus metrics; Alloy
+collects them into a local Prometheus, and Grafana draws the per-session
+curves. Because `zellijstat` only reads `/proc`, it keeps recording
+straight through a server wedge—the point of an *external* observer.
+
+```
+zellijstat ─/metrics─▶ Alloy ─▶ Prometheus ─┐
+zellij-diag logs ─────▶ Alloy ─▶ Loki ───────┼─▶ Grafana
+fork OTLP ────────────▶ Alloy ─▶ Tempo ──────┘
+```
+
+It runs on stock Zellij. Today only the metrics path carries data; the log
+(Loki) and trace (Tempo) paths are wired but idle until the Zellij and
+zellaude forks emit (issues #223 and #224).
+
+## Bring up the capture stack
+
+`chezmoi apply` installs the binaries and deploys the units; it does **not**
+start them. Enable the always-on target once per host:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now zellij-observability.target
+```
+
+To keep it running while you are logged out (so it captures an unattended
+wedge), enable lingering:
+
+```bash
+loginctl enable-linger
+```
+
+## View the dashboards
+
+Grafana is a separate on-demand viewer—start it only when looking:
+
+```bash
+systemctl --user start grafana
+```
+
+Open <http://127.0.0.1:3000> (default login `admin`/`admin`) and find the
+provisioned **Zellij freeze** dashboard. The Session variable filters to one
+or more sessions.
+
+## Ports and storage
+
+| Service    | Address           | Data under `~/.local/state/`        |
+|------------|-------------------|-------------------------------------|
+| zellijstat | `127.0.0.1:9095`  | —                                   |
+| Prometheus | `127.0.0.1:9090`  | `zellij-observability/prometheus`   |
+| Loki       | `127.0.0.1:3100`  | `zellij-observability/loki`         |
+| Tempo      | `127.0.0.1:3200`  | `zellij-observability/tempo`        |
+| Alloy      | `127.0.0.1:12345` | `zellij-observability/alloy` (WAL)  |
+| Grafana    | `127.0.0.1:3000`  | `zellij-observability/grafana`      |
+
+The forks write logs to `~/.local/state/zellij-diag/*.log`, which Alloy
+tails into Loki, and send OTLP to Alloy on `127.0.0.1:4317`.
+
+## Stop or inspect
+
+```bash
+systemctl --user stop zellij-observability.target   # stop the capture stack
+systemctl --user status alloy.service               # one service
+journalctl --user -u zellijstat.service -f          # follow its log
+curl -s 127.0.0.1:9095/metrics                       # raw sample, no stack needed
+```

--- a/docs/how-to/zellij-observability.md
+++ b/docs/how-to/zellij-observability.md
@@ -20,16 +20,18 @@ zellaude forks emit (issues #223 and #224).
 
 ## Bring up the capture stack
 
-`chezmoi apply` installs the binaries and deploys the units; it does **not**
-start them. Enable the always-on target once per host:
+`chezmoi apply` installs the binaries, deploys the units, and enables the
+`zellij-observability.target` (a `run_onchange_after` script runs
+`daemon-reload` + `enable --now`). A fresh host comes up capturing with no
+manual steps. The equivalent by hand, if you ever need it:
 
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now zellij-observability.target
 ```
 
-To keep it running while you are logged out (so it captures an unattended
-wedge), enable lingering:
+To keep the stack running while you are logged out (so it captures an
+unattended wedge), enable lingering:
 
 ```bash
 loginctl enable-linger
@@ -37,13 +39,8 @@ loginctl enable-linger
 
 ## View the dashboards
 
-Grafana is a separate on-demand viewer—start it only when looking:
-
-```bash
-systemctl --user start grafana
-```
-
-Open <http://127.0.0.1:3000> (default login `admin`/`admin`) and find the
+Grafana runs as part of the stack, so it's already up. Open
+<http://127.0.0.1:3000> (default login `admin`/`admin`) and find the
 provisioned **Zellij freeze** dashboard. The Session variable filters to one
 or more sessions.
 

--- a/docs/reference/zellij-freeze-observability-reference.md
+++ b/docs/reference/zellij-freeze-observability-reference.md
@@ -1,9 +1,10 @@
-# Zellij-freeze observability stack reference
+# Zellij-freeze observability reference
 
 Ports, storage locations, and the metrics `zellijstat` exposes. To operate the
-stack see [../how-to/zellij-observability.md](../how-to/zellij-observability.md);
+stack see
+[../how-to/viewing-zellij-freeze-data.md](../how-to/viewing-zellij-freeze-data.md);
 for the rationale see
-[../explanation/zellij-observability.md](../explanation/zellij-observability.md).
+[../explanation/zellij-freeze-observability.md](../explanation/zellij-freeze-observability.md).
 
 ## Services
 

--- a/docs/reference/zellij-observability.md
+++ b/docs/reference/zellij-observability.md
@@ -1,0 +1,39 @@
+# Zellij-freeze observability stack reference
+
+Ports, storage locations, and the metrics `zellijstat` exposes. To operate the
+stack see [../how-to/zellij-observability.md](../how-to/zellij-observability.md);
+for the rationale see
+[../explanation/zellij-observability.md](../explanation/zellij-observability.md).
+
+## Services
+
+| Service    | Listens on        | Data under `~/.local/state/`       |
+|------------|-------------------|------------------------------------|
+| zellijstat | `127.0.0.1:9095`  | —                                  |
+| Prometheus | `127.0.0.1:9090`  | `zellij-observability/prometheus`  |
+| Loki       | `127.0.0.1:3100`  | `zellij-observability/loki`        |
+| Tempo      | `127.0.0.1:3200`  | `zellij-observability/tempo`       |
+| Alloy      | `127.0.0.1:12345` | `zellij-observability/alloy` (WAL) |
+| Grafana    | `127.0.0.1:3000`  | `zellij-observability/grafana`     |
+
+Alloy's OTLP receiver listens on `127.0.0.1:4317` (gRPC) and `4318` (HTTP).
+The forks write logs to `~/.local/state/zellij-diag/*.log`, which Alloy tails
+into Loki.
+
+## Metrics
+
+`zellijstat` exposes these on `127.0.0.1:9095/metrics`. Every per-server series
+carries `session` and `pid` labels.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `zellijstat_servers` | gauge | Number of Zellij servers sampled. |
+| `zellijstat_server_threads` | gauge | Threads in the server process. |
+| `zellijstat_server_threads_by_comm` | gauge | Threads grouped by thread name (`comm` label). |
+| `zellijstat_server_threads_by_wchan` | gauge | Threads grouped by kernel wait-channel (`wchan` label); the futex pile-up. |
+| `zellijstat_server_unix_connections` | gauge | Unix-domain sockets held by the server. |
+| `zellijstat_server_unix_recvq_bytes` | gauge | Summed Recv-Q across those sockets. |
+| `zellijstat_server_unix_sendq_bytes` | gauge | Summed Send-Q across those sockets. |
+| `zellijstat_server_open_fds` | gauge | Open file descriptors. |
+| `zellijstat_server_cpu_seconds_total` | counter | Server CPU time (`utime` + `stime`), seconds. |
+| `zellijstat_server_memory_rss_bytes` | gauge | Resident set size, bytes. |

--- a/docs/reference/zellij-observability.md
+++ b/docs/reference/zellij-observability.md
@@ -16,9 +16,8 @@ for the rationale see
 | Alloy      | `127.0.0.1:12345` | `zellij-observability/alloy` (WAL) |
 | Grafana    | `127.0.0.1:3000`  | `zellij-observability/grafana`     |
 
-Alloy's OTLP receiver listens on `127.0.0.1:4317` (gRPC) and `4318` (HTTP).
-The forks write logs to `~/.local/state/zellij-diag/*.log`, which Alloy tails
-into Loki.
+Alloy's OTLP receiver listens on `127.0.0.1:4317` (gRPC) and `4318` (HTTP), and
+tails `~/.local/state/zellij-diag/*.log` into Loki.
 
 ## Metrics
 

--- a/dot_config/alloy/config.alloy
+++ b/dot_config/alloy/config.alloy
@@ -1,0 +1,72 @@
+// Alloy: the unified collector for the zellij-freeze observability stack.
+// Three pipelines feed the always-on local backends:
+//
+//   1. metrics  zellijstat /metrics  -> Prometheus            (live now)
+//   2. logs     $ZELLIJ_DIAG/*.log    -> Loki                  (zellaude fork, #224)
+//   3. OTLP     forks -> {Prometheus, Loki, Tempo}             (zellij fork, #223)
+//
+// Only pipeline 1 carries data today; the log tail finds no files and the
+// OTLP receiver no clients until the forks emit, but wiring them now means no
+// re-plumbing when they land. ZELLIJ_DIAG is set by the systemd unit.
+
+// --- 1. zellijstat metrics ---------------------------------------------------
+prometheus.scrape "zellijstat" {
+  targets         = [{ __address__ = "127.0.0.1:9095", job = "zellijstat" }]
+  scrape_interval = "2s"
+  scrape_timeout  = "1s"
+  forward_to      = [prometheus.remote_write.local.receiver]
+}
+
+prometheus.remote_write "local" {
+  endpoint {
+    url = "http://127.0.0.1:9090/api/v1/write"
+  }
+}
+
+// --- 2. zellij-diag log files ------------------------------------------------
+local.file_match "zellij_diag" {
+  path_targets = [{ __path__ = sys.env("ZELLIJ_DIAG") + "/*.log" }]
+}
+
+loki.source.file "zellij_diag" {
+  targets    = local.file_match.zellij_diag.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://127.0.0.1:3100/loki/api/v1/push"
+  }
+}
+
+// --- 3. OTLP from the forks --------------------------------------------------
+otelcol.receiver.otlp "forks" {
+  grpc {
+    endpoint = "127.0.0.1:4317"
+  }
+  http {
+    endpoint = "127.0.0.1:4318"
+  }
+  output {
+    metrics = [otelcol.exporter.prometheus.forks.input]
+    logs    = [otelcol.exporter.loki.forks.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+otelcol.exporter.prometheus "forks" {
+  forward_to = [prometheus.remote_write.local.receiver]
+}
+
+otelcol.exporter.loki "forks" {
+  forward_to = [loki.write.local.receiver]
+}
+
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "127.0.0.1:4417"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/dot_config/grafana/dashboards/zellij-freeze.json
+++ b/dot_config/grafana/dashboards/zellij-freeze.json
@@ -1,6 +1,6 @@
 {
   "uid": "zellij-freeze",
-  "title": "zellij freeze",
+  "title": "Zellij freeze",
   "tags": ["zellij", "freeze"],
   "timezone": "browser",
   "schemaVersion": 39,

--- a/dot_config/grafana/dashboards/zellij-freeze.json
+++ b/dot_config/grafana/dashboards/zellij-freeze.json
@@ -1,0 +1,161 @@
+{
+  "uid": "zellij-freeze",
+  "title": "zellij freeze",
+  "tags": ["zellij", "freeze"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "session",
+        "label": "Session",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+        "query": { "query": "label_values(zellijstat_server_threads, session)", "refId": "session" },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Threads per server",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_threads{session=~\"$session\"}",
+          "legendFormat": "{{session}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Threads by name (server_listener / server_router growth)",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_threads_by_comm{session=~\"$session\"}",
+          "legendFormat": "{{session}} {{comm}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Threads by wait-channel (futex pile-up)",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "showPoints": "never", "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_threads_by_wchan{session=~\"$session\"}",
+          "legendFormat": "{{session}} {{wchan}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Unix connections per server",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_unix_connections{session=~\"$session\"}",
+          "legendFormat": "{{session}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Socket queue depth",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_unix_recvq_bytes{session=~\"$session\"}",
+          "legendFormat": "{{session}} recv-q"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_unix_sendq_bytes{session=~\"$session\"}",
+          "legendFormat": "{{session}} send-q"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Open file descriptors",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_open_fds{session=~\"$session\"}",
+          "legendFormat": "{{session}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Resident memory",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "zellijstat_server_memory_rss_bytes{session=~\"$session\"}",
+          "legendFormat": "{{session}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "CPU usage",
+      "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "showPoints": "never" } }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "zellij-prometheus" },
+          "expr": "rate(zellijstat_server_cpu_seconds_total{session=~\"$session\"}[1m])",
+          "legendFormat": "{{session}}"
+        }
+      ]
+    }
+  ]
+}

--- a/dot_config/grafana/provisioning/dashboards/zellij-observability.yaml.tmpl
+++ b/dot_config/grafana/provisioning/dashboards/zellij-observability.yaml.tmpl
@@ -1,0 +1,12 @@
+# Load the zellij-freeze dashboard from ~/.config/grafana/dashboards. The path
+# must be absolute, so chezmoi injects the home directory at apply time.
+apiVersion: 1
+
+providers:
+  - name: zellij-observability
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: {{ .chezmoi.homeDir }}/.config/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/dot_config/grafana/provisioning/datasources/zellij-observability.yaml
+++ b/dot_config/grafana/provisioning/datasources/zellij-observability.yaml
@@ -1,0 +1,37 @@
+# Datasources for the zellij-freeze observability stack. All three backends
+# run on localhost; the correlation links (trace -> logs, trace -> metrics,
+# log -> trace) are where the OTEL stack pays off once the forks emit.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: zellij-prometheus
+    access: proxy
+    url: http://127.0.0.1:9090
+    isDefault: true
+
+  - name: Loki
+    type: loki
+    uid: zellij-loki
+    access: proxy
+    url: http://127.0.0.1:3100
+    jsonData:
+      # Jump from a log line's trace_id to the trace in Tempo.
+      derivedFields:
+        - name: trace_id
+          matcherType: label
+          matcherRegex: trace_id
+          datasourceUid: zellij-tempo
+          url: '${__value.raw}'
+
+  - name: Tempo
+    type: tempo
+    uid: zellij-tempo
+    access: proxy
+    url: http://127.0.0.1:3200
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: zellij-loki
+      tracesToMetrics:
+        datasourceUid: zellij-prometheus

--- a/dot_config/loki/config.yml
+++ b/dot_config/loki/config.yml
@@ -1,0 +1,38 @@
+# Loki for the zellij-freeze observability stack: single-binary, filesystem
+# storage, no auth, localhost only. ${ZELLIJ_OBS_STATE} is expanded at runtime
+# (the systemd unit passes -config.expand-env=true and sets the variable).
+auth_enabled: false
+
+server:
+  http_listen_address: 127.0.0.1
+  http_listen_port: 3100
+  grpc_listen_address: 127.0.0.1
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: ${ZELLIJ_OBS_STATE}/loki
+  storage:
+    filesystem:
+      chunks_directory: ${ZELLIJ_OBS_STATE}/loki/chunks
+      rules_directory: ${ZELLIJ_OBS_STATE}/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# Single-user local instance: keep everything, never reject for age/rate.
+limits_config:
+  retention_period: 0s
+  reject_old_samples: false

--- a/dot_config/prometheus/prometheus.yml
+++ b/dot_config/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+# Prometheus for the zellij-freeze observability stack.
+# Metrics arrive via remote-write from Alloy (the systemd unit starts
+# Prometheus with --web.enable-remote-write-receiver); the only scrape here
+# is Prometheus watching itself. Storage path is set on the command line.
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['127.0.0.1:9090']

--- a/dot_config/systemd/user/alloy.service
+++ b/dot_config/systemd/user/alloy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Grafana Alloy (zellij-freeze collector)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
+After=prometheus.service loki.service tempo.service
+
+[Service]
+Environment=ZELLIJ_DIAG=%S/zellij-diag
+ExecStart=%h/.local/bin/alloy run %h/.config/alloy/config.alloy \
+  --storage.path=%S/zellij-observability/alloy \
+  --server.http.listen-addr=127.0.0.1:12345
+StateDirectory=zellij-observability/alloy zellij-diag
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=zellij-observability.target

--- a/dot_config/systemd/user/alloy.service
+++ b/dot_config/systemd/user/alloy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Grafana Alloy (zellij-freeze collector)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 After=prometheus.service loki.service tempo.service
 

--- a/dot_config/systemd/user/grafana.service
+++ b/dot_config/systemd/user/grafana.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Grafana (zellij-freeze dashboards, on-demand viewer)
+Description=Grafana (zellij-freeze dashboards)
 Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
 
 [Service]
 Environment=GF_PATHS_HOME=%h/.local/share/grafana/current
@@ -11,8 +12,8 @@ Environment=GF_SERVER_HTTP_ADDR=127.0.0.1
 Environment=GF_SERVER_HTTP_PORT=3000
 ExecStart=%h/.local/share/grafana/current/bin/grafana server --homepath %h/.local/share/grafana/current
 StateDirectory=zellij-observability/grafana
-Restart=on-failure
+Restart=always
 RestartSec=2
 
 [Install]
-WantedBy=default.target
+WantedBy=zellij-observability.target

--- a/dot_config/systemd/user/grafana.service
+++ b/dot_config/systemd/user/grafana.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Grafana (zellij-freeze dashboards, on-demand viewer)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+
+[Service]
+Environment=GF_PATHS_HOME=%h/.local/share/grafana/current
+Environment=GF_PATHS_DATA=%S/zellij-observability/grafana
+Environment=GF_PATHS_LOGS=%S/zellij-observability/grafana/log
+Environment=GF_PATHS_PROVISIONING=%h/.config/grafana/provisioning
+Environment=GF_SERVER_HTTP_ADDR=127.0.0.1
+Environment=GF_SERVER_HTTP_PORT=3000
+ExecStart=%h/.local/share/grafana/current/bin/grafana server --homepath %h/.local/share/grafana/current
+StateDirectory=zellij-observability/grafana
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/dot_config/systemd/user/grafana.service
+++ b/dot_config/systemd/user/grafana.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Grafana (zellij-freeze dashboards)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 
 [Service]

--- a/dot_config/systemd/user/loki.service
+++ b/dot_config/systemd/user/loki.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Loki (zellij-freeze log store)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 
 [Service]

--- a/dot_config/systemd/user/loki.service
+++ b/dot_config/systemd/user/loki.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Loki (zellij-freeze log store)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
+
+[Service]
+Environment=ZELLIJ_OBS_STATE=%S/zellij-observability
+ExecStart=%h/.local/bin/loki -config.file=%h/.config/loki/config.yml -config.expand-env=true
+StateDirectory=zellij-observability/loki
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=zellij-observability.target

--- a/dot_config/systemd/user/prometheus.service
+++ b/dot_config/systemd/user/prometheus.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Prometheus (zellij-freeze metrics store)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
+
+[Service]
+ExecStart=%h/.local/bin/prometheus \
+  --config.file=%h/.config/prometheus/prometheus.yml \
+  --storage.tsdb.path=%S/zellij-observability/prometheus \
+  --web.listen-address=127.0.0.1:9090 \
+  --web.enable-remote-write-receiver
+StateDirectory=zellij-observability/prometheus
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=zellij-observability.target

--- a/dot_config/systemd/user/prometheus.service
+++ b/dot_config/systemd/user/prometheus.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Prometheus (zellij-freeze metrics store)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 
 [Service]

--- a/dot_config/systemd/user/tempo.service
+++ b/dot_config/systemd/user/tempo.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tempo (zellij-freeze trace store)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
+
+[Service]
+Environment=ZELLIJ_OBS_STATE=%S/zellij-observability
+ExecStart=%h/.local/bin/tempo -config.file=%h/.config/tempo/config.yml -config.expand-env=true
+StateDirectory=zellij-observability/tempo
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=zellij-observability.target

--- a/dot_config/systemd/user/tempo.service
+++ b/dot_config/systemd/user/tempo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tempo (zellij-freeze trace store)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 
 [Service]

--- a/dot_config/systemd/user/zellij-observability.target
+++ b/dot_config/systemd/user/zellij-observability.target
@@ -1,0 +1,12 @@
+[Unit]
+Description=zellij-freeze observability capture stack (always-on)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+# Wants pulls the capture services in when the target starts, so a single
+# `systemctl --user enable --now zellij-observability.target` brings up (and
+# auto-restarts at login) the whole stack. Grafana is deliberately absent —
+# it is an on-demand viewer, started only when looking.
+Wants=zellijstat.service prometheus.service loki.service tempo.service alloy.service
+After=zellijstat.service prometheus.service loki.service tempo.service alloy.service
+
+[Install]
+WantedBy=default.target

--- a/dot_config/systemd/user/zellij-observability.target
+++ b/dot_config/systemd/user/zellij-observability.target
@@ -1,6 +1,6 @@
 [Unit]
 Description=zellij-freeze observability capture stack (always-on)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 # Wants pulls the whole stack in when the target starts, so a single
 # `systemctl --user enable --now zellij-observability.target` brings up (and
 # auto-restarts at login) every service. run_onchange_after_10 runs that on

--- a/dot_config/systemd/user/zellij-observability.target
+++ b/dot_config/systemd/user/zellij-observability.target
@@ -1,12 +1,12 @@
 [Unit]
 Description=zellij-freeze observability capture stack (always-on)
 Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
-# Wants pulls the capture services in when the target starts, so a single
+# Wants pulls the whole stack in when the target starts, so a single
 # `systemctl --user enable --now zellij-observability.target` brings up (and
-# auto-restarts at login) the whole stack. Grafana is deliberately absent —
-# it is an on-demand viewer, started only when looking.
-Wants=zellijstat.service prometheus.service loki.service tempo.service alloy.service
-After=zellijstat.service prometheus.service loki.service tempo.service alloy.service
+# auto-restarts at login) every service. run_onchange_after_10 runs that on
+# `chezmoi apply`, so a fresh host comes up capturing without manual steps.
+Wants=zellijstat.service prometheus.service loki.service tempo.service alloy.service grafana.service
+After=zellijstat.service prometheus.service loki.service tempo.service alloy.service grafana.service
 
 [Install]
 WantedBy=default.target

--- a/dot_config/systemd/user/zellijstat.service
+++ b/dot_config/systemd/user/zellijstat.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=zellij server /proc sampler (Prometheus exporter)
-Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/viewing-zellij-freeze-data.md
 PartOf=zellij-observability.target
 
 [Service]

--- a/dot_config/systemd/user/zellijstat.service
+++ b/dot_config/systemd/user/zellijstat.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=zellij server /proc sampler (Prometheus exporter)
+Documentation=https://github.com/alunduil/alunduil-chezmoi/blob/main/docs/how-to/zellij-observability.md
+PartOf=zellij-observability.target
+
+[Service]
+ExecStart=%h/.local/bin/zellijstat --listen 127.0.0.1:9095
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=zellij-observability.target

--- a/dot_config/tempo/config.yml
+++ b/dot_config/tempo/config.yml
@@ -1,0 +1,28 @@
+# Tempo for the zellij-freeze observability stack: monolithic, local-block
+# storage, localhost only. Alloy forwards traces here over OTLP, so Tempo's
+# own OTLP receiver listens on 4417/4418 to stay clear of Alloy's 4317/4318.
+# ${ZELLIJ_OBS_STATE} is expanded at runtime (the unit passes
+# -config.expand-env=true and sets the variable).
+server:
+  http_listen_address: 127.0.0.1
+  http_listen_port: 3200
+  grpc_listen_address: 127.0.0.1
+  grpc_listen_port: 9097
+  log_level: warn
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 127.0.0.1:4417
+        http:
+          endpoint: 127.0.0.1:4418
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: ${ZELLIJ_OBS_STATE}/tempo/blocks
+    wal:
+      path: ${ZELLIJ_OBS_STATE}/tempo/wal

--- a/dot_local/bin/executable_zellijstat
+++ b/dot_local/bin/executable_zellijstat
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""External /proc sampler for zellij servers, exposed as Prometheus metrics.
+
+Enumerates every zellij *server* process (comm == ``zellij`` with a
+``--server`` argument — never a substring match, which would catch the
+sampler's own shell) and, per server, reports the signals the zellij-freeze
+investigation needs to watch climb: thread count by name, per-thread kernel
+wait-channel (the futex pile-up), Unix-socket connection count with
+Recv-Q/Send-Q, open fds, CPU and RSS. Each series is tagged by session.
+
+It is a pull exporter: a scrape samples /proc on demand, so the resolution is
+the scraper's interval (Alloy/Prometheus at ~2s). Reading /proc never touches
+the zellij IPC socket, so the sampler keeps reporting straight through a server
+wedge — which is the whole point of an *external* observer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+CLK_TCK = os.sysconf("SC_CLK_TCK")
+PID_RE = re.compile(rb"pid=(\d+)")
+_PID_DIR_RE = re.compile(r"\A\d+\Z")
+
+
+@dataclass
+class ServerSample:
+    """One sampled zellij server."""
+
+    pid: int
+    session: str
+    threads: int = 0
+    threads_by_comm: dict[str, int] = field(default_factory=dict)
+    threads_by_wchan: dict[str, int] = field(default_factory=dict)
+    connections: int = 0
+    recvq_bytes: int = 0
+    sendq_bytes: int = 0
+    open_fds: int = 0
+    cpu_seconds: float = 0.0
+    rss_bytes: int = 0
+
+
+def session_from_cmdline(cmdline: bytes) -> str | None:
+    """Return the session name from a zellij server's /proc cmdline.
+
+    The server is launched as ``zellij --server <socket-path>`` and the socket
+    file is named after the session, so the session is the basename of the
+    argument following ``--server``. Returns None when this is not a server
+    invocation (no ``--server``), which is how client processes are excluded.
+    """
+    args = [a for a in cmdline.split(b"\x00") if a]
+    for i, arg in enumerate(args):
+        if arg == b"--server" and i + 1 < len(args):
+            return os.path.basename(args[i + 1].decode("utf-8", "replace"))
+    return None
+
+
+def _read_bytes(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError:
+        return b""
+
+
+def _read_text(path: Path) -> str:
+    return _read_bytes(path).decode("utf-8", "replace")
+
+
+def collect_threads(task_dir: Path) -> tuple[int, dict[str, int], dict[str, int]]:
+    """Count threads under a process's task/ dir, grouped by comm and wchan."""
+    total = 0
+    by_comm: dict[str, int] = {}
+    by_wchan: dict[str, int] = {}
+    try:
+        tids = list(task_dir.iterdir())
+    except OSError:
+        return 0, by_comm, by_wchan
+    for tid in tids:
+        comm = _read_text(tid / "comm").strip()
+        if not comm:
+            # Thread vanished between listing and read; don't count a ghost.
+            continue
+        total += 1
+        by_comm[comm] = by_comm.get(comm, 0) + 1
+        # wchan is "0" (or empty) for a running thread; bucket those as
+        # "running" so the futex/poll waiters stand out against the baseline.
+        wchan = _read_text(tid / "wchan").strip() or "0"
+        if wchan == "0":
+            wchan = "running"
+        by_wchan[wchan] = by_wchan.get(wchan, 0) + 1
+    return total, by_comm, by_wchan
+
+
+def read_rss_bytes(status_text: str) -> int:
+    """Parse VmRSS (kB) from /proc/<pid>/status into bytes."""
+    for line in status_text.splitlines():
+        if line.startswith("VmRSS:"):
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return int(parts[1]) * 1024
+    return 0
+
+
+def read_cpu_seconds(stat_text: str) -> float:
+    """Parse utime+stime from /proc/<pid>/stat into seconds.
+
+    comm (field 2) may contain spaces and parens, so split on the last ')'
+    before reading the space-delimited fields that follow.
+    """
+    rparen = stat_text.rfind(")")
+    if rparen == -1:
+        return 0.0
+    rest = stat_text[rparen + 2 :].split()
+    # After comm, fields are 1-indexed from "state" (field 3). utime is field
+    # 14 and stime field 15, i.e. indices 11 and 12 of `rest`.
+    if len(rest) < 13:
+        return 0.0
+    try:
+        return (int(rest[11]) + int(rest[12])) / CLK_TCK
+    except ValueError:
+        return 0.0
+
+
+def parse_ss_unix(text: str) -> dict[int, tuple[int, int, int]]:
+    """Aggregate `ss -xp` output to pid -> (connections, recvq, sendq).
+
+    A socket is attributed to every pid named in its process column, so a
+    server's connection count is the number of Unix sockets it holds. Recv-Q
+    and Send-Q are columns 3 and 4 of each data line.
+    """
+    out: dict[int, list[int]] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("Netid"):
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        try:
+            recvq = int(parts[2])
+            sendq = int(parts[3])
+        except ValueError:
+            continue
+        for m in PID_RE.finditer(raw.encode("utf-8", "replace")):
+            pid = int(m.group(1))
+            agg = out.setdefault(pid, [0, 0, 0])
+            agg[0] += 1
+            agg[1] += recvq
+            agg[2] += sendq
+    return {pid: (c, r, s) for pid, (c, r, s) in out.items()}
+
+
+def run_ss() -> str:
+    """Return `ss -xp` output, or "" if ss is missing or fails."""
+    try:
+        proc = subprocess.run(
+            ["ss", "-xp"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout
+
+
+def iter_server_pids(proc_root: Path):
+    """Yield (pid, session) for every zellij server under proc_root."""
+    try:
+        entries = list(proc_root.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        if not _PID_DIR_RE.match(entry.name):
+            continue
+        if _read_text(entry / "comm").strip() != "zellij":
+            continue
+        session = session_from_cmdline(_read_bytes(entry / "cmdline"))
+        if session is None:
+            continue
+        yield int(entry.name), session
+
+
+def collect(proc_root: Path = Path("/proc"), ss_text: str | None = None):
+    """Sample every zellij server. ss_text is injectable for tests."""
+    if ss_text is None:
+        ss_text = run_ss()
+    ss_by_pid = parse_ss_unix(ss_text)
+    samples: list[ServerSample] = []
+    for pid, session in iter_server_pids(proc_root):
+        pid_dir = proc_root / str(pid)
+        s = ServerSample(pid=pid, session=session)
+        s.threads, s.threads_by_comm, s.threads_by_wchan = collect_threads(
+            pid_dir / "task"
+        )
+        s.rss_bytes = read_rss_bytes(_read_text(pid_dir / "status"))
+        s.cpu_seconds = read_cpu_seconds(_read_text(pid_dir / "stat"))
+        try:
+            s.open_fds = len(list((pid_dir / "fd").iterdir()))
+        except OSError:
+            s.open_fds = 0
+        s.connections, s.recvq_bytes, s.sendq_bytes = ss_by_pid.get(pid, (0, 0, 0))
+        samples.append(s)
+    return samples
+
+
+def _esc(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _labels(pairs: dict[str, str]) -> str:
+    return ",".join(f'{k}="{_esc(v)}"' for k, v in pairs.items())
+
+
+def render(samples: list[ServerSample]) -> str:
+    """Render samples as Prometheus text exposition format."""
+    lines: list[str] = []
+
+    def metric(name: str, mtype: str, help_text: str):
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {mtype}")
+
+    metric("zellijstat_servers", "gauge", "Number of zellij servers sampled.")
+    lines.append(f"zellijstat_servers {len(samples)}")
+
+    metric("zellijstat_server_threads", "gauge", "Threads in the zellij server.")
+    for s in samples:
+        lines.append(
+            f'zellijstat_server_threads{{{_labels({"session": s.session, "pid": str(s.pid)})}}} {s.threads}'
+        )
+
+    metric(
+        "zellijstat_server_threads_by_comm",
+        "gauge",
+        "Server threads grouped by thread name.",
+    )
+    for s in samples:
+        for comm, n in sorted(s.threads_by_comm.items()):
+            lbl = _labels({"session": s.session, "pid": str(s.pid), "comm": comm})
+            lines.append(f"zellijstat_server_threads_by_comm{{{lbl}}} {n}")
+
+    metric(
+        "zellijstat_server_threads_by_wchan",
+        "gauge",
+        "Server threads grouped by kernel wait channel.",
+    )
+    for s in samples:
+        for wchan, n in sorted(s.threads_by_wchan.items()):
+            lbl = _labels({"session": s.session, "pid": str(s.pid), "wchan": wchan})
+            lines.append(f"zellijstat_server_threads_by_wchan{{{lbl}}} {n}")
+
+    metric(
+        "zellijstat_server_unix_connections",
+        "gauge",
+        "Unix-domain sockets held by the zellij server.",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_unix_connections{{{lbl}}} {s.connections}")
+
+    metric(
+        "zellijstat_server_unix_recvq_bytes",
+        "gauge",
+        "Summed Recv-Q across the server's Unix sockets.",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_unix_recvq_bytes{{{lbl}}} {s.recvq_bytes}")
+
+    metric(
+        "zellijstat_server_unix_sendq_bytes",
+        "gauge",
+        "Summed Send-Q across the server's Unix sockets.",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_unix_sendq_bytes{{{lbl}}} {s.sendq_bytes}")
+
+    metric("zellijstat_server_open_fds", "gauge", "Open file descriptors.")
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_open_fds{{{lbl}}} {s.open_fds}")
+
+    metric(
+        "zellijstat_server_cpu_seconds_total",
+        "counter",
+        "Server CPU time (utime+stime) in seconds.",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_cpu_seconds_total{{{lbl}}} {s.cpu_seconds}")
+
+    metric("zellijstat_server_memory_rss_bytes", "gauge", "Resident set size.")
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_memory_rss_bytes{{{lbl}}} {s.rss_bytes}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _make_handler(proc_root: Path):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 (http.server API)
+            if self.path.rstrip("/") not in ("", "/metrics"):
+                self.send_error(404)
+                return
+            body = render(collect(proc_root)).encode("utf-8")
+            self.send_response(200)
+            self.send_header(
+                "Content-Type", "text/plain; version=0.0.4; charset=utf-8"
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):  # silence per-request stderr noise
+            pass
+
+    return Handler
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="zellijstat",
+        description="Sample zellij servers from /proc and expose Prometheus metrics.",
+    )
+    parser.add_argument(
+        "--listen",
+        default=os.environ.get("ZELLIJSTAT_LISTEN", "127.0.0.1:9095"),
+        metavar="HOST:PORT",
+        help="address to serve /metrics on (default: 127.0.0.1:9095)",
+    )
+    parser.add_argument(
+        "--proc-root",
+        default="/proc",
+        metavar="DIR",
+        help="procfs root to sample (default: /proc)",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="print one sample to stdout and exit (no server)",
+    )
+    args = parser.parse_args(argv)
+    proc_root = Path(args.proc_root)
+
+    if args.once:
+        sys.stdout.write(render(collect(proc_root)))
+        return 0
+
+    host, _, port = args.listen.rpartition(":")
+    server = ThreadingHTTPServer((host or "127.0.0.1", int(port)), _make_handler(proc_root))
+    sys.stderr.write(f"zellijstat: serving /metrics on {args.listen}\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dot_local/bin/executable_zellijstat
+++ b/dot_local/bin/executable_zellijstat
@@ -234,7 +234,7 @@ def render(samples: list[ServerSample]) -> str:
     metric("zellijstat_server_threads", "gauge", "Threads in the zellij server.")
     for s in samples:
         lines.append(
-            f'zellijstat_server_threads{{{_labels({"session": s.session, "pid": str(s.pid)})}}} {s.threads}'
+            f"zellijstat_server_threads{{{_labels({'session': s.session, 'pid': str(s.pid)})}}} {s.threads}"
         )
 
     metric(
@@ -314,9 +314,7 @@ def _make_handler(proc_root: Path):
                 return
             body = render(collect(proc_root)).encode("utf-8")
             self.send_response(200)
-            self.send_header(
-                "Content-Type", "text/plain; version=0.0.4; charset=utf-8"
-            )
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -357,7 +355,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     host, _, port = args.listen.rpartition(":")
-    server = ThreadingHTTPServer((host or "127.0.0.1", int(port)), _make_handler(proc_root))
+    server = ThreadingHTTPServer(
+        (host or "127.0.0.1", int(port)), _make_handler(proc_root)
+    )
     sys.stderr.write(f"zellijstat: serving /metrics on {args.listen}\n")
     try:
         server.serve_forever()

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ check:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
-    for c in check-pre-commit check-bats check-zellij check-chezmoi; do
+    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi; do
       just "$c" || rc=1
     done
     exit "$rc"
@@ -30,6 +30,10 @@ check-pre-commit:
 # Unit tests.
 check-bats:
     bats test/
+
+# Python unit tests (zellijstat parsers).
+check-python:
+    python3 test/zellijstat_test.py
 
 # Zellij KDL validation (needs zellij on PATH).
 check-zellij:

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ check:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
-    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi; do
+    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi check-observability; do
       just "$c" || rc=1
     done
     exit "$rc"
@@ -42,3 +42,8 @@ check-zellij:
 # Apply round-trip (needs chezmoi + age on PATH).
 check-chezmoi:
     script/checks/chezmoi-apply
+
+# Observability config validation (skips when the stack binaries are absent;
+# the live metrics smoke is CI-only — it binds the running stack's ports).
+check-observability:
+    script/checks/observability-config

--- a/renovate.json
+++ b/renovate.json
@@ -102,6 +102,41 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^script/install/alloy$/"],
+      "matchStrings": ["ALLOY_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "grafana/alloy",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^script/install/prometheus$/"],
+      "matchStrings": ["PROMETHEUS_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "prometheus/prometheus",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^script/install/loki$/"],
+      "matchStrings": ["LOKI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "grafana/loki",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^script/install/tempo$/"],
+      "matchStrings": ["TEMPO_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "grafana/tempo",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^script/install/grafana$/"],
+      "matchStrings": ["GRAFANA_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "grafana/grafana",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^run_once_before_05-install-standalone-tools\\.sh\\.tmpl$/"],
       "matchStrings": ["GH_POI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "seachicken/gh-poi",

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -10,6 +10,11 @@
 # vale content:       {{ include "script/install/vale" | sha256sum }}
 # trivy content:      {{ include "script/install/trivy" | sha256sum }}
 # just content:       {{ include "script/install/just" | sha256sum }}
+# alloy content:      {{ include "script/install/alloy" | sha256sum }}
+# prometheus content: {{ include "script/install/prometheus" | sha256sum }}
+# loki content:       {{ include "script/install/loki" | sha256sum }}
+# tempo content:      {{ include "script/install/tempo" | sha256sum }}
+# grafana content:    {{ include "script/install/grafana" | sha256sum }}
 # lib.sh content:     {{ include "script/install/lib.sh" | sha256sum }}
 # The hashes above embed the install scripts' content into this file's
 # rendered output so chezmoi re-runs this script when any of them change
@@ -29,6 +34,15 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/vale" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/trivy" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/just" --bin-dir "$HOME/.local/bin"
+
+# zellij-freeze observability stack (see docs/how-to/zellij-observability.md).
+# Always installed; the systemd services stay inert until enabled per host
+# with `systemctl --user enable --now zellij-observability.target`.
+"$INSTALL_DIR/alloy" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/prometheus" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/loki" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/tempo" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/grafana" --bin-dir "$HOME/.local/bin"
 
 # gcx ships its skill bundle inside the binary; `agent skills install
 # --all` extracts it to ~/.agents/skills (the cross-harness convention

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -35,7 +35,7 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/trivy" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/just" --bin-dir "$HOME/.local/bin"
 
-# zellij-freeze observability stack (see docs/how-to/zellij-observability.md).
+# zellij-freeze observability stack (see docs/how-to/viewing-zellij-freeze-data.md).
 # Always installed; the systemd services stay inert until enabled per host
 # with `systemctl --user enable --now zellij-observability.target`.
 "$INSTALL_DIR/alloy" --bin-dir "$HOME/.local/bin"

--- a/run_onchange_after_10-enable-observability.sh.tmpl
+++ b/run_onchange_after_10-enable-observability.sh.tmpl
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Unit hashes below re-run this script whenever a unit changes, so edits
+# (new ExecStart flags, added services) re-apply via daemon-reload + enable.
+# zellijstat unit:  {{ include "dot_config/systemd/user/zellijstat.service" | sha256sum }}
+# prometheus unit:  {{ include "dot_config/systemd/user/prometheus.service" | sha256sum }}
+# loki unit:        {{ include "dot_config/systemd/user/loki.service" | sha256sum }}
+# tempo unit:       {{ include "dot_config/systemd/user/tempo.service" | sha256sum }}
+# alloy unit:       {{ include "dot_config/systemd/user/alloy.service" | sha256sum }}
+# grafana unit:     {{ include "dot_config/systemd/user/grafana.service" | sha256sum }}
+# target unit:      {{ include "dot_config/systemd/user/zellij-observability.target" | sha256sum }}
+
+set -euo pipefail
+
+# Skip where there is no user systemd manager to talk to (headless apply over
+# SSH without lingering, container builds). The units are still deployed; a
+# later interactive apply, or a manual enable, brings the stack up.
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "==> observability: no user systemd session; leaving units disabled" >&2
+  exit 0
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now zellij-observability.target

--- a/script/checks/observability-config
+++ b/script/checks/observability-config
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Validate the observability service configs with each tool's own checker.
+# Needs promtool, alloy, loki, and tempo on PATH (installed by
+# script/install/*); skips cleanly when they are absent so a pre-bootstrap
+# `just check` does not fail. CI installs them, so there it actually runs.
+set -uo pipefail
+
+ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for tool in promtool alloy loki tempo; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '==> observability-config: %s not on PATH; skipping\n' "$tool" >&2
+    exit 0
+  fi
+done
+
+# Loki/Tempo expand these at parse time; Alloy reads ZELLIJ_DIAG via sys.env.
+state="${XDG_STATE_HOME:-$HOME/.local/state}"
+export ZELLIJ_OBS_STATE="${ZELLIJ_OBS_STATE:-$state/zellij-observability}"
+export ZELLIJ_DIAG="${ZELLIJ_DIAG:-$state/zellij-diag}"
+
+rc=0
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    printf 'OK: %s\n' "$name"
+  else
+    printf 'FAIL: %s config invalid\n' "$name" >&2
+    rc=1
+  fi
+}
+
+check prometheus promtool check config dot_config/prometheus/prometheus.yml
+check alloy alloy validate dot_config/alloy/config.alloy
+check loki loki -config.file=dot_config/loki/config.yml -config.expand-env=true -verify-config
+check tempo tempo -config.file=dot_config/tempo/config.yml -config.expand-env=true -config.verify=true
+
+exit "$rc"

--- a/script/checks/observability-smoke
+++ b/script/checks/observability-smoke
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# End-to-end smoke for the metrics path: launch zellijstat, Prometheus, and
+# Alloy on their real ports and assert a zellijstat sample reaches Prometheus
+# through Alloy. Catches runtime wiring bugs that static validation misses
+# (e.g. scrape_timeout > scrape_interval, which `alloy validate` accepts but
+# `alloy run` rejects). No zellij server is needed — zellijstat always emits
+# the zellijstat_servers gauge, so its arrival in Prometheus proves the whole
+# scrape -> remote_write -> store path.
+#
+# Binds 9090/9095/12345, so it is CI-only (a live local stack already holds
+# them). Needs alloy and prometheus on PATH; skips cleanly when absent.
+set -uo pipefail
+
+ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for tool in alloy prometheus; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '==> observability-smoke: %s not on PATH; skipping\n' "$tool" >&2
+    exit 0
+  fi
+done
+
+work="$(mktemp -d)"
+pids=()
+cleanup() {
+  for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null; done
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+export ZELLIJ_OBS_STATE="$work" ZELLIJ_DIAG="$work/diag"
+mkdir -p "$work/diag" "$work/prometheus" "$work/alloy"
+
+python3 dot_local/bin/executable_zellijstat --listen 127.0.0.1:9095 \
+  >"$work/zellijstat.log" 2>&1 &
+pids+=($!)
+prometheus --config.file=dot_config/prometheus/prometheus.yml \
+  --storage.tsdb.path="$work/prometheus" \
+  --web.listen-address=127.0.0.1:9090 \
+  --web.enable-remote-write-receiver >"$work/prometheus.log" 2>&1 &
+pids+=($!)
+alloy run dot_config/alloy/config.alloy \
+  --storage.path="$work/alloy" \
+  --server.http.listen-addr=127.0.0.1:12345 >"$work/alloy.log" 2>&1 &
+pids+=($!)
+
+for _ in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:9090/-/ready >/dev/null 2>&1 && break
+  sleep 1
+done
+
+query='http://127.0.0.1:9090/api/v1/query?query=zellijstat_servers'
+for _ in $(seq 1 30); do
+  if curl -fsS "$query" 2>/dev/null | grep -q '"__name__":"zellijstat_servers"'; then
+    echo "OK: zellijstat metrics reached Prometheus through Alloy"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "FAIL: zellijstat_servers never reached Prometheus" >&2
+echo "--- alloy.log (tail) ---" >&2
+tail -20 "$work/alloy.log" >&2
+exit 1

--- a/script/install/alloy
+++ b/script/install/alloy
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ALLOY_VERSION="v1.16.1"
+ARCH="linux-amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/alloy"
+if installed_version_matches "$bin" "$ALLOY_VERSION"; then
+  printf '==> alloy: %s already installed at %s\n' "$ALLOY_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> alloy: downloading %s\n' "$ALLOY_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}"
+asset="alloy-${ARCH}.zip"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/SHA256SUMS" "$base/SHA256SUMS"
+
+expected="$(expected_from_checksums "$tmp/SHA256SUMS" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+unzip -q "$tmp/$asset" -d "$tmp"
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/alloy-${ARCH}" "$bin"

--- a/script/install/grafana
+++ b/script/install/grafana
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GRAFANA_VERSION="v13.0.1"
+ARCH="linux-amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+# Accept --bin-dir for a uniform installer interface, but Grafana ships a
+# whole tree (conf/, public/), not a lone binary, so it installs under
+# XDG_DATA_HOME instead of BIN_DIR.
+parse_bin_dir "$@"
+
+data_root="${XDG_DATA_HOME:-$HOME/.local/share}/grafana"
+home_path="$data_root/grafana-${GRAFANA_VERSION}"
+if [ -x "$home_path/bin/grafana" ]; then
+  printf '==> grafana: %s already installed at %s\n' "$GRAFANA_VERSION" "$home_path" >&2
+  exit 0
+fi
+
+printf '==> grafana: downloading %s\n' "$GRAFANA_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://dl.grafana.com/oss/release"
+asset="grafana-${GRAFANA_VERSION#v}.${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
+
+# The sidecar lists the hash against an internal dist/ path, so take the
+# hash field directly rather than matching by asset name.
+expected="$(awk '{print $1}' "$tmp/$asset.sha256")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+# Tarball top dir is grafana-v<version>/; extract beside it and pin a
+# stable `current` symlink the systemd unit points its homepath at.
+mkdir -p "$data_root"
+tar -xzf "$tmp/$asset" -C "$data_root"
+ln -sfn "$home_path" "$data_root/current"

--- a/script/install/loki
+++ b/script/install/loki
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOKI_VERSION="v3.7.2"
+ARCH="linux-amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/loki"
+if installed_version_matches "$bin" "$LOKI_VERSION"; then
+  printf '==> loki: %s already installed at %s\n' "$LOKI_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> loki: downloading %s\n' "$LOKI_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/grafana/loki/releases/download/${LOKI_VERSION}"
+asset="loki-${ARCH}.zip"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/SHA256SUMS" "$base/SHA256SUMS"
+
+expected="$(expected_from_checksums "$tmp/SHA256SUMS" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+unzip -q "$tmp/$asset" -d "$tmp"
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/loki-${ARCH}" "$bin"

--- a/script/install/prometheus
+++ b/script/install/prometheus
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMETHEUS_VERSION="v3.12.0"
+ARCH="linux-amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/prometheus"
+if installed_version_matches "$bin" "$PROMETHEUS_VERSION"; then
+  printf '==> prometheus: %s already installed at %s\n' "$PROMETHEUS_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> prometheus: downloading %s\n' "$PROMETHEUS_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+dir="prometheus-${PROMETHEUS_VERSION#v}.${ARCH}"
+base="https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}"
+asset="${dir}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/sha256sums.txt" "$base/sha256sums.txt"
+
+expected="$(expected_from_checksums "$tmp/sha256sums.txt" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp"
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/$dir/prometheus" "$BIN_DIR/prometheus"
+install -m 0755 "$tmp/$dir/promtool" "$BIN_DIR/promtool"

--- a/script/install/tempo
+++ b/script/install/tempo
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEMPO_VERSION="v3.0.0"
+ARCH="linux_amd64"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/tempo"
+if installed_version_matches "$bin" "$TEMPO_VERSION"; then
+  printf '==> tempo: %s already installed at %s\n' "$TEMPO_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> tempo: downloading %s\n' "$TEMPO_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/grafana/tempo/releases/download/${TEMPO_VERSION}"
+asset="tempo_${TEMPO_VERSION#v}_${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/SHA256SUMS" "$base/SHA256SUMS"
+
+expected="$(expected_from_checksums "$tmp/SHA256SUMS" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp" tempo
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/tempo" "$bin"

--- a/test/zellijstat_test.py
+++ b/test/zellijstat_test.py
@@ -15,12 +15,18 @@ from pathlib import Path
 # Don't drop a __pycache__ beside the chezmoi-managed source when importing it.
 sys.dont_write_bytecode = True
 
-_SRC = Path(__file__).resolve().parent.parent / "dot_local" / "bin" / "executable_zellijstat"
+_SRC = (
+    Path(__file__).resolve().parent.parent
+    / "dot_local"
+    / "bin"
+    / "executable_zellijstat"
+)
 # The deployed file has no .py suffix, so name the loader explicitly rather
 # than letting importlib infer it from the extension. Register it in
 # sys.modules before exec so @dataclass can resolve its own module.
 _loader = SourceFileLoader("zellijstat", str(_SRC))
 _spec = importlib.util.spec_from_loader("zellijstat", _loader)
+assert _spec is not None  # spec_from_loader always returns a spec for a loader
 zs = importlib.util.module_from_spec(_spec)
 sys.modules["zellijstat"] = zs
 _loader.exec_module(zs)
@@ -120,7 +126,9 @@ class CollectAndIter(unittest.TestCase):
                 b"zellij\x00--server\x00/run/user/1000/zellij/0.43.1/sess-a\x00"
             )
             srv.joinpath("status").write_text("VmRSS:\t1024 kB\n")
-            srv.joinpath("stat").write_text("18533 (zellij) S 1 1 1 0 -1 0 0 0 0 0 5 5 0 0")
+            srv.joinpath("stat").write_text(
+                "18533 (zellij) S 1 1 1 0 -1 0 0 0 0 0 5 5 0 0"
+            )
             (srv / "fd").mkdir()
             (srv / "fd" / "0").write_text("")
             # A client process (no --server) must be skipped.

--- a/test/zellijstat_test.py
+++ b/test/zellijstat_test.py
@@ -1,0 +1,156 @@
+"""Function-layer tests for the zellijstat /proc sampler.
+
+Loads the chezmoi-managed executable (no .py suffix) by path and exercises its
+pure parsers against synthetic /proc and `ss` fixtures. These cover only
+zellijstat's own logic — session extraction, ss aggregation, stat/status
+parsing, thread grouping, and exposition rendering — not stdlib behaviour.
+"""
+
+import importlib.util
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "dot_local" / "bin" / "executable_zellijstat"
+# The deployed file has no .py suffix, so name the loader explicitly rather
+# than letting importlib infer it from the extension. Register it in
+# sys.modules before exec so @dataclass can resolve its own module.
+_loader = SourceFileLoader("zellijstat", str(_SRC))
+_spec = importlib.util.spec_from_loader("zellijstat", _loader)
+zs = importlib.util.module_from_spec(_spec)
+sys.modules["zellijstat"] = zs
+_loader.exec_module(zs)
+
+
+class SessionFromCmdline(unittest.TestCase):
+    def test_server_cmdline_yields_session(self):
+        cmd = b"/home/u/.local/bin/zellij\x00--server\x00/run/user/1000/zellij/0.43.1/mellifluous-muskrat\x00"
+        self.assertEqual(zs.session_from_cmdline(cmd), "mellifluous-muskrat")
+
+    def test_client_cmdline_has_no_server(self):
+        self.assertIsNone(zs.session_from_cmdline(b"zellij\x00"))
+
+    def test_server_flag_without_value(self):
+        self.assertIsNone(zs.session_from_cmdline(b"zellij\x00--server\x00"))
+
+
+class ReadRssBytes(unittest.TestCase):
+    def test_vmrss_kb_to_bytes(self):
+        status = "Name:\tzellij\nVmRSS:\t   167488 kB\nThreads:\t54\n"
+        self.assertEqual(zs.read_rss_bytes(status), 167488 * 1024)
+
+    def test_missing_vmrss(self):
+        self.assertEqual(zs.read_rss_bytes("Name:\tzellij\n"), 0)
+
+
+class ReadCpuSeconds(unittest.TestCase):
+    def test_utime_plus_stime(self):
+        # comm contains a ')' to prove the rfind-based split is robust.
+        stat = "42 (weird)name) S 1 1 1 0 -1 0 0 0 0 0 10 20 0 0 20 0 1 0 999"
+        self.assertAlmostEqual(zs.read_cpu_seconds(stat), 30 / zs.CLK_TCK)
+
+    def test_malformed_returns_zero(self):
+        self.assertEqual(zs.read_cpu_seconds("no parens here"), 0.0)
+
+
+class ParseSsUnix(unittest.TestCase):
+    def test_aggregates_per_pid_with_queues(self):
+        text = (
+            "Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n"
+            'u_str ESTAB 5 0 * 100 * 200 users:(("zellij",pid=18533,fd=9))\n'
+            'u_str ESTAB 0 7 * 101 * 201 users:(("zellij",pid=18533,fd=10))\n'
+            'u_str ESTAB 0 0 * 102 * 202 users:(("other",pid=999,fd=3))\n'
+        )
+        out = zs.parse_ss_unix(text)
+        self.assertEqual(out[18533], (2, 5, 7))
+        self.assertEqual(out[999], (1, 0, 0))
+
+    def test_lines_without_pid_are_ignored(self):
+        text = "u_str ESTAB 0 0 /run/systemd/journal/stdout 304 * 0\n"
+        self.assertEqual(zs.parse_ss_unix(text), {})
+
+
+class CollectThreads(unittest.TestCase):
+    def _make_task(self, root, threads):
+        task = root / "task"
+        for tid, (comm, wchan) in threads.items():
+            d = task / str(tid)
+            d.mkdir(parents=True)
+            (d / "comm").write_text(comm + "\n")
+            (d / "wchan").write_text(wchan)
+        return task
+
+    def test_groups_by_comm_and_wchan(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            task = self._make_task(
+                Path(tmp),
+                {
+                    1: ("zellij", "futex_wait"),
+                    2: ("server_router", "futex_wait"),
+                    3: ("server_router", "0"),
+                },
+            )
+            total, by_comm, by_wchan = zs.collect_threads(task)
+            self.assertEqual(total, 3)
+            self.assertEqual(by_comm["server_router"], 2)
+            self.assertEqual(by_wchan["futex_wait"], 2)
+            # wchan "0" is reported as the running bucket.
+            self.assertEqual(by_wchan["running"], 1)
+
+
+class CollectAndIter(unittest.TestCase):
+    def test_only_servers_sampled(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # A server process.
+            srv = root / "18533"
+            (srv / "task" / "18533").mkdir(parents=True)
+            (srv / "task" / "18533" / "comm").write_text("zellij\n")
+            (srv / "task" / "18533" / "wchan").write_text("futex_wait")
+            srv.joinpath("comm").write_text("zellij\n")
+            srv.joinpath("cmdline").write_bytes(
+                b"zellij\x00--server\x00/run/user/1000/zellij/0.43.1/sess-a\x00"
+            )
+            srv.joinpath("status").write_text("VmRSS:\t1024 kB\n")
+            srv.joinpath("stat").write_text("18533 (zellij) S 1 1 1 0 -1 0 0 0 0 0 5 5 0 0")
+            (srv / "fd").mkdir()
+            (srv / "fd" / "0").write_text("")
+            # A client process (no --server) must be skipped.
+            cli = root / "18530"
+            cli.mkdir()
+            cli.joinpath("comm").write_text("zellij\n")
+            cli.joinpath("cmdline").write_bytes(b"zellij\x00")
+
+            ss_text = 'u_str ESTAB 3 4 * 1 * 2 users:(("zellij",pid=18533,fd=9))\n'
+            samples = zs.collect(proc_root=root, ss_text=ss_text)
+
+            self.assertEqual(len(samples), 1)
+            s = samples[0]
+            self.assertEqual(s.session, "sess-a")
+            self.assertEqual(s.rss_bytes, 1024 * 1024)
+            self.assertEqual((s.connections, s.recvq_bytes, s.sendq_bytes), (1, 3, 4))
+            self.assertEqual(s.open_fds, 1)
+
+
+class Render(unittest.TestCase):
+    def test_exposition_shape_and_escaping(self):
+        s = zs.ServerSample(
+            pid=1,
+            session='we"ird',
+            threads=2,
+            threads_by_wchan={"futex_wait": 2},
+        )
+        out = zs.render([s])
+        self.assertIn("# TYPE zellijstat_server_threads gauge", out)
+        self.assertIn('session="we\\"ird"', out)
+        self.assertIn("zellijstat_servers 1", out)
+        self.assertTrue(out.endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/zellijstat_test.py
+++ b/test/zellijstat_test.py
@@ -12,6 +12,9 @@ import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+# Don't drop a __pycache__ beside the chezmoi-managed source when importing it.
+sys.dont_write_bytecode = True
+
 _SRC = Path(__file__).resolve().parent.parent / "dot_local" / "bin" / "executable_zellijstat"
 # The deployed file has no .py suffix, so name the loader explicitly rather
 # than letting importlib infer it from the extension. Register it in


### PR DESCRIPTION
## Summary

An always-on, out-of-band observability stack for the Zellij-freeze
investigation. `zellijstat` enumerates every Zellij server (`comm=zellij`
with `--server`, never a substring match) and exposes per-session Prometheus
metrics — thread count by name, **per-thread kernel wait-channel** (the futex
pile-up), Unix-socket connections with Recv-Q/Send-Q, fds, CPU, RSS. Alloy
collects into an always-on local Prometheus/Loki/Tempo; Grafana draws the
per-session curves. Because `zellijstat` only reads `/proc`, it keeps
recording straight through a server wedge — the point of an external observer.
Runs on stock Zellij, so it captures immediately. `chezmoi apply` installs,
deploys, and enables the whole stack — a fresh host comes up capturing with
no manual step. Closes #222.

This lands first; the fork instrumentation that feeds the log/trace paths is
#223 (Zellij OTEL) and #224 (zellaude logs).

## Gotchas

- **Scope expands past the issue's "metrics" acceptance to full
  traces/metrics/logs, by request.** Loki + Tempo are stood up and Alloy's
  log tail + OTLP receiver are wired, but they stay **idle until the forks
  (#223/#224)** emit. Decide whether you want the empty backends running now.
- **`chezmoi apply` auto-enables the stack on every host** with a user systemd
  session (no host profiles yet). That's six services (incl. an always-on
  Grafana, ~150 MB idle) starting on apply everywhere. Intentional per
  discussion; flag if you'd rather gate it.
- **OTLP receiver is loopback TCP `4317/4318`, not a Unix socket** — equally
  local, the documented Alloy config, and the OTLP SDK default the fork will
  target. None of these daemons support native systemd socket activation.

## Verification

- **End-to-end metrics smoke** (`script/checks/observability-smoke`, in CI):
  `zellijstat` → Alloy → Prometheus query returned the metric with the
  `session` label. Caught a real bug `alloy validate` accepts but `alloy run`
  rejects (`scrape_timeout` > `scrape_interval`) — the smoke is the only thing
  that catches that class.
- **Config validation** against the pinned binaries (`promtool`, `alloy
  validate`, `loki -verify-config`, `tempo -config.verify`), wrapped as
  `script/checks/observability-config` + run in CI.
- Ran the install scripts end to end (download + checksum + extract).
- `just check` green: pre-commit, bats, Python unit tests, zellij-config,
  chezmoi apply round-trip, observability config validation.

## CI and sensors

- **pre-commit** (every PR): `check-yaml`/`check-toml`/`check-json` for config
  syntax; **ruff-check + ruff-format + mypy** for the Python (`executable_zellijstat`
  matched by path, since chezmoi's `executable_` prefix leaves it `.py`-less);
  **actionlint** for the workflows; plus `debug-statements`/`check-ast`/`check-merge-conflict`.
- **`observability.yml`** (path-gated; installs ~400 MB only when the stack
  changes): config validation + the live metrics smoke.
- **`python.yml`**: zellijstat unit tests, consistent with bats.

## Follow-ups (filed from a coverage audit)

- #241 — verify the systemd units with `systemd-analyze` in CI.
- #242 — validate `run_*.sh.tmpl` rendering in CI (this PR's enable script is
  only hand-checked today).
- #243 — adopt repo-wide baseline hygiene hooks + markdownlint.