### PR TITLE
Branch pair-tab claude launch on prior conversation

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -52,13 +52,10 @@ layout {
     }
     tab name="pair" focus=true {
         pane split_direction="vertical" {
-            pane size="40%" name="claude" command="claude" {
-                // --continue resumes the worktree's most recent conversation;
-                // it falls back to a fresh session when there is none, so new
-                // worktrees open cleanly. Covers both Alt+. and Alt+/ since
-                // they share this launch point.
-                args "--continue"
-            }
+            // claude-pair resumes the worktree's most recent conversation,
+            // or starts fresh when there is none. Covers both Alt+. and
+            // Alt+/ since they share this launch point.
+            pane size="40%" name="claude" command="claude-pair"
             pane size="60%" name="lazygit" command="lazygit"
         }
     }

--- a/dot_local/bin/executable_claude-pair
+++ b/dot_local/bin/executable_claude-pair
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# claude launcher for ~/.config/zellij/layouts/pair.kdl.
+#
+# Resumes the worktree's most recent conversation when one exists, else
+# starts fresh. `claude --continue` cannot do this itself: in interactive
+# mode it errors with "no conversations to continue" when the directory
+# has no history, so a new worktree's pair tab would die on open. (Print
+# mode -p falls back to fresh, which is why #265 missed this.)
+#
+# claude stores history under ~/.claude/projects/<cwd with every
+# non-alphanumeric byte replaced by ->. Presence of a *.jsonl there is
+# the resume signal.
+
+set -euo pipefail
+
+project_dir="$HOME/.claude/projects/$(pwd | sed 's/[^a-zA-Z0-9]/-/g')"
+
+if compgen -G "$project_dir/*.jsonl" >/dev/null; then
+    exec claude --continue "$@"
+fi
+
+exec claude "$@"

--- a/test/claude_pair.bats
+++ b/test/claude_pair.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Exercises the resume-vs-fresh branch the zellij pair tab depends on.
+# A stub `claude` echoes its args so we can assert which mode was chosen.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+  STUB_DIR="$(mktemp -d)"
+  WRAPPER_DIR="$(mktemp -d)"
+  export HOME="$(mktemp -d)"
+  WORKTREE="$(mktemp -d)"
+
+  cat >"$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+printf 'args:[%s]\n' "$*"
+STUB
+  chmod +x "$STUB_DIR/claude"
+
+  install -m 0755 "$REPO_ROOT/dot_local/bin/executable_claude-pair" "$WRAPPER_DIR/claude-pair"
+
+  export PATH="$WRAPPER_DIR:$STUB_DIR:/usr/bin:/bin"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WRAPPER_DIR" "$HOME" "$WORKTREE"
+}
+
+# Mirror claude's project-dir encoding for a given path.
+project_dir_for() {
+  printf '%s/.claude/projects/%s' "$HOME" "$(printf '%s' "$1" | sed 's/[^a-zA-Z0-9]/-/g')"
+}
+
+@test "resumes when the worktree has prior conversations" {
+  mkdir -p "$(project_dir_for "$WORKTREE")"
+  : >"$(project_dir_for "$WORKTREE")/session.jsonl"
+
+  run bash -c "cd '$WORKTREE' && claude-pair"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "args:[--continue]" ]]
+}
+
+@test "starts fresh when no project dir exists" {
+  run bash -c "cd '$WORKTREE' && claude-pair"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "args:[]" ]]
+}
+
+@test "starts fresh when the project dir has no conversations" {
+  mkdir -p "$(project_dir_for "$WORKTREE")"
+
+  run bash -c "cd '$WORKTREE' && claude-pair"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "args:[]" ]]
+}


### PR DESCRIPTION
## Summary

Opening a pair tab on a fresh worktree no longer dies — it now starts a clean Claude session instead of erroring out. #265 wired the pane to `claude --continue` after confirming its fall-back-to-fresh behavior, but that check used print mode (`-p`); interactive mode errors with "no conversations to continue" and exits when the directory has no history, so brand-new worktrees broke. A new `claude-pair` launcher branches the decision: `claude --continue` only when the worktree already has history under `~/.claude/projects`, plain `claude` otherwise.

## Gotchas

The history check reconstructs claude's project-dir path by replacing every non-alphanumeric byte of cwd with `-` (verified against the live `~/.claude/projects` layout). If upstream changes that encoding, the wrapper silently always-starts-fresh rather than failing loudly — worth a glance there.

## Verification

- `bats test/claude_pair.bats` — 3/3 (history present → `--continue`; no project dir → fresh; empty project dir → fresh).
- `just check` proxy: `pre-commit run --all-files` all green, `bats test/` 80/80, `script/checks/zellij-config` rc=0.
- Not exercised: the live interactive resume in a real zellij pair pane — TUI behavior can't be asserted from inside a Claude session (same limit #265 noted); the bats branch coverage stands in.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)