### PR TITLE
Pin zellij debug build to v0.44.3, guard checkout

### DIFF
--- a/script/install/zellij
+++ b/script/install/zellij
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ZELLIJ_VERSION="v0.43.1"
+ZELLIJ_VERSION="v0.44.3"
 ARCH="x86_64-unknown-linux-musl"
 
 # shellcheck source-path=SCRIPTDIR source=lib.sh
@@ -38,13 +38,22 @@ if [ -z "${CI:-}" ] &&
     mkdir -p "$(dirname "$src")"
     git clone --quiet "$ZELLIJ_FORK_URL" "$src"
   fi
-  git -C "$src" -c advice.detachedHead=false checkout --quiet "$ZELLIJ_VERSION"
+  # The release build regenerates the checked-in wasm plugin assets
+  # (zellij-utils embeds them at compile time), leaving the tree dirty. Only
+  # switch refs when the pinned tag changed -- discarding those assets first,
+  # since a dirty tree aborts the checkout. When already on the tag, leave the
+  # tree alone so the cargo target cache and the regenerated assets carry
+  # forward instead of forcing a fat-LTO relink every apply.
+  target_commit="$(git -C "$src" rev-parse --verify "${ZELLIJ_VERSION}^{commit}")"
+  if [ "$(git -C "$src" rev-parse HEAD)" != "$target_commit" ]; then
+    git -C "$src" checkout --quiet -- .
+    git -C "$src" -c advice.detachedHead=false checkout --quiet "$ZELLIJ_VERSION"
+  fi
 
   printf '==> zellij: building %s from source with debug symbols (slow)\n' "$ZELLIJ_VERSION" >&2
   # debuginfo=2 atop the release profile's fat LTO peaks ~10-14 GiB in one
   # rustc process; a wedged zellij server holds ~8 GiB, so kill it first or
-  # this OOMs. v0.43.1 builds with `xtask build --release` (not the newer
-  # `ci build-release`, which exists only on main).
+  # this OOMs. `xtask build --release` carries the release profile's fat LTO.
   (
     cd "$src"
     CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=true \


### PR DESCRIPTION
## Summary

`chezmoi update` was aborting in bootstrap script 02. The debug-build path pinned zellij to v0.43.1, but the host now runs a locally-built v0.44.3 debug build (baking the upstream freeze fix tracked in #211). The v0.43.1 pin made the installer try to roll the source clone back to v0.43.1; the release build had dirtied the checked-in wasm plugin assets, so `git checkout` aborted and the script exited non-zero.

This bumps the pin to v0.44.3 so the committed state matches what's installed, and stops re-checking out when the clone is already on the pinned tag. The 3.9 GB cargo `target/` cache and the regenerated wasm assets now carry forward instead of forcing a fat-LTO relink on every apply.

## Gotchas

- The fix only reaches your machine once merged — `chezmoi update` reads the apply clone on `main`, not this branch. Merging is the actual unblock for the failing update.
- The checkout is now skipped when `HEAD` already equals the pinned tag. Switching to a *new* tag still works: it discards the dirty assets first, then checks out. Worth a look that the discard (`git checkout -- .`) is acceptably scoped to the disposable build clone.
- `script/install/*` is extensionless, so the pre-commit shellcheck/shfmt hooks (matching `executable_`/`*.sh.tmpl`) don't lint it. Ran shellcheck manually — clean.

## Verification

- Ran `shellcheck script/install/zellij` — clean (only the expected SC1091 for the sourced `lib.sh`).
- Confirmed the guard against the live clone: `v0.44.3^{commit}` resolves to the current `HEAD`, so the checkout is skipped and the dirty assets stay harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)