### PR TITLE
Render run_* script templates in CI

### DIFF
--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Check apply
         run: script/checks/chezmoi-apply
+
+      - name: Check script templates render
+        run: script/checks/chezmoi-template

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ check:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
-    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi check-observability; do
+    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi check-chezmoi-templates check-observability; do
       just "$c" || rc=1
     done
     exit "$rc"
@@ -42,6 +42,10 @@ check-zellij:
 # Apply round-trip (needs chezmoi + age on PATH).
 check-chezmoi:
     script/checks/chezmoi-apply
+
+# Render run_*.sh.tmpl script templates (needs chezmoi on PATH).
+check-chezmoi-templates:
+    script/checks/chezmoi-template
 
 # Observability config validation (skips when the stack binaries are absent;
 # the live metrics smoke is CI-only — it binds the running stack's ports).

--- a/script/checks/chezmoi-template
+++ b/script/checks/chezmoi-template
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Render every run_*.sh.tmpl with chezmoi execute-template so a broken
+# template or include fails CI. chezmoi-apply runs with --exclude=scripts,
+# so script templates are otherwise never rendered: a typo or bad include
+# path passes apply and only breaks on a real bootstrap.
+#
+# execute-template reads source bytes (include hashes, it doesn't decrypt),
+# so this needs neither a destination dir nor an age key.
+
+set -euo pipefail
+
+SOURCE_DIR="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+
+fail=0
+while IFS= read -r tmpl; do
+  if ! err="$(chezmoi execute-template --source="$SOURCE_DIR" \
+    < "$SOURCE_DIR/$tmpl" 2>&1 >/dev/null)"; then
+    printf 'FAIL: %s\n%s\n' "$tmpl" "$err" >&2
+    fail=1
+  fi
+done < <(git -C "$SOURCE_DIR" ls-files 'run_*.tmpl')
+
+exit "$fail"


### PR DESCRIPTION
## Summary

A template typo or bad `include` path in a `run_*.sh.tmpl` now fails CI instead of only surfacing on a real `chezmoi apply`. `chezmoi-apply` runs with `--exclude=scripts`, so script templates were never rendered before — #222's observability template (embedding `include "…" | sha256sum` unit hashes) was validated only by hand.

A new sibling check `script/checks/chezmoi-template` runs `chezmoi execute-template` over each `run_*.sh.tmpl` and fails on a render error, wired into `just check` and the chezmoi workflow.

## Gotchas

Decide whether a sibling check is the right call over folding into `chezmoi-apply`. I went sibling because the mechanism is the complement of apply, not a sub-step: `execute-template` reads source bytes (it hashes `encrypted_*.age` includes, doesn't decrypt), so it needs neither a destination dir nor an age key — whereas `chezmoi-apply` needs both. The only shared logic is the one-line git-toplevel source lookup, under the rule-of-three bar for coupling.

`script/checks/*` files sit outside the shellcheck/shfmt pre-commit glob (`executable_|\.sh\.tmpl$`), same as every existing sibling check, so this script isn't auto-linted — I ran shellcheck against it directly.

## Verification

- Ran `script/checks/chezmoi-template`: all 12 current templates render clean (rc 0).
- Appended a bad `include` to one template and confirmed the check fails with the offending file + chezmoi error, then restored and re-ran clean — confirms it isn't test theatre.
- Confirmed `include`, `.chezmoi.sourceDir`, `glob`, `joinPath` all resolve under `execute-template --source` with no age key present.
- `shellcheck script/checks/chezmoi-template` clean; `pre-commit run` on the changed files passed.

Closes #242