### PR TITLE
Guard Readwise CLI query against set -e on fresh prefix

### DIFF
--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -54,10 +54,12 @@ fi
 # ----------------------------------------------------------- Readwise CLI
 # Pin enforced (mirrors gh-poi in script 05): if a different version is
 # already installed, npm replaces it so renovate-tracked bumps actually
-# take effect. `npm ls -g` is the local query, no network round-trip.
+# take effect. `npm ls -g` is the local query, no network round-trip. It
+# exits 1 when the package is absent (e.g. fresh prefix after a node bump),
+# so `|| true` keeps set -e from killing the run before the install branch.
 READWISE_CLI_VERSION="0.5.6"
 installed="$(npm ls -g --depth=0 --parseable=false @readwise/cli 2>/dev/null |
-  sed -n 's,.*@readwise/cli@\([0-9][0-9.]*\).*,\1,p' | head -1)"
+  sed -n 's,.*@readwise/cli@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"
 if [ "$installed" != "$READWISE_CLI_VERSION" ]; then
   if [ -n "$installed" ]; then
     log "readwise-cli: replacing $installed with $READWISE_CLI_VERSION"


### PR DESCRIPTION
## Summary

`chezmoi update` now survives a node version bump: the node-ecosystem bootstrap no longer dies at the Readwise CLI step when the package is missing from a freshly created npm prefix.

The node 24.16.0 bump (7333ff5) made nvm create an empty npm prefix, and `npm ls -g @readwise/cli` exits 1 when the package is absent there. Under `set -euo pipefail` that status escaped the command substitution and tripped `set -e`, killing the script *before* the install branch that exists to handle the not-installed case. Latent since the block was written; only surfaces on a fresh prefix (node bump) or fresh-machine bootstrap. Fix appends `|| true` to the query.

## Gotchas

`|| true` looks like noise but is load-bearing — it's the guard against the `set -e` interaction described above. The added comment says so; don't let a future cleanup drop it.

## Verification

Reproduced the failure by setting `NPM_CONFIG_PREFIX` to the empty `versions/node/v24.16.0` dir and running the assignment under `set -euo pipefail` (exit 1, install branch unreached). Confirmed the patched line survives (exit 0, `installed` empty → falls through to install). shellcheck and shfmt pass via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)