### PR TITLE
Install and auto-update VS Code via the bootstrap

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -31,6 +31,7 @@ ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)
 command -v calibre                         # ebook library manager
+command -v code                            # VS Code (Microsoft apt repo)
 command -v truenas-mcp                     # TrueNAS MCP server binary
 trivy --version                            # vulnerability scanner (aquasecurity/trivy)
 gh extension list                          # confirms gh-poi (squash-merge pruner)

--- a/etc/apt/50unattended-upgrades
+++ b/etc/apt/50unattended-upgrades
@@ -14,6 +14,7 @@ Unattended-Upgrade::Origins-Pattern {
         "origin=gh,codename=stable";                            // GitHub CLI
         "origin=Tailscale,codename=${distro_codename}";         // Tailscale
         "origin=. xenial,codename=xenial";                      // Signal
+        "origin=code stable,codename=stable";                   // VS Code
         "site=prerelease.keybase.io";                           // Keybase (no repo metadata)
 };
 

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -45,12 +45,21 @@ if [ ! -f /etc/apt/sources.list.d/keybase.list ]; then
     sudo tee /etc/apt/sources.list.d/keybase.list >/dev/null
 fi
 
+# --------------------------------------------------------------- vscode (code)
+if [ ! -f /usr/share/keyrings/packages.microsoft.gpg ]; then
+  log "vscode: adding apt repository"
+  curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |
+    sudo gpg --dearmor -o /usr/share/keyrings/packages.microsoft.gpg
+  printf 'deb [arch=%s signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main\n' \
+    "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
+fi
+
 # -------------------------------------------------------------------- apt pkgs
 APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   golang-petname
-  keybase signal-desktop calibre
+  keybase signal-desktop calibre code
   nethack-console
 )
 missing=()


### PR DESCRIPTION
## Summary

VS Code now installs from the official Microsoft apt repo during bootstrap and auto-updates via unattended-upgrades, so it keeps receiving updates once #228 narrows origins to bootstrap-managed repos. The apt `code` build has no in-app updater, so without its repo under management it would silently stop updating. Closes #236.

## Gotchas

Nothing load-bearing left to check — the `origin=code stable,codename=stable` pattern is confirmed against the live `Release` file at `packages.microsoft.com/repos/code/dists/stable/` (`Origin: code stable`, `Codename: stable`).

## Verification

- Ran pre-commit, `bats test/` (68 ok), and `script/checks/chezmoi-apply` locally; all pass.
- Confirmed the unattended-upgrades origin against the repo's published `Release` metadata.

Did not run a live bootstrap (it would install `code` on this host), so the fresh-install/no-op round-trip and the runtime unattended-upgrades pickup are exercised only by the static config and the existing apt-repo pattern this mirrors.