### PR TITLE
Match chezmoi-apply check to rendered home paths

### DIFF
--- a/script/checks/chezmoi-apply
+++ b/script/checks/chezmoi-apply
@@ -15,11 +15,11 @@ chezmoi apply --source="$SOURCE_DIR" --destination="$dest" --exclude=scripts,enc
 
 fail=0
 while IFS= read -r cmd; do
-  resolved="${cmd/\$HOME/$dest}"
+  resolved="${cmd/#$HOME/$dest}"
   if [ ! -f "$resolved" ]; then
     printf 'FAIL: hook command %s not found at %s\n' "$cmd" "$resolved" >&2
     fail=1
   fi
-done < <(jq -r '.. | .command? // empty | select(startswith("$HOME/.claude/"))' "$dest/.claude/settings.json")
+done < <(jq -r --arg home "$HOME" '.. | .command? // empty | select(startswith($home + "/.claude/"))' "$dest/.claude/settings.json")
 
 exit "$fail"


### PR DESCRIPTION
## Summary

`script/checks/chezmoi-apply` now actually verifies that managed `~/.claude/` hook commands resolve to deployed scripts. Its selector keyed on the literal `$HOME/.claude/` prefix, but the rendered `settings.json` carries the expanded home path (`/home/alunduil/.claude/...`) from `{{ .chezmoi.homeDir }}`, so it matched zero commands and the check passed without asserting anything. Closes #262.

## Gotchas

- Confirm the `${cmd/#$HOME/$dest}` anchor (`#`) is intended — it replaces only a leading `$HOME`, which is correct here since commands are absolute home-rooted paths, but the prior `${cmd/\$HOME/...}` matched a literal `$HOME` substring that never existed.
- The `/.claude/` prefix is what keeps zellaude (`~/.config/zellij/...`) and `rtk hook claude` out of scope; widening the selector would pull those in.

## Verification

- Ran `script/checks/chezmoi-apply` on a clean tree — exit 0, and the selector now matches all three managed commands (`pr-draft-guard.sh`, `pre-commit-edit-guard.sh`, `statusline.sh`) rather than zero.
- Rendered to a temp destination, deleted a deployed hook, and reran the loop — produced `FAIL: … not found` with exit 1.
- `shellcheck` clean.