### PR TITLE
Pin chezmoi version in CI and bootstrap via Renovate

### DIFF
--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install chezmoi
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+        env:
+          CHEZMOI_VERSION: "v2.70.5"
+        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin -t "$CHEZMOI_VERSION"
 
       - name: Install age
         run: |

--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -3,7 +3,8 @@
 Zero to a fully configured host. Requires a Debian/Crostini host and the age key from a password manager.
 
 ```bash
-sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+CHEZMOI_VERSION="v2.70.5"
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin" -t "$CHEZMOI_VERSION"
 
 mkdir -p ~/.config/chezmoi
 $EDITOR ~/.config/chezmoi/key.txt          # paste age key contents

--- a/renovate.json
+++ b/renovate.json
@@ -211,6 +211,20 @@
       "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
       "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/chezmoi\\.yml$/"],
+      "matchStrings": ["CHEZMOI_VERSION: \"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "twpayne/chezmoi",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^docs/tutorials/bootstrap\\.md$/"],
+      "matchStrings": ["CHEZMOI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "twpayne/chezmoi",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

chezmoi's own version is now pinned (`v2.70.5`) and Renovate-tracked, instead of floating at whatever `get.chezmoi.io` served at run time. Bumps now arrive as reviewable PRs under the repo's existing 3-day bake, and CI runs a known chezmoi rather than a moving target — closing the one unpinned link in an otherwise fully pinned, reproducible setup.

Pinning uses the installer's own `-t` flag, so the official install path is unchanged otherwise. Two regex custom managers track `twpayne/chezmoi` (github-releases) and bump both copies — the CI workflow env var and the bootstrap doc shell var — in one PR.

## Gotchas

- The version lives inline in **two** places (`.github/workflows/chezmoi.yml`, `docs/tutorials/bootstrap.md`) rather than a shared `script/install/chezmoi`. Decide whether you're happy with that: chezmoi is the bootstrapper, so the bootstrap path runs before the repo is cloned and can't source a repo script; a shared script was considered and deliberately skipped for the minimal two-copy approach.
- Host updates are intentionally out of scope. `chezmoi upgrade` tracks latest *release* and can briefly overshoot the pin during Renovate's 3-day window — an accepted trade-off, not something this PR addresses.

## Verification

- `pre-commit run --files ...` on all three changed files: `renovate-config-validator`, `actionlint`, `check-json`, markdownlint, and vale all passed.
- Confirmed the `get.chezmoi.io` installer accepts `-t <tag>` (release tag, resolved via GitHub API) and that `v2.70.5` is current latest, so CI behavior is unchanged today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)