### PR TITLE
Bring Docker CE under the bootstrap and auto-updates

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -31,6 +31,7 @@ ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)
 command -v calibre                         # ebook library manager
+docker --version                           # container engine (docker-ce, auto-updated)
 command -v truenas-mcp                     # TrueNAS MCP server binary
 trivy --version                            # vulnerability scanner (aquasecurity/trivy)
 gh extension list                          # confirms gh-poi (squash-merge pruner)

--- a/etc/apt/50unattended-upgrades
+++ b/etc/apt/50unattended-upgrades
@@ -14,6 +14,7 @@ Unattended-Upgrade::Origins-Pattern {
         "origin=gh,codename=stable";                            // GitHub CLI
         "origin=Tailscale,codename=${distro_codename}";         // Tailscale
         "origin=. xenial,codename=xenial";                      // Signal
+        "origin=Docker,archive=${distro_codename}";             // Docker CE (publishes Suite, not Codename)
         "site=prerelease.keybase.io";                           // Keybase (no repo metadata)
 };
 

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -45,6 +45,16 @@ if [ ! -f /etc/apt/sources.list.d/keybase.list ]; then
     sudo tee /etc/apt/sources.list.d/keybase.list >/dev/null
 fi
 
+# --------------------------------------------------------------------- docker
+if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then
+  log "docker: adding apt repository"
+  curl -fsSL https://download.docker.com/linux/debian/gpg |
+    sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+  printf 'deb [arch=%s signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian %s stable\n' \
+    "$(dpkg --print-architecture)" "$(lsb_release -cs)" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+fi
+
 # -------------------------------------------------------------------- apt pkgs
 APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin
@@ -52,6 +62,8 @@ APT_PACKAGES=(
   golang-petname
   keybase signal-desktop calibre
   nethack-console
+  docker-ce docker-ce-cli docker-ce-rootless-extras containerd.io
+  docker-buildx-plugin docker-compose-plugin
 )
 missing=()
 for pkg in "${APT_PACKAGES[@]}"; do


### PR DESCRIPTION
## Summary

Docker CE on this host now installs and auto-updates through the chezmoi bootstrap instead of being an unmanaged manual install. Closes #235. Follows #228, which scoped unattended-upgrades to bootstrap-added repos — without this, the Docker engine (a network-facing daemon) would have silently dropped off the patch timer.

The bootstrap adds the `download.docker.com` apt key + source and the six Docker packages (`docker-ce`, `docker-ce-cli`, `docker-ce-rootless-extras`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`) in `run_once_before_01`, and the Docker origin lands in the unattended-upgrades `Origins-Pattern`.

## Gotchas

- The origin pattern uses `archive=${distro_codename}`, **not** `codename=`. Docker's `Release` file publishes `Suite: bookworm` with no `Codename:` field, so a `codename=` match would silently never fire. I verified this against `/var/lib/apt/lists/download.docker.com_*InRelease` on the host. Don't "fix for consistency" with the sibling `codename=` entries.
- Keyring path follows repo precedent (`/usr/share/keyrings/docker-archive-keyring.gpg`), not the host's existing manual `/etc/apt/keyrings/docker.gpg`. On the live host the first re-apply rewrites `docker.list` to point at the precedent keyring and leaves the old keyring orphaned-but-harmless; fresh machines are clean. Worth a glance if you'd rather match Docker's documented `/etc/apt/keyrings` convention instead.

## Verification

- `just check` — all sensors pass (pre-commit, bats, zellij + chezmoi-apply round-trip, observability config).
- Confirmed the live host's repo metadata (`Origin: Docker`, `Suite: bookworm`, no `Codename`) and that all six packages are already installed, so the package set matches reality.
- `run_once_before_04` embeds a `sha256sum` of `50unattended-upgrades`, so the edit re-triggers the config install on next apply without extra wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)