### PR TITLE
Install VS Code from upstream .deb, not a hand-rolled repo

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -31,7 +31,7 @@ ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)
 command -v calibre                         # ebook library manager
-command -v code                            # VS Code (Microsoft apt repo)
+command -v code                            # VS Code (upstream .deb)
 docker --version                           # container engine (docker-ce, auto-updated)
 command -v truenas-mcp                     # TrueNAS MCP server binary
 trivy --version                            # vulnerability scanner (aquasecurity/trivy)

--- a/run_once_before_01-install-system-packages.sh.tmpl
+++ b/run_once_before_01-install-system-packages.sh.tmpl
@@ -46,13 +46,12 @@ if [ ! -f /etc/apt/sources.list.d/keybase.list ]; then
 fi
 
 # --------------------------------------------------------------- vscode (code)
-if [ ! -f /usr/share/keyrings/packages.microsoft.gpg ]; then
-  log "vscode: adding apt repository"
-  curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |
-    sudo gpg --dearmor -o /usr/share/keyrings/packages.microsoft.gpg
-  printf 'deb [arch=%s signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main\n' \
-    "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
-fi
+# We install `code` from its upstream .deb (below), whose postinst manages the
+# apt repo itself (vscode.sources + microsoft.gpg). A hand-rolled vscode.list
+# naming a second keyring path collides with that postinst source and wedges
+# apt with a "Conflicting values set for option Signed-By" error. Drop the
+# stale entry before any apt call so sources stay readable.
+sudo rm -f /etc/apt/sources.list.d/vscode.list /usr/share/keyrings/packages.microsoft.gpg
 
 # --------------------------------------------------------------------- docker
 if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then
@@ -70,7 +69,7 @@ APT_PACKAGES=(
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   protobuf-compiler
   golang-petname
-  keybase signal-desktop calibre code
+  keybase signal-desktop calibre
   nethack-console
   docker-ce docker-ce-cli docker-ce-rootless-extras containerd.io
   docker-buildx-plugin docker-compose-plugin
@@ -85,6 +84,17 @@ if ((${#missing[@]} > 0)); then
   sudo apt-get install -y "${missing[@]}"
 else
   log "apt: all packages present"
+fi
+
+# --------------------------------------------------------------- vscode (code)
+# Installed from the upstream .deb rather than the apt batch so its postinst
+# owns the apt repo (see the keyring cleanup above). Pulls dependencies from
+# the now-readable apt sources.
+if ! command -v code >/dev/null 2>&1; then
+  log "vscode: installing from upstream .deb"
+  curl -fsSL 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64' -o /tmp/code.deb
+  sudo apt-get install -y /tmp/code.deb
+  rm -f /tmp/code.deb
 fi
 
 # ---------------------------------------------------------------- tailscale


### PR DESCRIPTION
## Summary

`apt-get`/`apt-cache` no longer wedge with "Conflicting values set for option Signed-By" on the vscode repo, so apt-based bootstrap (script 01) runs to completion again. We were declaring the Microsoft `code` repo in our own `vscode.list` with one keyring path while the `code` package's postinst writes `vscode.sources` with another; apt refuses to read sources when the two `Signed-By` paths disagree (the keys themselves are byte-identical). Fix drops our entry and installs `code` from Microsoft's upstream `.deb`, letting its postinst own the single source.

Closes #286

## Gotchas

- The stale-`vscode.list` removal is placed *before* the apt batch on purpose — on an already-broken host the first `apt-get update` dies otherwise, before any cleanup could run. Confirm the ordering reads right.
- I could not exercise the apply on a genuinely affected host (no spare fresh Crostini to break + re-apply). Worth a sanity check if you have one: the recovery path depends on this script re-running, which it does because its content hash changed.
- `.deb` URL is Microsoft's stable redirect (`code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64`) rather than a pinned version — matches how `code` was previously unpinned via apt, so no regression in pinning posture, but flag if you'd rather pin.

## Verification

- `pre-commit run` (shellcheck, shfmt, vale, markdownlint) passed on both changed files.
- No bats tests cover script 01; none added (would be testing apt/dpkg behaviour, not our logic).