### PR TITLE
Schedule git poi sweeps via systemd user timers

### DIFF
--- a/dot_config/systemd/user/git-poi-all.service
+++ b/dot_config/systemd/user/git-poi-all.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Prune merged local branches across all GitHub clones (git poi-all)
+
+[Service]
+Type=oneshot
+# The user manager's PATH lacks ~/.local/bin, where both `gh` and the git-*
+# helpers live; set it so the script resolves git and gh. No tty here, so the
+# scripts auto-disable colour (NO_COLOR) and the journal stays clean.
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/.local/bin/git-poi-all

--- a/dot_config/systemd/user/git-poi-all.timer
+++ b/dot_config/systemd/user/git-poi-all.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly gh-poi sweep across all GitHub clones
+
+[Timer]
+OnCalendar=Sun *-*-* 03:30:00
+# This host (Crostini) is frequently suspended; without Persistent a missed
+# window is lost. Persistent runs the catch-up on next wake.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/dot_config/systemd/user/git-worktree-poi.service
+++ b/dot_config/systemd/user/git-worktree-poi.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Prune merged and empty git worktrees (git worktree-poi)
+
+[Service]
+Type=oneshot
+# The user manager's PATH lacks ~/.local/bin, where both `gh` and the git-*
+# helpers live; set it so the script resolves git and gh. No tty here, so the
+# scripts auto-disable colour (NO_COLOR) and the journal stays clean.
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/.local/bin/git-worktree-poi

--- a/dot_config/systemd/user/git-worktree-poi.timer
+++ b/dot_config/systemd/user/git-worktree-poi.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hourly prune of merged and empty git worktrees
+
+[Timer]
+OnCalendar=*-*-* *:00:00
+# This host (Crostini) is frequently suspended; Persistent coalesces the
+# windows missed while asleep into a single catch-up run on next wake.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/run_onchange_after_11-enable-git-maintenance.sh.tmpl
+++ b/run_onchange_after_11-enable-git-maintenance.sh.tmpl
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Unit hashes below re-run this script whenever a unit changes, so edits
+# (new ExecStart flags, schedule changes) re-apply via daemon-reload + enable.
+# worktree-poi service: {{ include "dot_config/systemd/user/git-worktree-poi.service" | sha256sum }}
+# worktree-poi timer:   {{ include "dot_config/systemd/user/git-worktree-poi.timer" | sha256sum }}
+# poi-all service:      {{ include "dot_config/systemd/user/git-poi-all.service" | sha256sum }}
+# poi-all timer:        {{ include "dot_config/systemd/user/git-poi-all.timer" | sha256sum }}
+
+set -euo pipefail
+
+# Skip where there is no user systemd manager to talk to (headless apply over
+# SSH without lingering, container builds). The units are still deployed; a
+# later interactive apply, or a manual enable, brings the timers up.
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "==> git-maintenance: no user systemd session; leaving timers disabled" >&2
+  exit 0
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now git-worktree-poi.timer git-poi-all.timer


### PR DESCRIPTION
## Summary

`git worktree-poi` and `git poi-all` now run on their own schedule instead of by hand — worktree-poi hourly, poi-all weekly (Sunday). Both run with default-safe flags, so the host prunes merged/closed worktrees and merged-PR local branches on its own while leaving anything in-use, dirty, unpushed, or with an open PR alone.

Cadence reasoning: worktree-poi is the inner loop (worktrees churn as work starts/finishes), so hourly keeps the picker/session list tight — its merged/closed path is always safe (a terminal PR state proves the work was pushed). poi-all is heavier (walks `$HOME`, one network round-trip per clone) and branch cruft accrues slowly, so weekly fits.

## Gotchas

- `git-worktree-poi.timer` is **hourly**, which moves the empty-worktree heuristic (reaps a worktree with no commits / no PR / not in-use) into working hours. Decide whether that's acceptable: the failure mode is reaping a just-created-then-abandoned empty worktree, recoverable with one picker invocation. If it ever bites, the fix is an age threshold on *just* that path, not reverting cadence.
- Services set `Environment=PATH=` deliberately — the `systemd --user` manager's PATH omits `~/.local/bin`, where `gh` and the `git-*` helpers resolve. Without it the units can't find `gh`.

## Verification

- Confirmed `gh` reads the keyring token from a user-unit context: ran `gh auth status` under `systemd-run --user`, exited 0 with the real token. `gnome-keyring-daemon` runs under `user@1000.service`, so the unlocked keyring is reachable for the session. A locked keyring (boot catch-up before login) degrades both tools to a no-op.
- `systemd-analyze --user verify` clean on all four units; both `OnCalendar` expressions resolve.
- Sandboxed `chezmoi apply` to a temp destination lands all four units at `~/.config/systemd/user/` with correct `ExecStart`/`PATH`.
- pre-commit (shellcheck, shfmt, vale) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)