### PR TITLE
Reclaim out-of-cache dev caches on a weekly GC timer

### DIFF
--- a/.github/workflows/systemd.yml
+++ b/.github/workflows/systemd.yml
@@ -13,6 +13,7 @@ on:
       - 'dot_local/bin/executable_zellijstat'
       - 'dot_local/bin/executable_git-poi-all'
       - 'dot_local/bin/executable_git-worktree-poi'
+      - 'dot_local/bin/executable_dev-cache-gc'
       - 'script/install/prometheus'
       - 'script/install/alloy'
       - 'script/install/loki'
@@ -44,7 +45,7 @@ jobs:
           for t in prometheus alloy loki tempo grafana; do
             script/install/"$t" --bin-dir "$HOME/.local/bin"
           done
-          for s in zellijstat git-poi-all git-worktree-poi; do
+          for s in zellijstat git-poi-all git-worktree-poi dev-cache-gc; do
             install -m 0755 "dot_local/bin/executable_$s" "$HOME/.local/bin/$s"
           done
 

--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -28,6 +28,8 @@ yq --version                               # YAML processor (mikefarah/yq)
 vale --version                             # prose linter (vale-cli/vale)
 just --version                             # command runner (justfiles)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
+pnpm --version                             # pnpm package manager (npm global)
+command -v cargo-cache                     # cargo registry GC helper (needs cargo)
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)
 command -v calibre                         # ebook library manager

--- a/dot_config/systemd/user/dev-cache-gc.service
+++ b/dot_config/systemd/user/dev-cache-gc.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reclaim out-of-~/.cache dev tool caches (dev-cache-gc)
+
+[Service]
+Type=oneshot
+# The user manager's PATH lacks ~/.local/bin, where dev-cache-gc lives; set it
+# so ExecStart resolves. The script itself sources nvm/cargo/ghcup to put each
+# toolchain's GC on PATH. No tty here, so the script auto-disables colour and
+# the journal stays clean.
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/.local/bin/dev-cache-gc

--- a/dot_config/systemd/user/dev-cache-gc.timer
+++ b/dot_config/systemd/user/dev-cache-gc.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly GC of out-of-~/.cache dev tool caches
+
+[Timer]
+OnCalendar=Sun *-*-* 04:00:00
+# This host (Crostini) is frequently suspended; without Persistent a missed
+# window is lost. Persistent runs the catch-up on next wake.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/dot_local/bin/dev_cache_gc.bats
+++ b/dot_local/bin/dev_cache_gc.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  GC="$REPO_ROOT/dot_local/bin/executable_dev-cache-gc"
+
+  TMPROOT="$(mktemp -d)"
+  export HOME="$TMPROOT/home"
+  mkdir -p "$HOME"
+
+  # One stub binary, linked under each tool name: logs "<name>\t<args>" per call
+  # so tests assert which GC ran with which flags. Exits non-zero when its name
+  # is listed in $GC_FAIL, letting a test force one tool to error.
+  STUB_DIR="$TMPROOT/stubs"
+  mkdir -p "$STUB_DIR"
+  cat >"$STUB_DIR/stub" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "${0##*/}" "$*" >>"$GC_LOG"
+for f in $GC_FAIL; do
+  [[ "${0##*/}" == "$f" ]] && exit 1
+done
+exit 0
+STUB
+  chmod +x "$STUB_DIR/stub"
+  export GC_LOG="$TMPROOT/gc.log"
+  : >"$GC_LOG"
+  export GC_FAIL=""
+  export PATH="$STUB_DIR:/usr/bin:/bin"
+}
+
+teardown() { rm -rf "$TMPROOT"; }
+
+# Link the stub under each given tool name so `command -v` finds it and calls
+# route through the logging stub.
+stub_tools() {
+  local t
+  for t in "$@"; do ln -sf "$STUB_DIR/stub" "$STUB_DIR/$t"; done
+}
+
+@test "runs each tool's native GC with the expected flags" {
+  # cargo-cache gates the `cargo cache` call, so both binaries are present.
+  stub_tools ghcup npm cargo cargo-cache pnpm
+  run env -i HOME="$HOME" PATH="$PATH" GC_LOG="$GC_LOG" GC_FAIL="$GC_FAIL" bash "$GC"
+  [ "$status" -eq 0 ]
+  grep -qx "ghcup	gc -c -t" "$GC_LOG"
+  grep -qx "npm	cache verify" "$GC_LOG"
+  grep -qx "cargo	cache --autoclean" "$GC_LOG"
+  grep -qx "pnpm	store prune" "$GC_LOG"
+}
+
+@test "a missing tool is skipped, not a failure" {
+  stub_tools ghcup npm cargo cargo-cache
+  run env -i HOME="$HOME" PATH="$PATH" GC_LOG="$GC_LOG" GC_FAIL="$GC_FAIL" bash "$GC"
+  [ "$status" -eq 0 ]
+  # pnpm never ran, and the run still succeeded.
+  [ "$(grep -c '^pnpm' "$GC_LOG")" -eq 0 ]
+  [[ "$output" == *"pnpm store: pnpm absent, skipping"* ]]
+}
+
+@test "cargo GC is gated on cargo-cache, not cargo" {
+  # cargo present but cargo-cache absent: the registry GC must not run, since
+  # `cargo cache` would be an unknown subcommand.
+  stub_tools ghcup npm cargo pnpm
+  run env -i HOME="$HOME" PATH="$PATH" GC_LOG="$GC_LOG" GC_FAIL="$GC_FAIL" bash "$GC"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^cargo	' "$GC_LOG")" -eq 0 ]
+  [[ "$output" == *"cargo registry: cargo-cache absent, skipping"* ]]
+}
+
+@test "a failing tool is reported and non-fatal" {
+  stub_tools ghcup npm cargo cargo-cache pnpm
+  export GC_FAIL="npm"
+  run env -i HOME="$HOME" PATH="$PATH" GC_LOG="$GC_LOG" GC_FAIL="$GC_FAIL" bash "$GC"
+  [ "$status" -eq 1 ]
+  # Every tool was still attempted — the npm failure didn't abort the sweep.
+  grep -qx "ghcup	gc -c -t" "$GC_LOG"
+  grep -qx "cargo	cache --autoclean" "$GC_LOG"
+  grep -qx "pnpm	store prune" "$GC_LOG"
+  [[ "$output" == *"failed"* ]]
+  [[ "$output" == *"npm cache"* ]]
+}
+
+@test "-h prints usage and exits 0" {
+  run env -i HOME="$HOME" PATH="$PATH" GC_LOG="$GC_LOG" GC_FAIL="$GC_FAIL" bash "$GC" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: dev-cache-gc"* ]]
+}

--- a/dot_local/bin/executable_dev-cache-gc
+++ b/dot_local/bin/executable_dev-cache-gc
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# usage: the script's documentation and its -h/--help output, in one place.
+# Laid out the way Click renders a command's help — Usage synopsis, the full
+# description, then an aligned Options block.
+usage() {
+    cat <<'EOF'
+Usage: dev-cache-gc
+
+  Reclaim disk by running each dev tool's native garbage collection over the
+  caches that live *outside* ~/.cache, where the systemd-tmpfiles cleaner can't
+  reach them. Each tool's own GC is used rather than a blind age-deleter: these
+  trees mix regenerable cache with installed toolchains, and only the tool
+  knows which is which. Installed toolchains and version stores are left
+  untouched by design.
+
+  A tool whose binary is absent is skipped cleanly; a tool that errors is
+  reported without aborting the rest. Run weekly by dev-cache-gc.timer; safe to
+  run by hand any time.
+
+Options:
+  -h, --help     Show this message and exit.
+EOF
+}
+
+# systemd --user does not source ~/.bashrc, and each toolchain installs its
+# binaries outside the unit's PATH. Load the same environment .bashrc would so
+# `command -v` resolves ghcup, cargo (+ cargo-cache), npm, and pnpm. Each guard
+# no-ops when the toolchain is absent, which is also what lets the tests run
+# against PATH stubs alone.
+export NVM_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvm"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "$NVM_DIR/nvm.sh"
+    nvm use default >/dev/null 2>&1 || true
+fi
+# shellcheck disable=SC1091
+[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+# shellcheck disable=SC1091
+[[ -f "$HOME/.ghcup/env" ]] && . "$HOME/.ghcup/env"
+
+# NO_COLOR (https://no-color.org): any non-empty value disables colour.
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    RESET=$'\033[0m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+else
+    BOLD='' DIM='' RESET='' RED='' GREEN=''
+fi
+
+declare -a failures=()
+
+# run_gc LABEL BIN -- CMD...: run one tool's native GC. Skip cleanly (not a
+# failure) when BIN is missing, so an uninstalled tool is a no-op; record a
+# non-zero exit in `failures` without aborting, so the remaining tools still
+# run. BIN is the guard and may differ from CMD's binary — cargo-cache backs
+# the `cargo cache` subcommand, so it gates a `cargo` invocation.
+run_gc() {
+    local label=$1 bin=$2
+    shift 3 # drop label, bin, and the -- separator
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        printf '%s-- %s: %s absent, skipping%s\n' "$DIM" "$label" "$bin" "$RESET"
+        return 0
+    fi
+    printf '%s==> %s%s\n' "$BOLD" "$label" "$RESET"
+    # The `if !` exempts the call from set -e so a failing tool is recorded and
+    # skipped, not fatal.
+    if ! "$@"; then
+        failures+=("$label")
+    fi
+    printf '\n'
+}
+
+# Tests source this script to exercise run_gc against stubs without running the
+# sweep below.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+# -c (cache) and -t (tmpdirs) only: -o/-u remove GHC versions and -p/-s strip
+# profiling libs / docs from installed toolchains, all of which the version
+# store stays out of by design.
+run_gc "ghcup cache" ghcup -- ghcup gc -c -t
+run_gc "npm cache" npm -- npm cache verify
+run_gc "cargo registry" cargo-cache -- cargo cache --autoclean
+run_gc "pnpm store" pnpm -- pnpm store prune
+
+if ((${#failures[@]})); then
+    printf '%s%d tool(s) failed:%s\n' "$BOLD" "${#failures[@]}" "$RESET"
+    for f in "${failures[@]}"; do
+        printf '  %s%s%s\n' "$RED" "$f" "$RESET"
+    done
+    exit 1
+fi
+
+printf '%sdev caches reclaimed%s\n' "$GREEN" "$RESET"

--- a/renovate.json
+++ b/renovate.json
@@ -194,6 +194,20 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
+      "matchStrings": ["PNPM_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "pnpm",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^run_once_before_09-install-rust-ecosystem\\.sh\\.tmpl$/"],
+      "matchStrings": ["CARGO_CACHE_VERSION=\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "cargo-cache",
+      "datasourceTemplate": "crate"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"

--- a/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -89,4 +89,21 @@ else
   log "devcontainers-cli: $DEVCONTAINER_CLI_VERSION already installed"
 fi
 
+# ---------------------------------------------------------------------- pnpm
+# Backs dev-cache-gc's `pnpm store prune`. Same pin-enforced replace as the
+# CLIs above; nvm owns the runtime so this is the only pnpm on PATH.
+PNPM_VERSION="11.5.1"
+installed="$(npm ls -g --depth=0 --parseable=false pnpm 2>/dev/null |
+  sed -n 's,.*pnpm@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"
+if [ "$installed" != "$PNPM_VERSION" ]; then
+  if [ -n "$installed" ]; then
+    log "pnpm: replacing $installed with $PNPM_VERSION"
+  else
+    log "pnpm: installing $PNPM_VERSION"
+  fi
+  npm install -g "pnpm@$PNPM_VERSION"
+else
+  log "pnpm: $PNPM_VERSION already installed"
+fi
+
 log "node ecosystem complete"

--- a/run_once_before_09-install-rust-ecosystem.sh.tmpl
+++ b/run_once_before_09-install-rust-ecosystem.sh.tmpl
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Installs Rust-ecosystem helpers via cargo. Canonical installer only: cargo
+# (crates.io). cargo/rustup themselves are not bootstrap-managed, so this
+# no-ops on a host without Rust rather than installing a toolchain behind the
+# user's back.
+
+set -euo pipefail
+
+log() { printf '==> %s\n' "$*" >&2; }
+
+if ! command -v cargo >/dev/null 2>&1; then
+  log "rust: cargo not found; skipping cargo-cache"
+  exit 0
+fi
+
+# ------------------------------------------------------------------ cargo-cache
+# Backs dev-cache-gc's `cargo cache --autoclean`. cargo-cache ships only on
+# crates.io (no release binaries), so it can't use the script/install/
+# download-and-verify pattern; `cargo install` is the canonical path. Pin
+# enforced (Renovate-tracked, crate datasource): if a different version is
+# installed, --force replaces it so bumps actually take effect.
+CARGO_CACHE_VERSION="0.8.3"
+installed="$(cargo cache --version 2>/dev/null | awk '{print $2}' || true)"
+if [ "$installed" != "$CARGO_CACHE_VERSION" ]; then
+  if [ -n "$installed" ]; then
+    log "cargo-cache: replacing $installed with $CARGO_CACHE_VERSION"
+  else
+    log "cargo-cache: installing $CARGO_CACHE_VERSION"
+  fi
+  cargo install cargo-cache --version "$CARGO_CACHE_VERSION" --force
+else
+  log "cargo-cache: $CARGO_CACHE_VERSION already installed"
+fi
+
+log "rust ecosystem complete"

--- a/run_onchange_after_13-enable-dev-cache-gc.sh.tmpl
+++ b/run_onchange_after_13-enable-dev-cache-gc.sh.tmpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Unit hashes below re-run this script whenever a unit changes, so edits
+# (new ExecStart flags, schedule changes) re-apply via daemon-reload + enable.
+# dev-cache-gc service: {{ include "dot_config/systemd/user/dev-cache-gc.service" | sha256sum }}
+# dev-cache-gc timer:   {{ include "dot_config/systemd/user/dev-cache-gc.timer" | sha256sum }}
+
+set -euo pipefail
+
+# Skip where there is no user systemd manager to talk to (headless apply over
+# SSH without lingering, container builds). The units are still deployed; a
+# later interactive apply, or a manual enable, brings the timer up.
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "==> dev-cache-gc: no user systemd session; leaving timer disabled" >&2
+  exit 0
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now dev-cache-gc.timer


### PR DESCRIPTION
## Summary

Out-of-`~/.cache` dev tool caches (`~/.ghcup`, `~/.npm`, `~/.cargo`) now get reclaimed weekly by a `dev-cache-gc` systemd user timer that runs each tool's own GC — the trees the `systemd-tmpfiles` cleaner from #271 can't safely reach. Closes #289.

## Gotchas

- **cabal was dropped from the timer** — decide if you agree. The issue assumed `~/.local/state/cabal` was 1.8G of logs; it's actually the compiled `store/` (a version store, excluded by the same reasoning as rustup toolchains), and the real cabal logs live under `~/.cache/cabal`, already swept by #271. So neither half belongs here.
- **`ghcup gc -c -t` only** — review the flag choice. `-o/-u` remove GHC versions and `-p/-s` strip profiling libs / docs from installed toolchains; all four are excluded so the timer never prunes a toolchain. This means the bulk of `~/.ghcup` (the GHC installs) stays by design — the timer reclaims cache + tmpdirs, not the 2.9G of toolchains.
- **cargo stays unmanaged.** cargo-cache installs via `cargo install` from the new rust-ecosystem script (it has no release binaries, so the `script/install/` pattern doesn't fit), guarded on `command -v cargo`. On a host without Rust the install no-ops and the timer skips cargo — we don't bootstrap a toolchain behind the user's back.

## Verification

- `bats dot_local/bin/dev_cache_gc.bats` — 5 tests (right flags, missing-tool skip, cargo-gated-on-cargo-cache, failure non-fatal, `-h`); full suite 85/0.
- `systemd-analyze --user verify` on both units — clean (the acceptance criterion).
- `pre-commit run --all-files` (shellcheck/shfmt/renovate-validator/vale/markdownlint), `script/checks/chezmoi-template`, and `script/checks/chezmoi-apply` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)