### PR TITLE
Run observability config validation on every PR

### DIFF
--- a/.github/workflows/observability-config.yml
+++ b/.github/workflows/observability-config.yml
@@ -1,0 +1,42 @@
+name: Observability Config
+
+# Static config validation for the observability stack. Cheap to run but
+# needs the tools' own validators (promtool, alloy, loki, tempo) on PATH, so
+# it installs the binaries — cached on the pinned versions to keep the
+# always-on cost low. Runs on every PR (unlike the path-gated smoke) so a
+# broken service config fails the build regardless of which files changed.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.local/bin
+          key: obs-bins-${{ hashFiles('script/install/prometheus', 'script/install/alloy', 'script/install/loki', 'script/install/tempo', 'script/install/lib.sh') }}
+
+      - name: Install stack binaries
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          for t in prometheus alloy loki tempo; do
+            script/install/"$t" --bin-dir "$HOME/.local/bin"
+          done
+          echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+
+      - name: Validate configs
+        run: script/checks/observability-config

--- a/.github/workflows/observability-smoke.yml
+++ b/.github/workflows/observability-smoke.yml
@@ -14,7 +14,7 @@ on:
       - 'script/install/alloy'
       - 'script/install/prometheus'
       - 'script/checks/observability-smoke'
-      - '.github/workflows/observability.yml'
+      - '.github/workflows/observability-smoke.yml'
   pull_request:
     paths: *paths
 

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -1,25 +1,18 @@
-name: Observability
+name: Observability Smoke
 
-# Heavy: installs the ~400 MB telemetry binaries, so it only runs when the
-# observability stack itself changes. Validates every service config and
-# smoke-tests the live metrics path (zellijstat -> Alloy -> Prometheus).
+# Heavy: installs the telemetry binaries and binds their real ports, so it
+# only runs when the metrics path itself changes. Smoke-tests the live path
+# (zellijstat -> Alloy -> Prometheus). Static config validation lives in
+# observability-config.yml, which runs on every PR.
 on:
   push:
     branches: [main]
     paths: &paths
       - 'dot_config/alloy/**'
       - 'dot_config/prometheus/**'
-      - 'dot_config/loki/**'
-      - 'dot_config/tempo/**'
-      - 'dot_config/grafana/**'
-      - 'dot_config/systemd/user/**'
       - 'dot_local/bin/executable_zellijstat'
       - 'script/install/alloy'
       - 'script/install/prometheus'
-      - 'script/install/loki'
-      - 'script/install/tempo'
-      - 'script/install/grafana'
-      - 'script/checks/observability-config'
       - 'script/checks/observability-smoke'
       - '.github/workflows/observability.yml'
   pull_request:
@@ -46,13 +39,10 @@ jobs:
       - name: Install stack binaries
         run: |
           mkdir -p "$HOME/.local/bin"
-          for t in prometheus alloy loki tempo; do
+          for t in prometheus alloy; do
             script/install/"$t" --bin-dir "$HOME/.local/bin"
           done
           echo "$HOME/.local/bin" >>"$GITHUB_PATH"
-
-      - name: Validate configs
-        run: script/checks/observability-config
 
       - name: Smoke the metrics path
         run: script/checks/observability-smoke

--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -75,6 +75,7 @@ worktrees
 
 # Common tech terms
 config
+justfile
 dev
 dotfile
 dotfiles

--- a/docs/adr/0002-keep-per-workflow-ci.md
+++ b/docs/adr/0002-keep-per-workflow-ci.md
@@ -1,0 +1,88 @@
+# 2. Keep one CI workflow per sensor
+
+## Status
+
+Accepted
+
+## Context
+
+CI runs one workflow per sensor (`bats`, `python`, `zellij`, `chezmoi`,
+`pre-commit`, `lychee`, `observability`), and each repeats the same
+`on`/`permissions`/`concurrency` boilerplate. The justfile defines most
+of the same checks as recipes (`check-bats`, `check-observability`, …),
+so the two can drift. #274 asks whether to collapse the workflows into a
+single `ci.yml` with one job per check calling `just <check>`, making the
+justfile the single source of truth CI reads from.
+
+Two pressures motivate the question:
+
+- **Drift.** Workflow and justfile encode the same check twice; a recipe
+  rename or new sensor has to be made in both places.
+- **An actual gap.** `observability.yml` is path-gated to stack-file
+  changes, so the cheap `script/checks/observability-config` never runs
+  on an unrelated PR, and observability coverage looks absent on most PRs.
+
+Consolidation is weaker than it first appears:
+
+- The only genuinely duplicated boilerplate is the
+  `on`/`permissions`/`concurrency` blocks (~10 lines each). The bulk,
+  per-job setup, stays distinct regardless: age for `check-chezmoi`,
+  Zellij for `check-zellij`, the stack binaries for observability, Python
+  for `check-python`.
+- Three of the seven don't map to `just <check>`. `bats`, `pre-commit`,
+  and `lychee` drive both install and run through marketplace actions
+  (`bats-core/bats-action`, `pre-commit/action`,
+  `lycheeverse/lychee-action` with its own cache), and `lychee` isn't a
+  justfile recipe at all (it's CI-only).
+- GitHub supports `paths:` only at the workflow trigger, not per job. A
+  single `ci.yml` would need `dorny/paths-filter` or per-job `if` to keep
+  the observability smoke gated, more machinery than the per-workflow
+  `paths:` it replaces.
+
+The drift risk is already bounded: the justfile header notes each sensor
+also runs in its own workflow, so a stale recipe list causes a local
+false-pass that CI then catches, never a bad merge. CI is authoritative.
+
+## Decision
+
+We will keep one CI workflow per sensor. New checks land as new
+workflows, not as jobs in a shared `ci.yml`. The
+consolidation in #274 is rejected, not deferred.
+
+The observability gap is fixed within this structure by splitting the one
+workflow in two:
+
+- `observability-config.yml`: static config validation, no path gate,
+  runs on every PR. It installs the binaries those checks need (cached on
+  their pinned versions to keep the always-on cost low).
+- `observability.yml`: the heavy live-metrics smoke, still path-gated to
+  the metrics path it exercises.
+
+Issue #241 (`systemd-analyze verify` on the user units) lands as its own
+`script/checks/*` + `just` recipe + workflow, consistent with this
+structure.
+
+We will revisit when any of these triggers fire:
+
+- A new check is genuinely a `just <check>` one-liner with no bespoke
+  setup, and three or more such checks accumulate; at that point a
+  shared `ci.yml` job matrix stops duplicating boilerplate without the
+  per-job-gating tax.
+- Workflow/justfile drift causes a real miss (a check silently stops
+  running in CI), not just a theoretical one.
+
+## Consequences
+
+- `observability-config` runs on every PR; a broken service config fails
+  the build regardless of which files changed. The always-on binary
+  install is the cost, mitigated by version-keyed caching.
+- Each sensor keeps an independent status check and a native `paths:`
+  filter. No `dorny/paths-filter`, no per-job `if`.
+- The per-workflow boilerplate (`on`/`permissions`/`concurrency`) stays
+  duplicated across files. A new sensor means a new file copied from an
+  existing one.
+- justfile recipes and workflows continue to encode checks twice; they
+  can drift, caught by CI rather than prevented structurally.
+- The smoke workflow installs only the binaries it uses (Prometheus,
+  Alloy); Loki/Tempo/Grafana config validation moved to the always-on
+  config workflow.

--- a/docs/adr/0002-keep-per-workflow-ci.md
+++ b/docs/adr/0002-keep-per-workflow-ci.md
@@ -10,9 +10,10 @@ CI runs one workflow per sensor (`bats`, `python`, `zellij`, `chezmoi`,
 `pre-commit`, `lychee`, `observability`), and each repeats the same
 `on`/`permissions`/`concurrency` boilerplate. The justfile defines most
 of the same checks as recipes (`check-bats`, `check-observability`, …),
-so the two can drift. #274 asks whether to collapse the workflows into a
-single `ci.yml` with one job per check calling `just <check>`, making the
-justfile the single source of truth CI reads from.
+so the two can drift. The structural choice is between this per-workflow
+layout and a single `ci.yml` with one job per check calling
+`just <check>`, making the justfile the single source of truth CI reads
+from (#274).
 
 Two pressures motivate the question:
 
@@ -46,8 +47,8 @@ false-pass that CI then catches, never a bad merge. CI is authoritative.
 ## Decision
 
 We will keep one CI workflow per sensor. New checks land as new
-workflows, not as jobs in a shared `ci.yml`. The
-consolidation in #274 is rejected, not deferred.
+workflows, not as jobs in a shared `ci.yml`. Consolidation into a single
+`ci.yml` is rejected, not deferred.
 
 The observability gap is fixed within this structure by splitting the one
 workflow in two:
@@ -55,8 +56,8 @@ workflow in two:
 - `observability-config.yml`: static config validation, no path gate,
   runs on every PR. It installs the binaries those checks need (cached on
   their pinned versions to keep the always-on cost low).
-- `observability.yml`: the heavy live-metrics smoke, still path-gated to
-  the metrics path it exercises.
+- `observability-smoke.yml`: the heavy live-metrics smoke, still
+  path-gated to the metrics path it exercises.
 
 Issue #241 (`systemd-analyze verify` on the user units) lands as its own
 `script/checks/*` + `just` recipe + workflow, consistent with this

--- a/docs/adr/0002-keep-per-workflow-ci.md
+++ b/docs/adr/0002-keep-per-workflow-ci.md
@@ -6,84 +6,47 @@ Accepted
 
 ## Context
 
-CI runs one workflow per sensor (`bats`, `python`, `zellij`, `chezmoi`,
-`pre-commit`, `lychee`, `observability`), and each repeats the same
-`on`/`permissions`/`concurrency` boilerplate. The justfile defines most
-of the same checks as recipes (`check-bats`, `check-observability`, …),
-so the two can drift. The structural choice is between this per-workflow
-layout and a single `ci.yml` with one job per check calling
-`just <check>`, making the justfile the single source of truth CI reads
-from (#274).
+Each CI sensor runs in its own workflow, duplicating the
+`on`/`permissions`/`concurrency` boilerplate, and most are also justfile
+recipes, so the two can drift. The recurring temptation (#274) is to
+collapse them into a single `ci.yml` whose jobs each call `just <check>`,
+making the justfile the one source of truth.
 
-Two pressures motivate the question:
+The temptation is weaker than it looks. Consolidation removes only the
+trigger boilerplate (~10 lines per file); the bulk of each workflow is
+per-job setup (tool installs, language toolchains, secret material) that
+stays distinct wherever the jobs live. Not every check is a
+`just <check>` one-liner: some install and run through marketplace
+actions, and link-checking isn't a recipe at all. And GitHub gates paths
+only per workflow, not per job, so a single `ci.yml` would reintroduce
+path filtering as in-job conditionals, machinery the per-workflow layout
+gets for free along with an independent status check per sensor.
 
-- **Drift.** Workflow and justfile encode the same check twice; a recipe
-  rename or new sensor has to be made in both places.
-- **An actual gap.** `observability.yml` is path-gated to stack-file
-  changes, so the cheap `script/checks/observability-config` never runs
-  on an unrelated PR, and observability coverage looks absent on most PRs.
-
-Consolidation is weaker than it first appears:
-
-- The only genuinely duplicated boilerplate is the
-  `on`/`permissions`/`concurrency` blocks (~10 lines each). The bulk,
-  per-job setup, stays distinct regardless: age for `check-chezmoi`,
-  Zellij for `check-zellij`, the stack binaries for observability, Python
-  for `check-python`.
-- Three of the seven don't map to `just <check>`. `bats`, `pre-commit`,
-  and `lychee` drive both install and run through marketplace actions
-  (`bats-core/bats-action`, `pre-commit/action`,
-  `lycheeverse/lychee-action` with its own cache), and `lychee` isn't a
-  justfile recipe at all (it's CI-only).
-- GitHub supports `paths:` only at the workflow trigger, not per job. A
-  single `ci.yml` would need `dorny/paths-filter` or per-job `if` to keep
-  the observability smoke gated, more machinery than the per-workflow
-  `paths:` it replaces.
-
-The drift risk is already bounded: the justfile header notes each sensor
-also runs in its own workflow, so a stale recipe list causes a local
-false-pass that CI then catches, never a bad merge. CI is authoritative.
+A related question is when a workflow should be path-gated. Gating hides
+a check on unrelated PRs; gating a check whose only cost is fast
+validation silently drops coverage, which is how the observability config
+validation came to never run on most PRs.
 
 ## Decision
 
-We will keep one CI workflow per sensor. New checks land as new
-workflows, not as jobs in a shared `ci.yml`. Consolidation into a single
-`ci.yml` is rejected, not deferred.
+We keep one workflow per sensor. New checks land as new workflows, not as
+jobs in a shared `ci.yml`. Consolidation is rejected, not deferred.
 
-The observability gap is fixed within this structure by splitting the one
-workflow in two:
+A workflow is path-gated only when its setup is expensive, such as a
+heavy install or binding real ports. A check whose only cost is fast
+validation runs unconditionally, so coverage is never silently absent.
 
-- `observability-config.yml`: static config validation, no path gate,
-  runs on every PR. It installs the binaries those checks need (cached on
-  their pinned versions to keep the always-on cost low).
-- `observability-smoke.yml`: the heavy live-metrics smoke, still
-  path-gated to the metrics path it exercises.
-
-Issue #241 (`systemd-analyze verify` on the user units) lands as its own
-`script/checks/*` + `just` recipe + workflow, consistent with this
-structure.
-
-We will revisit when any of these triggers fire:
-
-- A new check is genuinely a `just <check>` one-liner with no bespoke
-  setup, and three or more such checks accumulate; at that point a
-  shared `ci.yml` job matrix stops duplicating boilerplate without the
-  per-job-gating tax.
-- Workflow/justfile drift causes a real miss (a check silently stops
-  running in CI), not just a theoretical one.
+We revisit if enough checks become genuine `just <check>` one-liners with
+no bespoke setup that a shared job matrix would remove real duplication,
+or if workflow/justfile drift ever causes a check to silently stop
+running in CI.
 
 ## Consequences
 
-- `observability-config` runs on every PR; a broken service config fails
-  the build regardless of which files changed. The always-on binary
-  install is the cost, mitigated by version-keyed caching.
 - Each sensor keeps an independent status check and a native `paths:`
-  filter. No `dorny/paths-filter`, no per-job `if`.
-- The per-workflow boilerplate (`on`/`permissions`/`concurrency`) stays
-  duplicated across files. A new sensor means a new file copied from an
-  existing one.
-- justfile recipes and workflows continue to encode checks twice; they
-  can drift, caught by CI rather than prevented structurally.
-- The smoke workflow installs only the binaries it uses (Prometheus,
-  Alloy); Loki/Tempo/Grafana config validation moved to the always-on
-  config workflow.
+  filter, with no per-job path conditionals.
+- The trigger boilerplate stays duplicated across files: a new sensor is
+  a new file copied from an existing one, and recipe/workflow drift is
+  caught by CI rather than prevented structurally.
+- Cheap checks pay a small cost on every PR in exchange for never going
+  silently uncovered; only expensive setup is gated.


### PR DESCRIPTION
## Summary

`observability-config` now runs on every PR. The observability workflow was entirely path-gated to stack-file changes, so the cheap config validation never ran on unrelated PRs and coverage looked absent. It's split into `observability-config.yml` (always runs; validates every service config) and `observability-smoke.yml` (the heavy live-metrics smoke, still path-gated to the path it exercises). ADR-0002 records the structural decision the issue asked for: keep one workflow per sensor rather than consolidating into a single `just`-driven `ci.yml`.

## Gotchas

- The load-bearing review is **ADR-0002** (`docs/adr/0002-keep-per-workflow-ci.md`) — it's the "record which wins" deliverable and lands `Accepted`, so this PR is the acceptance step. If you'd rather consolidate after all, that's the place to push back.
- Config validation needs `promtool`/`alloy`/`loki`/`tempo` on PATH, so "cheap" still pays the binary install on every PR — more than the issue's framing implied. I mitigated with `actions/cache` keyed on the pinned install scripts (same pattern as `lychee.yml`); confirm that tradeoff is acceptable versus eating a fresh ~400 MB install per PR.
- `observability-smoke.yml` now installs only Prometheus + Alloy (the binaries its script actually uses) and dropped Loki/Tempo/Grafana from both its install loop and `paths:` filter, since those are config-only concerns now covered by the always-on config workflow.

## Notes

- Merged `main` to clear a conflict with #259, which landed `systemd.yml` as its own workflow — a concrete instance of this ADR's "new checks land as new workflows" rule, so the ADR no longer needs to name #241 explicitly.

## Verification

- `pre-commit run --all-files` passed, including actionlint (workflow YAML) and vale.
- Did not exercise the observability jobs in CI from this checkout (they need the stack binaries and bind real ports); the split preserves the existing install/check steps verbatim, so CI is the first real run.

Closes #274