### PR TITLE
Install pre-commit reproducibly via uv

### DIFF
--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -27,6 +27,8 @@ lychee --version                           # markdown link checker (mirrors CI)
 yq --version                               # YAML processor (mikefarah/yq)
 vale --version                             # prose linter (vale-cli/vale)
 just --version                             # command runner (justfiles)
+uv --version                               # Python-CLI installer (astral-sh/uv)
+pre-commit --version                       # git hook runner (uv tool install)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)

--- a/renovate.json
+++ b/renovate.json
@@ -130,6 +130,20 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^script/install/uv$/"],
+      "matchStrings": ["UV_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_02-install-binary-tools\\.sh\\.tmpl$/"],
+      "matchStrings": ["PRE_COMMIT_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "pre-commit",
+      "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^script/install/alloy$/"],
       "matchStrings": ["ALLOY_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "grafana/alloy",

--- a/run_once_before_02-install-binary-tools.sh.tmpl
+++ b/run_once_before_02-install-binary-tools.sh.tmpl
@@ -10,6 +10,7 @@
 # vale content:       {{ include "script/install/vale" | sha256sum }}
 # trivy content:      {{ include "script/install/trivy" | sha256sum }}
 # just content:       {{ include "script/install/just" | sha256sum }}
+# uv content:         {{ include "script/install/uv" | sha256sum }}
 # alloy content:      {{ include "script/install/alloy" | sha256sum }}
 # prometheus content: {{ include "script/install/prometheus" | sha256sum }}
 # loki content:       {{ include "script/install/loki" | sha256sum }}
@@ -35,6 +36,19 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 "$INSTALL_DIR/vale" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/trivy" --bin-dir "$HOME/.local/bin"
 "$INSTALL_DIR/just" --bin-dir "$HOME/.local/bin"
+"$INSTALL_DIR/uv" --bin-dir "$HOME/.local/bin"
+
+# pre-commit ships only as a Python package, so uv owns its install. --force
+# overwrites a pre-existing pip-installed pre-commit on the PATH; the guard
+# keys off `uv tool list` rather than `pre-commit --version`, which can't tell
+# a uv-managed install from the legacy pip one at the same version.
+PRE_COMMIT_VERSION="4.6.0"
+if "$HOME/.local/bin/uv" tool list 2>/dev/null | grep -qx "pre-commit v$PRE_COMMIT_VERSION"; then
+  printf '==> pre-commit: %s already installed via uv\n' "$PRE_COMMIT_VERSION" >&2
+else
+  printf '==> pre-commit: installing %s via uv\n' "$PRE_COMMIT_VERSION" >&2
+  "$HOME/.local/bin/uv" tool install --force "pre-commit==$PRE_COMMIT_VERSION"
+fi
 
 # bats helper libraries (bats-support, bats-assert), loaded by the co-located
 # *.bats suites via bats_load_library. The `just check-bats` recipe points

--- a/script/install/uv
+++ b/script/install/uv
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# astral-sh/uv tags have no `v` prefix (like casey/just), so the version
+# variable and Renovate matcher both use bare semver. uv is the host's
+# Python-CLI installer: `uv tool install` gives pre-commit a reproducible,
+# pinned home without a system `pip --user` (blocked here under PEP 668).
+UV_VERSION="0.11.19"
+ARCH="x86_64-unknown-linux-musl"
+
+# shellcheck source-path=SCRIPTDIR source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+parse_bin_dir "$@"
+
+bin="$BIN_DIR/uv"
+if [ -x "$bin" ] && "$bin" --version 2>/dev/null | grep -qF "$UV_VERSION"; then
+  printf '==> uv: %s already installed at %s\n' "$UV_VERSION" "$bin" >&2
+  exit 0
+fi
+
+printf '==> uv: downloading %s\n' "$UV_VERSION" >&2
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+base="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}"
+asset="uv-${ARCH}.tar.gz"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
+
+expected="$(expected_from_checksums "$tmp/$asset.sha256" "$asset")"
+verify_sha256 "$tmp/$asset" "$expected"
+
+tar -xzf "$tmp/$asset" -C "$tmp" --strip-components=1 "uv-${ARCH}/uv"
+mkdir -p "$BIN_DIR"
+install -m 0755 "$tmp/uv" "$bin"

--- a/script/install/uv_install.bats
+++ b/script/install/uv_install.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Exercises the pinned uv binary directly: the chezmoi CI check excludes
+# scripts, so run_once_before_02 never runs there. Catches a broken release
+# asset (URL/name/checksum) on a version bump, and a `uv tool install`
+# interface change that would break the bootstrap's pre-commit step, before
+# either reaches `chezmoi apply`. Keep the install flags in sync with
+# run_once_before_02-install-binary-tools.sh.tmpl.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  BIN_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$BIN_DIR"
+}
+
+@test "pinned uv installs and exposes the tool-install interface" {
+  "$REPO_ROOT/script/install/uv" --bin-dir "$BIN_DIR"
+  run "$BIN_DIR/uv" tool install --force --help
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`pre-commit` now installs as part of the bootstrap instead of surviving as an unmanaged `pip install --user`. A new pinned `script/install/uv` binary installer (GitHub release + SHA256, bare-semver tag, Renovate regex manager — mirroring `just`) lands uv into script 02, which then `uv tool install`s a pinned pre-commit. Picks the uv path from #287's two options: uv is a single static binary, so it dodges the apt-keyring conflict that makes pipx un-installable today and fits the existing pinned-binary pattern without an apt dependency.

Closes #287

## Gotchas

- This host already has a legacy pip `~/.local/bin/pre-commit` at the same 4.6.0. On apply, `uv tool install --force` overwrites it — confirm you're OK retiring the pip copy (the whole point of the issue), since `--force` is what lets uv claim that PATH entry.
- The idempotency guard greps `uv tool list` for `pre-commit v4.6.0` rather than `pre-commit --version`, because the legacy pip install reports an identical version and can't be told apart that way. If a future uv changes that list format the guard silently falls through to a (harmless, `--force`) reinstall — worth a glance.

## Verification

- `bats script/install/uv_install.bats` — downloads the real pinned uv, verifies its checksum, and asserts `uv tool install --force --help` parses (guards the bootstrap invocation).
- `pre-commit run --files …` green across shellcheck/shfmt/vale/markdownlint and `renovate-config-validator`.
- `chezmoi execute-template -S "\$PWD"` renders the new `{{ include "script/install/uv" }}` hash line; the full apply round-trip is left to CI.