### PR TITLE
Manage settings.json via modify_ merge script

### DIFF
--- a/dot_claude/modify_private_settings.json.tmpl
+++ b/dot_claude/modify_private_settings.json.tmpl
@@ -1,4 +1,13 @@
-{
+#!/usr/bin/env bash
+# Manage ~/.claude/settings.json without re-syncing when a new key appears.
+# Claude rewrites this file in its own key order; chezmoi reads that live
+# copy on stdin and overwrites only the keys it owns (policy plus paths to
+# chezmoi-deployed scripts), leaving theme and enabledPlugins for Claude to
+# mutate at runtime. jq + preserves on-disk key order and appends new keys,
+# so chezmoi's target matches Claude's serialization regardless of insertion.
+set -euo pipefail
+
+jq --slurp '(.[0] // {}) + {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
@@ -93,9 +102,9 @@
       "Bash(git push -f*)",
       "Bash(git push* -f*)",
       "Bash(git push*main*)",
-      "Read(/home/alunduil/.claude/.credentials.json)",
-      "Read(/home/alunduil/.gnupg/**)",
-      "Read(/home/alunduil/.ssh/**)"
+      "Read({{ .chezmoi.homeDir }}/.claude/.credentials.json)",
+      "Read({{ .chezmoi.homeDir }}/.gnupg/**)",
+      "Read({{ .chezmoi.homeDir }}/.ssh/**)"
     ],
     "ask": [
       "Bash(bash -c*)",
@@ -130,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.claude/hooks/pr-draft-guard.sh"
+            "command": "{{ .chezmoi.homeDir }}/.claude/hooks/pr-draft-guard.sh"
           }
         ]
       },
@@ -138,7 +147,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -159,7 +168,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -170,7 +179,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.claude/hooks/pre-commit-edit-guard.sh"
+            "command": "{{ .chezmoi.homeDir }}/.claude/hooks/pre-commit-edit-guard.sh"
           }
         ]
       }
@@ -180,7 +189,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -192,7 +201,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -204,7 +213,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -216,7 +225,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -228,7 +237,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -240,7 +249,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -252,7 +261,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -264,7 +273,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/alunduil/.config/zellij/plugins/zellaude-hook.sh",
+            "command": "{{ .chezmoi.homeDir }}/.config/zellij/plugins/zellaude-hook.sh",
             "timeout": 5,
             "async": true
           }
@@ -274,10 +283,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "/home/alunduil/.claude/statusline.sh"
-  },
-  "theme": "auto",
-  "enabledPlugins": {
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "command": "{{ .chezmoi.homeDir }}/.claude/statusline.sh"
   }
 }
+'


### PR DESCRIPTION
## Summary

`chezmoi update` no longer re-prompts about `~/.claude/settings.json` when Claude introduces a brand-new object key. A `modify_` script reads the live file on stdin and `jq`-merges only the keys chezmoi owns over it, so chezmoi's computed target always equals Claude's own serialization — no more hand re-syncing via `chezmoi add` when a key lands somewhere Claude disagrees with. Follow-up to #245.

## What chezmoi owns vs. what Claude keeps

- chezmoi owns `$schema`, `permissions`, `hooks`, `statusLine` — policy plus the paths to chezmoi-deployed scripts. These are full top-level replacements (jq `+` is a shallow merge), so the source stays the curated truth: an interactive "always allow" that appends to `permissions.allow` reverts on the next apply until committed, which is the existing behaviour.
- `theme` and `enabledPlugins` pass through untouched as Claude's to mutate at runtime. Because `modify_` preserves on-disk keys, this no longer risks the silent-disable that #214 had to guard against — chezmoi simply stops touching them. Trade-off: a fresh machine won't auto-enable `rust-analyzer-lsp`; if that ever matters, the consistent home is a bootstrap `claude plugin install` step, not this policy file.

## Gotchas

- Focus on byte-identity. The whole approach rests on jq's serialization exactly matching Claude's (indentation, escaping, trailing newline) — verified `diff <(cat live) <(jq . live)` is empty. If a future jq bump changes formatting, every apply would diff; that's the thing to watch.
- `.chezmoi.homeDir` renders to `/home/alunduil` here, byte-identical to the literal paths Claude writes. That's the reason the file is a `.tmpl` and the only place portability enters.

## Verification

- `chezmoi cat --source=.` output is byte-identical to the live `~/.claude/settings.json`.
- Perturbation test: fed a file with a new unmanaged top-level key inserted mid-object and `theme` reordered to the front — the new key and its position survive, managed keys stay intact, and a second pass is a fixed point (no churn).
- New-managed-key applies through the merge; empty stdin (fresh machine) yields the managed block alone.
- `script/checks/chezmoi-apply`, `pre-commit run --all-files`, and `bats test/` (68 tests) all pass.

While verifying I found `script/checks/chezmoi-apply`'s hook-existence selector is a vacuous no-op (matches `$HOME/.claude/` literally, never the rendered absolute paths) — pre-existing, filed as #262 rather than fixed here.