### PR TITLE
Cut zjstatus fork load in the pair layout

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -4,7 +4,7 @@
 //
 // Template:
 //   zellaude   (1 line) — per-tab Claude Code activity + tab list
-//   zjstatus   (1 line) — current branch (5s) + open-PR list (60s)
+//   zjstatus   (1 line) — current branch (30s) + open-PR list (60s)
 //   children   (the panes)
 //   zjstatus   (1 line) — gh rate-limit flags (60s), left-aligned
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
@@ -25,11 +25,11 @@ layout {
             plugin location="zjstatus" {
                 format_left  "#[bg=16]{command_branch}{command_prs}"
                 format_space "#[bg=16]"
-                command_branch_command         "bash -lc zellij-branch-status"
+                command_branch_command         "bash -c zellij-branch-status"
                 command_branch_format          "{stdout}"
                 command_branch_rendermode      "dynamic"
-                command_branch_interval        "5"
-                command_prs_command            "bash -lc zellij-pr-status"
+                command_branch_interval        "30"
+                command_prs_command            "bash -c zellij-pr-status"
                 command_prs_format             "{stdout}"
                 command_prs_rendermode         "dynamic"
                 command_prs_interval           "60"
@@ -40,7 +40,7 @@ layout {
             plugin location="zjstatus" {
                 format_left  "#[bg=16]{command_ratelimits}"
                 format_space "#[bg=16]"
-                command_ratelimits_command     "bash -lc zellij-rate-limit-status"
+                command_ratelimits_command     "bash -c zellij-rate-limit-status"
                 command_ratelimits_format      "{stdout}"
                 command_ratelimits_rendermode  "dynamic"
                 command_ratelimits_interval    "60"


### PR DESCRIPTION
## Summary

Reduces the per-session fork load of the pair layout's zjstatus status widgets, which fork-bombed the zellij server into a thread-spawn panic when ~12 pair sessions launched at once (#211). Each pair tab ran three widgets as `bash -lc <script>` through the server's background-job runner; `-l` re-sourced `~/.bashrc` every time, and the branch widget fired every 5s. At 12× that, the server forked interactive shells faster than it reaped them — ~3300 zombie `bash` children until `clone()` hit `EAGAIN` and `server_listener` panicked. This drops the login shell (`bash -lc` → `bash -c`) on all three and lengthens the branch interval 5s → 30s.

## Gotchas

The `bash -c` widgets are non-login, so they resolve `zellij-*-status` via the server's *inherited* PATH rather than re-deriving it from `~/.bashrc`. That holds because zellij is launched from `~/.local/bin` (so the server already has it). If zellij is ever started from a context without `~/.local/bin` on PATH, the branch widget renders `"?"` (documented fallback) — not a crash. Worth a sanity check that this matches how you start zellij.

This is a mitigation, not the root fix for #211 — it lowers the load that triggered the panic; the upstream question (zellij fork-bombing itself under high `run_command`/`cli pipe` rate, and zellaude's synchronous hook pipe) is separate.

## Verification

- `script/checks/zellij-config` against zellij 0.44.3 — layouts parse clean.
- Root cause traced from a live capture (prometheus/zellijstat series + full gdb backtrace): server healthy at 16:27 (35 threads / 9 conns), acute fork+pipe storm 16:28, `server_listener` thread-spawn panic 16:33. Not a slow leak, not the route_thread_main deadlock.