### PR TITLE
Restrict Claude to PR description over new comments

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -53,6 +53,10 @@ A per-repo `CLAUDE.md` overrides anything here.
 - When adding commits to an open PR, regenerate the body from scratch.
   The body describes the merge state, not the commit log; appending
   each round drifts toward changelog narration.
+- Never post a new comment on a PR we're working. Carry the update in
+  the description (regenerate the body) — it's the single source of
+  truth. The only PR comment allowed is a direct reply to an existing
+  comment on that PR.
 
 ## Commits
 


### PR DESCRIPTION
## Summary

Claude no longer posts standalone comments on PRs it authors — updates go into the description (regenerated each round), which is the single source of truth for the squash-merge context. The only comment Claude may post is a direct reply to an existing comment. Adds the rule to the Pull requests section of `dot_claude/CLAUDE.md`, which deploys to `~/.claude/CLAUDE.md`.

## Gotchas

This is text-only enforcement — it relies on Claude following the rule, unlike the draft guard which hard-blocks via hook. If it slips, decide whether to add a `gh pr comment` / `add_issue_comment` hook; the reply-to-existing-comment exception makes that harder to encode, which is why I left it as text for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)