### PR TITLE
Resume the worktree's last conversation in the pair layout

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -52,7 +52,13 @@ layout {
     }
     tab name="pair" focus=true {
         pane split_direction="vertical" {
-            pane size="40%" name="claude" command="claude"
+            pane size="40%" name="claude" command="claude" {
+                // --continue resumes the worktree's most recent conversation;
+                // it falls back to a fresh session when there is none, so new
+                // worktrees open cleanly. Covers both Alt+. and Alt+/ since
+                // they share this launch point.
+                args "--continue"
+            }
             pane size="60%" name="lazygit" command="lazygit"
         }
     }


### PR DESCRIPTION
## Summary

Opening a worktree in the pair layout now resumes its most recent Claude conversation instead of starting empty. Both worktree-open paths — the Alt+. fan-out and the Alt+/ picker — funnel through the one `claude` pane in `pair.kdl`, so wiring resume there covers both.

The pane now passes `--continue`. The issue's open question assumed `--continue` errors with no prior conversation and so would need a guard wrapper; that premise is stale on claude 2.1.160 — a no-conversation directory starts a fresh session cleanly. So this is a one-line layout change, no wrapper.

## Gotchas

The change rides entirely on `--continue`'s fall-back-to-fresh behavior. I confirmed it on claude 2.1.160 (see Verification), but it's upstream behavior we don't control — if a future version reverts to erroring on no-conversation, new worktrees would break and we'd reintroduce a guard.

## Verification

- `claude --continue -p "say OK"` in a guaranteed-empty directory (no project dir at all) returned `OK`, rc=0 — confirms no-conversation falls back to fresh rather than erroring.
- `script/checks/zellij-config` rc=0; `pre-commit run --all-files` all green; `bats test/` 68/68.
- Not exercised: the live interactive resume in an actual zellij pair pane (resuming real history vs. opening clean). Interactive TUI behavior can't be asserted cleanly from inside a Claude session; the print-mode + KDL-validation checks are the proxy.

Closes #233