### PR TITLE
Add git-poi-all to sweep gh poi across every clone

### DIFF
--- a/dot_local/bin/executable_git-poi-all
+++ b/dot_local/bin/executable_git-poi-all
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# usage: the script's documentation and its -h/--help output, in one place.
+# Laid out the way Click renders a command's help — Usage synopsis, the full
+# description, then an aligned Options block.
+usage() {
+    cat <<'EOF'
+Usage: git poi-all [GH_POI_ARGS...]
+
+  Sweep `gh poi` across every GitHub clone on the host: prune merged local
+  branches everywhere at once instead of one cd + `gh poi` at a time. Walks
+  $HOME for canonical clones (a .git directory with a github.com origin),
+  then runs `gh poi` in each, reporting per-repo so one failure (no GitHub
+  remote, auth, detached HEAD) doesn't abort the sweep.
+
+  Worktrees share their canonical's .git as a *file*, not a directory, so the
+  walk skips them — branch refs are repo-wide and a per-worktree run would be
+  redundant. git-worktree-poi handles the worktree axis.
+
+  Any arguments are forwarded verbatim to each `gh poi`, so the upstream flags
+  apply across the whole sweep:
+
+    git poi-all --dry-run            preview deletions in every repo
+    git poi-all --state closed       prune closed-PR branches too
+
+Options:
+  -h, --help     Show this message and exit (gh poi's own flags pass through).
+EOF
+}
+
+# NO_COLOR (https://no-color.org): any non-empty value disables colour.
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    RESET=$'\033[0m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+else
+    BOLD='' DIM='' RESET='' RED='' GREEN=''
+fi
+
+die() { printf 'git-poi-all: %s\n' "$*" >&2; exit 1; }
+
+# github_slug <remote-url>: emit "owner/repo" from a GitHub remote URL,
+# stripping any trailing .git. Returns non-zero for non-GitHub remotes so the
+# caller drops the clone from the sweep — `gh poi` needs a GitHub remote.
+github_slug() {
+    local url=$1
+    url=${url%.git}
+    case "$url" in
+    *github.com/*) printf '%s\n' "${url##*github.com/}" ;;
+    *github.com:*) printf '%s\n' "${url##*github.com:}" ;;
+    *) return 1 ;;
+    esac
+}
+
+# discover_repos: emit "<slug>\t<dir>" for each canonical GitHub clone under
+# $HOME, sorted and de-duplicated. The find prunes hidden directories (so it
+# never descends into ~/.cache, ~/.local, ...) but keeps .git itself, and
+# matches .git *directories* only — worktree .git files are excluded, giving
+# the once-per-repository guarantee for free. Clones with a non-GitHub or
+# missing origin are dropped by github_slug.
+discover_repos() {
+    local gitdir dir url slug
+    while IFS= read -r gitdir; do
+        dir=${gitdir%/.git}
+        url=$(git -C "$dir" remote get-url origin 2>/dev/null) || continue
+        slug=$(github_slug "$url") || continue
+        printf '%s\t%s\n' "$slug" "$dir"
+    done < <(find "$HOME" -maxdepth 4 \
+        \( -name '.*' ! -name '.git' -prune \) -o \
+        \( -name .git -type d -print \) 2>/dev/null) \
+        | sort -u
+}
+
+# Tests source this script to exercise helpers above without running the
+# main flow.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+for cmd in git gh; do
+    command -v "$cmd" >/dev/null 2>&1 || die "$cmd required but not found"
+done
+
+declare -a failures=()
+count=0
+while IFS=$'\t' read -r slug dir; do
+    [[ -z "$dir" ]] && continue
+    ((++count))
+    printf '%s==> %s%s %s(%s)%s\n' "$BOLD" "$slug" "$RESET" "$DIM" "$dir" "$RESET"
+    # Subshell cd keeps each `gh poi` in its own repo; the `if !` exempts the
+    # call from set -e so a failing repo is recorded and skipped, not fatal.
+    if ! (cd "$dir" && gh poi "$@"); then
+        failures+=("$slug ($dir)")
+    fi
+    printf '\n'
+done < <(discover_repos)
+
+if ((count == 0)); then
+    printf 'no GitHub clones found under %s\n' "$HOME"
+    exit 0
+fi
+
+if ((${#failures[@]})); then
+    printf '%s%d of %d repo(s) failed:%s\n' "$BOLD" "${#failures[@]}" "$count" "$RESET"
+    for f in "${failures[@]}"; do
+        printf '  %s%s%s\n' "$RED" "$f" "$RESET"
+    done
+    exit 1
+fi
+
+printf '%sswept %d repo(s)%s\n' "$GREEN" "$count" "$RESET"

--- a/test/git_poi_all.bats
+++ b/test/git_poi_all.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  POI_ALL="$REPO_ROOT/dot_local/bin/executable_git-poi-all"
+
+  TMPROOT="$(mktemp -d)"
+  export HOME="$TMPROOT/home"
+  mkdir -p "$HOME"
+
+  # gh stub: log "<cwd>\t<args>" per call so tests can assert which repos were
+  # swept with which flags; exit non-zero when the cwd's basename is listed in
+  # $GH_POI_FAIL, letting a test force one repo to error.
+  STUB_DIR="$TMPROOT/stubs"
+  mkdir -p "$STUB_DIR"
+  cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$PWD" "$*" >>"$GH_POI_LOG"
+for f in $GH_POI_FAIL; do
+  [[ "${PWD##*/}" == "$f" ]] && exit 1
+done
+exit 0
+STUB
+  chmod +x "$STUB_DIR/gh"
+  export GH_POI_LOG="$TMPROOT/gh.log"
+  : >"$GH_POI_LOG"
+  export GH_POI_FAIL=""
+  export PATH="$STUB_DIR:/usr/bin:/bin"
+}
+
+teardown() { rm -rf "$TMPROOT"; }
+
+# Real checkout with the given origin, so discover_repos runs against actual
+# `git remote get-url` plumbing rather than a parser harness. Commits once so
+# the dir can host worktrees.
+mkclone() {
+  local dir="$1" url="$2"
+  git init --quiet "$dir"
+  git -C "$dir" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  git -C "$dir" remote add origin "$url"
+}
+
+# --- discover_repos: which clones the sweep visits ---
+
+@test "discover_repos: HTTPS clone emits slug and dir" {
+  mkclone "$HOME/me/repo" "https://github.com/me/repo.git"
+  run bash -c 'source "$1"; discover_repos' _ "$POI_ALL"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'me/repo\t%s' "$HOME/me/repo")" ]
+}
+
+@test "discover_repos: SSH clone emits slug and dir" {
+  mkclone "$HOME/grafana/k6" "git@github.com:grafana/k6.git"
+  run bash -c 'source "$1"; discover_repos' _ "$POI_ALL"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'grafana/k6\t%s' "$HOME/grafana/k6")" ]
+}
+
+@test "discover_repos: non-github clone is dropped" {
+  mkclone "$HOME/elsewhere/repo" "git@gitlab.com:elsewhere/repo.git"
+  run bash -c 'source "$1"; discover_repos' _ "$POI_ALL"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "discover_repos: worktree of a clone is not visited separately" {
+  mkclone "$HOME/me/repo" "https://github.com/me/repo.git"
+  git -C "$HOME/me/repo" worktree add --quiet "$HOME/me/repo-wt" -b feature
+  run bash -c 'source "$1"; discover_repos' _ "$POI_ALL"
+  [ "$status" -eq 0 ]
+  # Only the canonical clone, never the worktree (its .git is a file).
+  [ "$output" = "$(printf 'me/repo\t%s' "$HOME/me/repo")" ]
+}
+
+@test "discover_repos: clone under a hidden dir is pruned" {
+  mkclone "$HOME/.cache/repo" "https://github.com/me/repo.git"
+  run bash -c 'source "$1"; discover_repos' _ "$POI_ALL"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- main flow ---
+
+@test "runs gh poi once per repo, forwarding args" {
+  mkclone "$HOME/me/alpha" "https://github.com/me/alpha.git"
+  mkclone "$HOME/me/beta" "https://github.com/me/beta.git"
+  run bash "$POI_ALL" --dry-run
+  [ "$status" -eq 0 ]
+  [ "$(grep -c "	poi --dry-run$" "$GH_POI_LOG")" -eq 2 ]
+  grep -qx "$HOME/me/alpha	poi --dry-run" "$GH_POI_LOG"
+  grep -qx "$HOME/me/beta	poi --dry-run" "$GH_POI_LOG"
+}
+
+@test "a failing repo is reported and non-fatal" {
+  mkclone "$HOME/me/alpha" "https://github.com/me/alpha.git"
+  mkclone "$HOME/me/beta" "https://github.com/me/beta.git"
+  export GH_POI_FAIL="beta"
+  run bash "$POI_ALL"
+  [ "$status" -eq 1 ]
+  # Both repos were still attempted — the failure didn't abort the sweep.
+  [ "$(wc -l <"$GH_POI_LOG")" -eq 2 ]
+  [[ "$output" == *"failed"* ]]
+  [[ "$output" == *"me/beta"* ]]
+}
+
+@test "no clones found exits cleanly" {
+  run bash "$POI_ALL"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no GitHub clones found"* ]]
+  [ ! -s "$GH_POI_LOG" ]
+}
+
+@test "-h prints usage and exits 0" {
+  run bash "$POI_ALL" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: git poi-all"* ]]
+}


### PR DESCRIPTION
## Summary

One command now prunes merged branches across every checked-out repo. `git poi-all` walks `$HOME` for canonical GitHub clones and runs `gh poi` in each, reporting per-repo so a failure in one (no GitHub remote, auth, detached HEAD) doesn't abort the sweep. Closes #239.

Decisions recorded (acceptance criterion #4):
- **Route/location** — bash in `dot_local/bin/`, not a gh extension. Follows ADR-0001 (the bash-vs-extension question for this tool family) and the `git-*` host-tool family (`git-worktree-poi`, `git-repo-picker`); the body is well under the ~100-line threshold ADR-0001 set for reconsidering.
- **Name** — `git-poi-all`, invoked `git poi-all`. Sits next to `git worktree-poi` (the worktree axis) rather than docking against the upstream `gh poi` it wraps.
- **Discovery** — minimal inline `$HOME` walk for `.git` directories with a github origin. Simpler than the picker's `collect_locals` (no org/repo parsing needed here) and self-contained, so no cross-script coupling.

## Gotchas

- The once-per-repository guarantee rides entirely on `find ... -type d` matching `.git` *directories* and thus skipping worktrees (whose `.git` is a file). That's the load-bearing line — `discover_repos: worktree of a clone is not visited separately` pins it.
- Discovery duplicates the picker's `$HOME` walk rather than sharing it. I argued against extracting a lib (rule-of-three; this walk is strictly simpler — no slug parse), but if you'd rather consolidate now, that's the place to push back.

## Verification

- `bats test/git_poi_all.bats` — 9 tests: discovery (HTTPS/SSH/non-github), worktree exclusion, hidden-dir pruning, arg forwarding, non-fatal failure, empty-host, help.
- `just check` green (shellcheck, shfmt, full bats suite, zellij/chezmoi/observability checks).
- Did **not** run the live sweep across `$HOME` (would fire `gh poi`'s GraphQL against ~30 repos); the main-flow tests exercise the real script end-to-end against a `gh` stub instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)