### PR TITLE
Guard devcontainers CLI query against set -e on fresh prefix

### DIFF
--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -77,7 +77,7 @@ fi
 # PATH.
 DEVCONTAINER_CLI_VERSION="0.87.0"
 installed="$(npm ls -g --depth=0 --parseable=false @devcontainers/cli 2>/dev/null |
-  sed -n 's,.*@devcontainers/cli@\([0-9][0-9.]*\).*,\1,p' | head -1)"
+  sed -n 's,.*@devcontainers/cli@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"
 if [ "$installed" != "$DEVCONTAINER_CLI_VERSION" ]; then
   if [ -n "$installed" ]; then
     log "devcontainers-cli: replacing $installed with $DEVCONTAINER_CLI_VERSION"


### PR DESCRIPTION
## Summary

`chezmoi update`/`apply` now survives the node-ecosystem bootstrap on a host that doesn't yet have the devcontainers CLI installed. The block added in #282 dropped the `|| true` guard that #278 had already applied to the readwise block, so on a fresh npm prefix `npm ls -g @devcontainers/cli` exited 1, propagated through `pipefail`, and `set -e` killed the script before its install branch could run.

## Gotchas

This is the same regression #278 fixed, reintroduced one block down — worth a glance at whether any future `npm ls -g` block should share a helper rather than each re-deriving the `installed=` query and its guard. Not done here (rule of three; only two call sites), but flagging it.

## Verification

`pre-commit run --all-files` passed (shellcheck/shfmt included). Reproduced the failure path mentally against the original error output: it died right after "readwise-cli: 0.5.6 already installed", i.e. entering the unguarded devcontainers block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)