### PR TITLE
Name pair tabs at creation instead of renaming after

### DIFF
--- a/dot_config/zellij/layouts/pair.kdl
+++ b/dot_config/zellij/layouts/pair.kdl
@@ -9,12 +9,15 @@
 //   zjstatus   (1 line) — gh rate-limit flags (60s), left-aligned
 //   status-bar (1 line, clipped) — mode indicator only; tips suppressed
 //
-// Invoke:
-//   zellij --layout pair                         # fresh session
-//   zellij action new-tab --layout pair          # new tab in current session
-//   Alt+/                                        # keybind, same as above
-//                                                # (git-repo-picker renames the
-//                                                # spawned tab to the repo name)
+// Invoke (Alt+/ and Alt+. both run git-repo-picker):
+//   Alt+/                                        # pick a repo/worktree
+//   Alt+.                                        # fan out a tab per worktree
+//   zellij --layout pair                         # fresh session (tab unnamed)
+//
+// The tab is intentionally nameless: git-repo-picker spawns it with
+// `new-tab --name "<repo> (petname)"`, and zellij's CLI --name only takes
+// effect when the layout declares no tab name of its own. Naming the tab
+// here would shadow --name and every spawned tab would read "pair".
 
 layout {
     default_tab_template {
@@ -50,7 +53,7 @@ layout {
             plugin location="status-bar"
         }
     }
-    tab name="pair" focus=true {
+    tab focus=true {
         pane split_direction="vertical" {
             // claude-pair resumes the worktree's most recent conversation,
             // or starts fresh when there is none. Covers both Alt+. and

--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -194,12 +194,12 @@ print_remotes() {
 }
 
 spawn_pair_tab() {
-    local cwd=$1 tab=$2 id
-    # new-tab prints the created tab's id; rename it by id rather than the
-    # active tab, so the --all-worktrees loop can't race a rename onto a tab a
-    # later new-tab already pulled focus to.
-    id=$(zellij action new-tab --layout pair --cwd "$cwd")
-    zellij action rename-tab --tab-id "$id" "$tab"
+    local cwd=$1 tab=$2
+    # Name the tab at creation. pair.kdl deliberately leaves its tab nameless
+    # so this --name wins (zellij treats CLI --name as a fallback the layout's
+    # own name would otherwise shadow). Atomic, so the --all-worktrees loop has
+    # no separate rename to race onto the wrong tab.
+    zellij action new-tab --layout pair --cwd "$cwd" --name "$tab"
 }
 
 # Tests source this script to exercise helpers above without triggering the

--- a/dot_local/bin/fixtures/git_repo_picker/stubs/zellij
+++ b/dot_local/bin/fixtures/git_repo_picker/stubs/zellij
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
 # zellij stub: appends "$@" to $ZELLIJ_RECORDER; emits $ZELLIJ_TAB_NAMES
-# (newline-delimited) for `action query-tab-names`, matching real CLI output;
-# emits a --cwd-derived numeric id for `action new-tab`, mirroring real zellij
-# printing the created tab's id. Tests correlate the id the picker feeds back
-# into `rename-tab --tab-id` against this same cksum of the tab's cwd.
+# (newline-delimited) for `action query-tab-names`, matching real CLI output.
 printf '%s\n' "$*" >>"$ZELLIJ_RECORDER"
 if [[ "${1:-}" == "action" && "${2:-}" == "query-tab-names" ]]; then
   printf '%s' "${ZELLIJ_TAB_NAMES:-}"
-elif [[ "${1:-}" == "action" && "${2:-}" == "new-tab" ]]; then
-  cwd=""
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --cwd) cwd="$2"; shift 2 ;;
-      *) shift ;;
-    esac
-  done
-  cksum <<<"$cwd" | cut -d' ' -f1
 fi

--- a/dot_local/bin/git_repo_picker.bats
+++ b/dot_local/bin/git_repo_picker.bats
@@ -52,14 +52,10 @@ petdir() {
   printf '%s' "$XDG_DATA_HOME/git-worktrees/$1/$2/$3"
 }
 
-# Assert the picker spawned this worktree's pair tab: new-tab at its petdir, and
-# rename-tab targeting the id new-tab returned for that cwd (the zellij stub
-# derives it as cksum of --cwd), both reached $ZELLIJ_RECORDER.
+# Assert the picker spawned this worktree's pair tab: a single new-tab at its
+# petdir, named via --name in the same call, reached $ZELLIJ_RECORDER.
 assert_spawn() {
-  local id
-  id=$(cksum <<<"$(petdir "$@")" | cut -d' ' -f1)
-  grep -Fxq "action new-tab --layout pair --cwd $(petdir "$@")" "$ZELLIJ_RECORDER" \
-    && grep -Fxq "action rename-tab --tab-id $id $(tab_name "$@")" "$ZELLIJ_RECORDER"
+  grep -Fxq "action new-tab --layout pair --cwd $(petdir "$@") --name $(tab_name "$@")" "$ZELLIJ_RECORDER"
 }
 
 # Assert the picker did not spawn a pair tab for this worktree.
@@ -204,7 +200,7 @@ mkcanonical() {
   assert_focus me hello kind-newt
 }
 
-@test "dispatch spawn: zellij new-tab + rename-tab fire with petdir and tab name" {
+@test "dispatch spawn: zellij new-tab fires with petdir and tab name" {
   export FZF_OUTPUT=$'worktree:hello (kind-newt)\tspawn\t'"$(petdir me hello kind-newt)"$'\thello (kind-newt)'
   run bash "$PICKER"
   assert_success


### PR DESCRIPTION
## Summary

Pair tabs opened by git-repo-picker (Alt+/, Alt+.) now get their `<repo> (petname)` name at creation via `new-tab --name`, instead of a follow-up `rename-tab`. A tab can no longer get stuck showing the layout's default "pair" name: there's no separate rename step to miss, and a miss was previously silent (logged server-side only, nothing in the picker's floating pane).

This works because `pair.kdl` now declares no tab name of its own — zellij honors the CLI `--name` only as a fallback when the layout sets none, so leaving it nameless is what lets `--name` win. Supersedes the `--tab-id` rename binding from #298, which is removed.

## Gotchas

- The real behavior change rides on `pair.kdl` dropping `name="pair"`. Confirm you're comfortable that a bare `zellij --layout pair` fresh session now opens an unnamed ("Tab #N") tab — the picker paths are unaffected since they pass `--name`.
- The zellij test stub lost its `new-tab` id emission (it only fed the old `--tab-id` round-trip). If you'd rather keep the fixture closer to real zellij output, that's the line to reconsider.

## Verification

- `bats dot_local/bin/git_repo_picker.bats` — 23/23 pass; spawn and `--all-worktrees` cases now assert the single `new-tab … --name` call.
- `pre-commit run` (shellcheck, shfmt) and `script/checks/zellij-config` (KDL validation) pass.
- Not yet exercised live against a running zellij session.