### PR TITLE
Restart services after library upgrades with needrestart

### DIFF
--- a/etc/apt/50unattended-upgrades
+++ b/etc/apt/50unattended-upgrades
@@ -21,8 +21,9 @@ Unattended-Upgrade::Origins-Pattern {
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
 // Attended box -- never reboot automatically (see #228). Moot on Crostini
-// regardless: nothing flags /var/run/reboot-required (kernel is ChromeOS's,
-// no needrestart/update-notifier installed).
+// regardless: the kernel is ChromeOS's, so a reboot can't pick up a new one.
+// needrestart (run_once_before_04) restarts services onto upgraded libraries
+// in place instead, which is the part that actually matters here. See #238.
 Unattended-Upgrade::Automatic-Reboot "false";
 
 // Pause on battery. Real here -- powermgmt-base (installed by

--- a/etc/needrestart/conf.d/zz-alunduil.conf
+++ b/etc/needrestart/conf.d/zz-alunduil.conf
@@ -1,0 +1,13 @@
+# needrestart drop-in for this host. The package's needrestart.conf sources
+# conf.d/*.conf after its own defaults, so this overrides them. Full option
+# reference ships at /usr/share/doc/needrestart/examples/needrestart.conf.
+
+# Restart affected services without prompting. unattended-upgrades runs
+# needrestart via its apt DPkg::Post-Invoke hook with no tty, so the default
+# interactive mode ('i') would stall the run; 'a' restarts everything itself.
+# This is the whole point: a patched library takes effect without a reboot.
+$nrconf{restart} = 'a';
+
+# Suppress the pending-kernel hint. The kernel is ChromeOS-managed on Crostini
+# -- nothing here can reboot into a new one -- so the comparison only adds noise.
+$nrconf{kernelhints} = -1;

--- a/run_once_before_04-configure-unattended-upgrades.sh.tmpl
+++ b/run_once_before_04-configure-unattended-upgrades.sh.tmpl
@@ -7,21 +7,29 @@
 # email or desktop notification (the box is attended), and automatic reboot
 # stays off. See #228.
 #
+# Also installs needrestart, which complements u-u: auto-reboot is off, so when
+# an upgrade replaces a shared library the daemons mapping the old copy keep
+# running it until they happen to restart. needrestart's apt DPkg::Post-Invoke
+# hook restarts them in place after each upgrade, so the security fix takes hold
+# without a reboot. See #238.
+#
 # run_once hashes the rendered script, so changes to the config files alone
 # would not re-trigger it. Embed their hashes here to force a re-run on edit:
 # 20auto-upgrades content:       {{ include "etc/apt/20auto-upgrades" | sha256sum }}
 # 50unattended-upgrades content: {{ include "etc/apt/50unattended-upgrades" | sha256sum }}
+# needrestart drop-in content:   {{ include "etc/needrestart/conf.d/zz-alunduil.conf" | sha256sum }}
 
 set -euo pipefail
 
 log() { printf '==> %s\n' "$*" >&2; }
 
 APT_CONF_SRC="{{ .chezmoi.sourceDir }}/etc/apt"
+NEEDRESTART_CONF_SRC="{{ .chezmoi.sourceDir }}/etc/needrestart"
 
 # -------------------------------------------------------------------- install
 # powermgmt-base provides on_ac_power, which the OnlyOnACPower gate in
 # 50unattended-upgrades needs to read the AC line; without it u-u fails open.
-PACKAGES=(unattended-upgrades powermgmt-base)
+PACKAGES=(unattended-upgrades powermgmt-base needrestart)
 missing=()
 for pkg in "${PACKAGES[@]}"; do
   dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
@@ -38,6 +46,12 @@ fi
 log "unattended-upgrades: installing apt config"
 sudo install -m 0644 "$APT_CONF_SRC/20auto-upgrades" /etc/apt/apt.conf.d/20auto-upgrades
 sudo install -m 0644 "$APT_CONF_SRC/50unattended-upgrades" /etc/apt/apt.conf.d/50unattended-upgrades
+
+# needrestart drop-in: a conf.d snippet so the package's own needrestart.conf
+# stays untouched. -D creates /etc/needrestart/conf.d/ if the package layout
+# ever drops it.
+log "needrestart: installing drop-in config"
+sudo install -D -m 0644 "$NEEDRESTART_CONF_SRC/conf.d/zz-alunduil.conf" /etc/needrestart/conf.d/zz-alunduil.conf
 
 # --------------------------------------------------------------------- timers
 sudo systemctl enable --now apt-daily.timer apt-daily-upgrade.timer


### PR DESCRIPTION
## Summary

Library security fixes now take effect without a reboot. Auto-reboot is off here (the kernel is ChromeOS-managed, so a reboot can't pick up a new one), which left daemons running the old copy of an upgraded shared library until they happened to restart — potentially a long time on a box that reboots only when the Chromebook does. needrestart's apt `DPkg::Post-Invoke` hook now restarts the affected services in place after each unattended-upgrades run. Installed alongside unattended-upgrades in `run_once_before_04` since it's the same automatic-patching path.

Closes #238.

## Gotchas

- The drop-in (`etc/needrestart/conf.d/zz-alunduil.conf`) is a `conf.d` snippet, not a replacement for the package's own `needrestart.conf` — confirm you're comfortable relying on the package sourcing `conf.d/*.conf` after its defaults (standard Debian layout, but I couldn't introspect it: needrestart isn't installed on this host).
- `$nrconf{restart} = 'a'` is load-bearing: a tty-less u-u run with the default interactive mode would stall on a prompt.

## Verification

- `pre-commit run` (shellcheck, shfmt, vale, …) passed on all three files.
- `chezmoi execute-template` renders script 04 cleanly and the drop-in's embedded content hash resolves.
- needrestart's auto-restart behavior is not exercised here — it's not installed on this host, so the apt-hook + `conf.d`-sourcing path is from Debian packaging, not a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)