### PR TITLE
Install devcontainer CLI as a pinned nvm npm global

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -159,6 +159,13 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
+      "matchStrings": ["DEVCONTAINER_CLI_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "@devcontainers/cli",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"

--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -69,4 +69,22 @@ else
   log "readwise-cli: $READWISE_CLI_VERSION already installed"
 fi
 
+# --------------------------------------------------------- devcontainers CLI
+# Same pin-enforced replace as readwise-cli above. Backs the global guide's
+# devcontainer-exec helper; nvm owns the runtime so this is the only copy on
+# PATH.
+DEVCONTAINER_CLI_VERSION="0.87.0"
+installed="$(npm ls -g --depth=0 --parseable=false @devcontainers/cli 2>/dev/null |
+  sed -n 's,.*@devcontainers/cli@\([0-9][0-9.]*\).*,\1,p' | head -1)"
+if [ "$installed" != "$DEVCONTAINER_CLI_VERSION" ]; then
+  if [ -n "$installed" ]; then
+    log "devcontainers-cli: replacing $installed with $DEVCONTAINER_CLI_VERSION"
+  else
+    log "devcontainers-cli: installing $DEVCONTAINER_CLI_VERSION"
+  fi
+  npm install -g "@devcontainers/cli@$DEVCONTAINER_CLI_VERSION"
+else
+  log "devcontainers-cli: $DEVCONTAINER_CLI_VERSION already installed"
+fi
+
 log "node ecosystem complete"


### PR DESCRIPTION
## Summary
The host's `@devcontainers/cli` now installs from the bootstrap as a pinned, Renovate-tracked npm global under nvm, instead of running by coincidence from a manually-installed root-owned copy whose shebang happened to resolve to the nvm Node after #268 purged the system Node.

Script 03 installs `@devcontainers/cli@0.87.0` using the same install-or-replace block as `@readwise/cli`, and `renovate.json` gains a matching npm-datasource custom manager. The orphaned `/usr/lib/node_modules/@devcontainers` tree and `/usr/bin/devcontainer` symlink are removed as a one-time host cleanup, leaving the nvm-managed CLI as the only copy on PATH.

## Gotchas
- The orphan removal is **not** scripted into the bootstrap — it's a one-time host action, mirroring how #268 purged its stray Node manually rather than baking a `sudo rm` into an idempotent script that runs on every fresh host. Decide whether you'd rather it be scripted; I left it out on that precedent. **This host cleanup is not yet done — see Verification.**

## Verification
- `pre-commit run --all-files` — all hooks pass, including `renovate-config-validator`.
- `bats test/` — 80/80 pass.
- Host cleanup (`sudo rm -rf /usr/lib/node_modules/@devcontainers /usr/bin/devcontainer`, then `npm install -g @devcontainers/cli@0.87.0` under nvm) is **pending** — it touches root-owned files and the live nvm prefix, so I left it for you to run rather than mutating host state from the PR. After it, `which -a devcontainer` should resolve only under `~/.config/nvm/...`.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)