### PR TITLE
Pin nvm Node and make it the sole Node path

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -145,6 +145,14 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
+      "matchStrings": ["NODE_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
       "matchStrings": ["READWISE_CLI_VERSION=\"(?<currentValue>[\\d.]+)\""],
       "depNameTemplate": "@readwise/cli",
       "datasourceTemplate": "npm"

--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Installs nvm, a Node LTS via nvm, and npm global packages. Canonical
-# installers only: nvm for Node, npm for packages. Debian apt Node is
-# avoided by design (it lags upstream).
+# Installs nvm, a pinned Node version via nvm, and npm global packages.
+# Canonical installers only: nvm for Node, npm for packages. Debian apt Node
+# is avoided by design (it lags upstream).
 
 set -euo pipefail
 
@@ -23,14 +23,16 @@ fi
 # shellcheck disable=SC1091
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-# Ensure an nvm-managed node exists. The `command -v node` check that was
-# here before could find a system /usr/bin/node and skip installation,
-# leaving nvm with zero versions and npm pointed at /usr/lib.
-if ! nvm ls default >/dev/null 2>&1; then
-  log "node: installing LTS via nvm"
-  nvm install --lts
-  nvm alias default 'lts/*'
+# Pinned (Renovate-tracked via the node-version datasource): chezmoi re-runs
+# this once-script when the pin changes, so a bump applies on apply. Match by
+# explicit version rather than `command -v node`, which could find a system
+# /usr/bin/node and skip installation, leaving nvm with zero versions.
+NODE_VERSION="24.15.0"
+if ! nvm ls "$NODE_VERSION" >/dev/null 2>&1; then
+  log "node: installing $NODE_VERSION via nvm"
+  nvm install "$NODE_VERSION"
 fi
+nvm alias default "$NODE_VERSION"
 nvm use default >/dev/null 2>&1
 log "node: $(node --version) via nvm"
 


### PR DESCRIPTION
## Summary
Node now has one canonical path — nvm — pinned to a version Renovate tracks and bumps. Previously the bootstrap installed Node via a floating `nvm install --lts` (so the version answered to neither apt nor Renovate), while this host *also* carried a stray NodeSource system Node (v20) from an apt repo the bootstrap never adds — the dual-Node state the #228 origins audit flagged. nvm wins (script 03's stated design intent, "Debian apt Node is avoided by design"), the stray was purged from the host, and no NodeSource origin is added to unattended-upgrades.

Closes #237.

## Gotchas
- The pin lives **inside** the `run_once_` script on purpose: that's what makes a Renovate bump actually apply (chezmoi re-runs the script when its content hash changes). A separate `.nvmrc` would need a `run_onchange_` conversion to apply — worth confirming you're happy with the pin-in-script tradeoff vs. an `.nvmrc`.
- `versioning: node` is the load-bearing bit for staying on LTS — it's what limits cross-major bumps to LTS→LTS, preserving the old `--lts` intent. There's no LTS-only preset; the versioning scheme is the mechanism.

## Verification
- `pre-commit run --all-files` — passed, incl. `renovate-config-validator --strict` (Node custom manager is valid) and shellcheck/shfmt on script 03.
- `bats test/` — 68 passed.
- Purged on this host: `apt-get purge nodejs` (dry-run confirmed only `nodejs` removed, empty reverse-deps), removed `nodesource.list` + `nodesource.gpg`, `apt-get update` clean. `which -a node` now resolves only to the nvm path; `dpkg -s nodejs` → not installed.

## Follow-up (not in this PR)
The purge left `@devcontainers/cli` orphaned in root-owned `/usr/lib/node_modules` with a `/usr/bin/devcontainer` symlink. It still runs (its `env node` shebang picks up nvm's node), but it's a manually-installed global outside any bootstrap script. I'll file a separate issue to bring it under management rather than fold it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)