### PR TITLE
Supersede ADR 0001: port git-worktree-poi to Rust

### DIFF
--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -60,6 +60,8 @@ Erlang
 Cabal
 pnpm
 corepack
+rustup
+CLIs
 
 # Doc conventions
 README
@@ -83,5 +85,5 @@ keybinds
 namespaced
 repo
 repos
-toolchains
+(?i)toolchains?
 facto

--- a/docs/adr/0001-keep-git-worktree-poi-in-bash.md
+++ b/docs/adr/0001-keep-git-worktree-poi-in-bash.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted
+Superseded by [0002](0002-port-git-worktree-poi-to-rust.md).
+
+The triggers below fired: the script reached 633 lines and #147 landed
+as bash in #154. The bash-vs-rewrite question was re-evaluated in #205;
+0002 records the decision to port to Rust.
 
 ## Context
 

--- a/docs/adr/0001-keep-git-worktree-poi-in-bash.md
+++ b/docs/adr/0001-keep-git-worktree-poi-in-bash.md
@@ -4,10 +4,6 @@
 
 Superseded by [0002](0002-port-git-worktree-poi-to-rust.md).
 
-The triggers below fired: the script reached 633 lines and #147 landed
-as bash in #154. The bash-vs-rewrite question was re-evaluated in #205;
-0002 records the decision to port to Rust.
-
 ## Context
 
 `dot_local/bin/executable_git-worktree-poi` started as a small

--- a/docs/adr/0002-port-git-worktree-poi-to-rust.md
+++ b/docs/adr/0002-port-git-worktree-poi-to-rust.md
@@ -1,0 +1,62 @@
+# 2. Port git-worktree-poi to Rust
+
+## Status
+
+Accepted
+
+Supersedes [0001](0001-keep-git-worktree-poi-in-bash.md).
+
+## Context
+
+ADR 0001 kept `git-worktree-poi` in bash and deferred the rewrite behind
+explicit re-evaluation triggers. Two have since fired:
+
+- **Size.** ADR 0001 cited the script at 234 lines as evidence it sat
+  below the threshold where bash becomes a tax. `dot_local/bin/executable_git-worktree-poi`
+  is now 633 lines—2.7×—past the ADR's own "more than roughly 100 lines
+  of bash addition" trigger.
+- **GraphQL batching.** ADR 0001 named #147 (batched PR-state lookup) as
+  a revisit trigger. It landed as bash in #154 via a `gh api graphql`
+  heredoc plus `jq`—the "more jq/heredoc surgery than the equivalent
+  rewrite would cost" trigger.
+
+ADR 0001's reversibility argument was explicit that, at a trigger,
+porting is cheaper then than after further accretion. We're past that
+point.
+
+ADR 0001 also picked Go, on the reasoning that Go is the de facto
+language for `gh` extensions and `gh-poi` is the reference point. That
+framing no longer holds: `git-worktree-poi` never became a `gh`
+extension—it's a standalone binary in `dot_local/bin/`—and the
+companion CLIs have since standardized on Rust (`git-repo-picker`,
+alunduil-infrastructure#54; `zellij-git-status`, alunduil-infrastructure#26).
+rustup is already bootstrapped in chezmoi. Rust aligns the toolchain
+with the tools `git-worktree-poi` ships alongside.
+
+## Decision
+
+We will port `git-worktree-poi` out of chezmoi-managed bash into a
+standalone Rust binary repository, reversing ADR 0001's "keep bash"
+decision and its Go language pick.
+
+Project execution—repo bootstrap, milestones, CI/release, and the
+chezmoi consumer swap (`script/install/` pin, bash removal, systemd
+`ExecStart` swap, bats removal)—is carried in
+alunduil-infrastructure#116, mirroring the `git-repo-picker` planning
+artifact (alunduil-infrastructure#54). This ADR records only the
+decision to reverse 0001 and the language; the milestone tracking lives
+in the infrastructure issue.
+
+## Consequences
+
+- Toolchain aligns with `git-repo-picker` and `zellij-git-status`:
+  shared release/CI patterns, `cargo test` instead of the
+  PATH-shim `bats` model, struct-based mocks, a real color crate in
+  place of `tput`/ANSI.
+- The #154 batched PR-state lookup moves from a `gh api graphql` heredoc
+  and `jq` into typed code (`octocrab` or a structured `gh` shell-out).
+- Costs: a new repository, its publishing and release flow, and Rust in
+  that repo's CI. chezmoi gains a `script/install/` pin and loses the
+  bash bin plus its `bats` coverage (moved to the new repo).
+- ADR 0001 is retained as the historical record of why bash was
+  originally chosen and which triggers governed the reversal.


### PR DESCRIPTION
## Summary

ADR 0001's deferral triggers fired, so git-worktree-poi is now slated to leave chezmoi-managed bash for a standalone Rust binary. ADR 0002 records that reversal; ADR 0001 is marked superseded and kept as the historical record. The new project is carried in [alunduil-infrastructure#116](https://github.com/alunduil/alunduil-infrastructure/issues/116), with the chezmoi-side consumer swap tracked in #295.

The script grew from the cited 234 lines to 633 (past 0001's "~100 lines of bash addition" trigger), and GraphQL batching (#147) landed as bash in #154 — exactly the "more jq/heredoc surgery than a rewrite would cost" trigger. Rust over 0001's Go aligns the toolchain with the companion CLIs (git-repo-picker, zellij-git-status); 0001's Go rationale rested on a `gh`-extension framing the tool never adopted.

## Gotchas

- This deliberately does **not** scrub "234 lines"/"#147 pending" from ADR 0001's body, even though #205's acceptance criterion #2 asks for that. Criterion #2 was written for the re-affirm path; #205's Scope says the porting path should *supersede rather than edit in place*. The bare `Superseded by 0002` pointer redirects any reader to 0002, where the current 633/#154 numbers live — so no one decides from 0001's stale body. Confirm you're happy preserving the historical body vs. rewriting it.
- ADR 0001's Status is a bare pointer (no reversal justification) per Nygard convention — the rationale lives in 0002, not duplicated in the superseded record.

## Verification

- `pre-commit run --files …` over the changed files: vale + markdownlint pass (added `rustup`, `CLIs`, `(?i)toolchains?` to the shared vocabulary to clear new spelling flags).

Closes #205