### PR TITLE
Gate ADR readability at Flesch-Kincaid grade 12

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,3 +8,9 @@ BasedOnStyles = Vale, Microsoft, proselint, alex
 proselint.Cliches = NO
 proselint.Spelling = NO
 alex.ProfanityUnlikely = NO
+
+# ADRs are reconstructed months later, so cap their reading difficulty.
+# Flesch-Kincaid grade level <= 12; error because vale only fails on error
+# severity (warnings never gate, and the pre-commit hook prints at error).
+[docs/adr/*.md]
+ADR.Readability = error

--- a/.vale.ini
+++ b/.vale.ini
@@ -10,7 +10,10 @@ proselint.Spelling = NO
 alex.ProfanityUnlikely = NO
 
 # ADRs are reconstructed months later, so cap their reading difficulty.
-# Flesch-Kincaid grade level <= 12; error because vale only fails on error
-# severity (warnings never gate, and the pre-commit hook prints at error).
+# Score is the mean of Flesch-Kincaid and Automated Readability (one
+# syllable-based, one character-based: averaging cancels the syllable-
+# estimation noise each metric introduces on technical jargon), capped
+# at 12. error because vale only fails on error severity (warnings never
+# gate, and the pre-commit hook prints at error).
 [docs/adr/*.md]
 ADR.Readability = error

--- a/.vale/styles/ADR/Readability.yml
+++ b/.vale/styles/ADR/Readability.yml
@@ -1,6 +1,7 @@
 extends: readability
-message: "ADR Flesch-Kincaid grade level is %s; tighten to 12 or below so the decision stays skimmable months later."
+message: "ADR reading-difficulty score is %s; tighten to 12 or below so the decision stays skimmable months later."
 level: error
 metrics:
   - Flesch-Kincaid
+  - Automated Readability
 grade: 12

--- a/.vale/styles/ADR/Readability.yml
+++ b/.vale/styles/ADR/Readability.yml
@@ -1,0 +1,6 @@
+extends: readability
+message: "ADR Flesch-Kincaid grade level is %s; tighten to 12 or below so the decision stays skimmable months later."
+level: error
+metrics:
+  - Flesch-Kincaid
+grade: 12


### PR DESCRIPTION
## Summary

ADRs that drift into dense, hard-to-skim prose now fail `vale` instead of slipping through review. A readability rule scoped to `docs/adr/*.md` errors when an ADR's reading-difficulty score — the mean of Flesch-Kincaid and Automated Readability — exceeds 12.

Closes #296.

## Gotchas

- **Level is `error`, not `warning` — decide if you disagree.** The issue floated `warning`, but vale only fails the build on `error` severity, and the pre-commit hook runs `--minAlertLevel=error` (so a warning would neither block nor even print). A warning-level rule would be inert here; `error` is the only level that does anything without adding a second non-failing vale invocation. The repo-wide warning/suggestion-regression job that needs is filed separately as #310.
- **Metric is an FK + Automated Readability average, threshold 12.** FK estimates syllables, ARI counts characters; averaging a syllable-based and a character-based metric cancels the syllable-estimation noise each introduces on technical jargon and code identifiers, so the score tracks sentence structure (editable) over unavoidable vocabulary. Threshold 12 clears the baseline with ~1.2 headroom — averaged scores top out at 10.83 (0002-keep-per-workflow-ci); the issue's example of 8 would fail all four ADRs (technical prose sits ~10).
- `Vale.Readability = YES` isn't a thing in Vale v3 — readability is an extension point, so the rule is a custom style at `.vale/styles/ADR/Readability.yml`. It's covered by the existing global `.vale/styles/` pre-commit exclude (like the vendored packages) and ignored by chezmoi (dot-prefixed source), so it deploys nowhere.

## Verification

- Ran `vale --minAlertLevel=error docs/adr/*.md` → exit 0 (all four ADRs pass at 12; scores 8.93–10.83).
- Dropped a deliberately dense file into `docs/adr/` → fired `ADR.Readability` at 43.72, exit 1.
- Confirmed scope: the rule produces 0 hits on `README.md`, so non-ADR markdown is unaffected.
- `pre-commit run vale --files docs/adr/*.md` → Passed.