### PR TITLE
Age out stale ~/.cache via systemd-tmpfiles timer

### DIFF
--- a/dot_config/user-tmpfiles.d/cache.conf
+++ b/dot_config/user-tmpfiles.d/cache.conf
@@ -1,0 +1,8 @@
+#  Age stale entries out of the user cache directory (%C = $XDG_CACHE_HOME,
+#  i.e. ~/.cache), which the XDG spec defines as regenerable. The user
+#  systemd-tmpfiles-clean.timer runs `systemd-tmpfiles --user --clean` daily.
+#  Removal requires atime, mtime, and ctime to all exceed the age, so files in
+#  active use are never reaped and the cost of a deletion is at most a rebuild
+#  on next use.
+#Type Path Mode User Group Age Argument
+e     %C   -    -    -     30d

--- a/run_onchange_after_12-enable-tmpfiles-clean.sh.tmpl
+++ b/run_onchange_after_12-enable-tmpfiles-clean.sh.tmpl
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# The config hash below re-runs this script when the cleaner config appears or
+# changes, re-asserting the (system-provided) timer. No daemon-reload: we ship
+# tmpfiles config, not a unit.
+# cache cleaner config: {{ include "dot_config/user-tmpfiles.d/cache.conf" | sha256sum }}
+
+set -euo pipefail
+
+# Skip where there is no user systemd manager to talk to (headless apply over
+# SSH without lingering, container builds). The config is still deployed; a
+# later interactive apply, or a manual enable, brings the timer up.
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "==> tmpfiles-clean: no user systemd session; leaving timer disabled" >&2
+  exit 0
+fi
+
+systemctl --user enable --now systemd-tmpfiles-clean.timer


### PR DESCRIPTION
## Summary

`~/.cache` now ages itself out: files untouched for 30 days are reclaimed by the user `systemd-tmpfiles-clean.timer`, which this PR enables and feeds a `user-tmpfiles.d` config. On this host that targets a 12G tree (7.8G of it stale `pre-commit` hook envs) without ever touching a cache in active use.

A file is removed only when its atime, mtime, *and* ctime all exceed the age, and `$HOME` is `relatime` (atime bumped at least daily on read), so anything used recently survives; the only cost of a deletion is a rebuild/refetch on next use.

Scope is deliberately just `~/.cache` — the one tree the XDG spec defines as regenerable. Tool caches outside it (`.cargo`, `.rustup`, `.npm`, `.ghcup`, `.local/state`) mix cache with installed state and ship their own pruning, so a generic age-deleter has no business there.

## Gotchas

- **Retention is 30d at one blanket age** — confirm that's the cadence you want before this merges; it's the only real knob. Bump the `30d` in `cache.conf` to lengthen it. Per-path tuning was considered and rejected: `~/.cache` is uniformly disposable by spec, so the only differentiator is rebuild *cost*, not safety.
- The enable script keys its `run_onchange` hash on `cache.conf` and **omits `daemon-reload`** (unlike the #273/observability enables) — we ship tmpfiles config, not a systemd unit, so there's nothing to reload.

## Verification

- Confirmed `%C` expands to `/home/alunduil/.cache` under `systemd-tmpfiles --user` (debug `--create`, no-op on the existing dir).
- Confirmed the age rule via a throwaway dir + debug `--clean`: a 60-day-old file was kept with `change time ... too new` (`age-by: abcmABM`), proving deletion needs all of atime/mtime/ctime stale.
- `systemd-tmpfiles --user --clean --dry-run` from the acceptance criteria does **not** exist on this host (systemd 252; `--dry-run` landed in 254) — validated with debug logging instead. Worth noting in the issue.
- Did **not** run `--clean` against the real config (it would delete now); behavior proven against a temp target.
- Template renders with a resolved hash against this checkout; pre-commit (shellcheck, shfmt, vale) clean.

Closes #271