### PR TITLE
Bind pair-tab rename to the new tab's id

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -194,9 +194,12 @@ print_remotes() {
 }
 
 spawn_pair_tab() {
-    local cwd=$1 tab=$2
-    zellij action new-tab --layout pair --cwd "$cwd"
-    zellij action rename-tab "$tab"
+    local cwd=$1 tab=$2 id
+    # new-tab prints the created tab's id; rename it by id rather than the
+    # active tab, so the --all-worktrees loop can't race a rename onto a tab a
+    # later new-tab already pulled focus to.
+    id=$(zellij action new-tab --layout pair --cwd "$cwd")
+    zellij action rename-tab --tab-id "$id" "$tab"
 }
 
 # Tests source this script to exercise helpers above without triggering the

--- a/dot_local/bin/fixtures/git_repo_picker/stubs/zellij
+++ b/dot_local/bin/fixtures/git_repo_picker/stubs/zellij
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # zellij stub: appends "$@" to $ZELLIJ_RECORDER; emits $ZELLIJ_TAB_NAMES
-# (newline-delimited) for `action query-tab-names`, matching real CLI output.
+# (newline-delimited) for `action query-tab-names`, matching real CLI output;
+# emits a --cwd-derived numeric id for `action new-tab`, mirroring real zellij
+# printing the created tab's id. Tests correlate the id the picker feeds back
+# into `rename-tab --tab-id` against this same cksum of the tab's cwd.
 printf '%s\n' "$*" >>"$ZELLIJ_RECORDER"
 if [[ "${1:-}" == "action" && "${2:-}" == "query-tab-names" ]]; then
   printf '%s' "${ZELLIJ_TAB_NAMES:-}"
+elif [[ "${1:-}" == "action" && "${2:-}" == "new-tab" ]]; then
+  cwd=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --cwd) cwd="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  cksum <<<"$cwd" | cut -d' ' -f1
 fi

--- a/dot_local/bin/git_repo_picker.bats
+++ b/dot_local/bin/git_repo_picker.bats
@@ -50,11 +50,14 @@ petdir() {
   printf '%s' "$XDG_DATA_HOME/git-worktrees/$1/$2/$3"
 }
 
-# Assert the picker spawned this worktree's pair tab: new-tab at its petdir and
-# rename-tab to its rendered name both reached $ZELLIJ_RECORDER.
+# Assert the picker spawned this worktree's pair tab: new-tab at its petdir, and
+# rename-tab targeting the id new-tab returned for that cwd (the zellij stub
+# derives it as cksum of --cwd), both reached $ZELLIJ_RECORDER.
 assert_spawn() {
+  local id
+  id=$(cksum <<<"$(petdir "$@")" | cut -d' ' -f1)
   grep -Fxq "action new-tab --layout pair --cwd $(petdir "$@")" "$ZELLIJ_RECORDER" \
-    && grep -Fxq "action rename-tab $(tab_name "$@")" "$ZELLIJ_RECORDER"
+    && grep -Fxq "action rename-tab --tab-id $id $(tab_name "$@")" "$ZELLIJ_RECORDER"
 }
 
 # Assert the picker did not spawn a pair tab for this worktree.


### PR DESCRIPTION
## Summary

Alt . (`git-repo-picker --all-worktrees`) now names every rehydrated pair tab correctly. The fan-out loop spawned a tab per closed worktree and then renamed "the active tab" — but `new-tab` and `rename-tab` are independent zellij server messages with no ordering, so a later iteration's `new-tab` could steal focus before the prior rename landed, dropping renames onto the wrong tab or leaving the layout's default `pair` name. The rename is now bound to the id `new-tab` returns, so it targets the tab it created regardless of focus timing.

## Gotchas

The id-on-stdout contract is specific to zellij v0.43.1 (confirmed in `new-tab --help`); if the pinned version bumps, re-check that `new-tab` still prints the tab id and `rename-tab` still takes `--tab-id`. I passed on the alternative `new-tab --name` because `pair.kdl` hard-codes `tab name="pair"` and I couldn't verify non-disruptively whether `--name` overrides a layout-supplied name — worth a sanity check if you'd prefer that shape.

## Verification

Ran the picker bats suite (23 tests, all pass); the `--all-worktrees` test now asserts each `rename-tab --tab-id` matches the id `new-tab` returned for that worktree's cwd, so it catches id↔tab mispairing order-independently, not just a missing flag. `pre-commit` (shellcheck, shfmt) green on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)