### PR TITLE
Complete zellijstat census: panes, fd types, uptime

### DIFF
--- a/docs/reference/zellij-freeze-observability-reference.md
+++ b/docs/reference/zellij-freeze-observability-reference.md
@@ -35,5 +35,10 @@ carries `session` and `pid` labels.
 | `zellijstat_server_unix_recvq_bytes` | gauge | Summed Recv-Q across those sockets. |
 | `zellijstat_server_unix_sendq_bytes` | gauge | Summed Send-Q across those sockets. |
 | `zellijstat_server_open_fds` | gauge | Open file descriptors. |
+| `zellijstat_server_open_fds_by_type` | gauge | Open file descriptors grouped by type (`type` label: `socket`/`pipe`/`pty`/`anon`/`file`); `socket` vs `pipe` separates a connection leak from a pipe leak. |
+| `zellijstat_server_panes` | gauge | Direct child processes of the server, one per pane command. |
+| `zellijstat_server_panes_by_class` | gauge | Pane children grouped by command class (`class` label: `shell`/`claude`/`other`). |
+| `zellijstat_server_uptime_seconds` | gauge | Seconds since the server process started. |
+| `zellijstat_server_state` | gauge | Always 1 while the server exists, labelled with its process state code (`state` label: `R`/`S`/`D`/`Z`/…) so a wedged or zombie server stands out. |
 | `zellijstat_server_cpu_seconds_total` | counter | Server CPU time (`utime` + `stime`), seconds. |
 | `zellijstat_server_memory_rss_bytes` | gauge | Resident set size, bytes. |

--- a/dot_local/bin/executable_zellijstat
+++ b/dot_local/bin/executable_zellijstat
@@ -6,7 +6,10 @@ Enumerates every zellij *server* process (comm == ``zellij`` with a
 sampler's own shell) and, per server, reports the signals the zellij-freeze
 investigation needs to watch climb: thread count by name, per-thread kernel
 wait-channel (the futex pile-up), Unix-socket connection count with
-Recv-Q/Send-Q, open fds, CPU and RSS. Each series is tagged by session.
+Recv-Q/Send-Q, open fds broken down by descriptor type (socket/pipe/pty/anon/
+file — connection-leak vs pipe-leak), the server's direct child processes
+classified as pane commands (shell/claude/other), session uptime and process
+state, CPU and RSS. Each series is tagged by session.
 
 It is a pull exporter: a scrape samples /proc on demand, so the resolution is
 the scraper's interval (Alloy/Prometheus at ~2s). Reading /proc never touches
@@ -43,6 +46,10 @@ class ServerSample:
     recvq_bytes: int = 0
     sendq_bytes: int = 0
     open_fds: int = 0
+    fds_by_type: dict[str, int] = field(default_factory=dict)
+    panes_by_class: dict[str, int] = field(default_factory=dict)
+    uptime_seconds: float = 0.0
+    state: str = ""
     cpu_seconds: float = 0.0
     rss_bytes: int = 0
 
@@ -98,6 +105,69 @@ def collect_threads(task_dir: Path) -> tuple[int, dict[str, int], dict[str, int]
     return total, by_comm, by_wchan
 
 
+def classify_fd(target: str) -> str:
+    """Bucket an fd's readlink target into socket/pipe/pty/anon/file.
+
+    Distinguishes the leak modes that the bare fd count can't: a socket pile-up
+    (connection leak) from a pipe pile-up (pipe leak) from pty churn. The
+    pty bucket holds both the multiplexer (/dev/ptmx) and slave (/dev/pts/N).
+    """
+    if target.startswith("socket:"):
+        return "socket"
+    if target.startswith("pipe:"):
+        return "pipe"
+    if target.startswith("anon_inode:"):
+        return "anon"
+    if target.startswith("/dev/pts/") or target == "/dev/ptmx":
+        return "pty"
+    return "file"
+
+
+def collect_fds(fd_dir: Path) -> tuple[int, dict[str, int]]:
+    """Count open fds under fd/, grouped by descriptor type.
+
+    The total is the fds we could classify, so it equals the sum of the
+    buckets; an fd closed between listing and readlink is dropped rather than
+    counted as an untyped ghost.
+    """
+    total = 0
+    by_type: dict[str, int] = {}
+    try:
+        entries = list(fd_dir.iterdir())
+    except OSError:
+        return 0, by_type
+    for fd in entries:
+        try:
+            target = os.readlink(fd)
+        except OSError:
+            continue
+        total += 1
+        cls = classify_fd(target)
+        by_type[cls] = by_type.get(cls, 0) + 1
+    return total, by_type
+
+
+_SHELL_COMMS = frozenset({"bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh"})
+
+
+def classify_child(comm: str) -> str:
+    """Bucket a child process's comm as a pane command: shell/claude/other."""
+    if comm in _SHELL_COMMS:
+        return "shell"
+    if comm == "claude":
+        return "claude"
+    return "other"
+
+
+def classify_children(comms: list[str]) -> dict[str, int]:
+    """Count a server's direct children by pane-command class."""
+    by_class: dict[str, int] = {}
+    for comm in comms:
+        cls = classify_child(comm)
+        by_class[cls] = by_class.get(cls, 0) + 1
+    return by_class
+
+
 def read_rss_bytes(status_text: str) -> int:
     """Parse VmRSS (kB) from /proc/<pid>/status into bytes."""
     for line in status_text.splitlines():
@@ -108,23 +178,53 @@ def read_rss_bytes(status_text: str) -> int:
     return 0
 
 
-def read_cpu_seconds(stat_text: str) -> float:
-    """Parse utime+stime from /proc/<pid>/stat into seconds.
+def _stat_after_comm(stat_text: str) -> list[str]:
+    """Fields of /proc/<pid>/stat following comm, i.e. from "state" (field 3).
 
-    comm (field 2) may contain spaces and parens, so split on the last ')'
-    before reading the space-delimited fields that follow.
+    comm (field 2) may contain spaces and parens, so split on the last ')'.
+    The returned list is 0-indexed at "state", so stat field N is index N-3.
+    Returns [] when stat is malformed.
     """
     rparen = stat_text.rfind(")")
     if rparen == -1:
-        return 0.0
-    rest = stat_text[rparen + 2 :].split()
-    # After comm, fields are 1-indexed from "state" (field 3). utime is field
-    # 14 and stime field 15, i.e. indices 11 and 12 of `rest`.
+        return []
+    return stat_text[rparen + 2 :].split()
+
+
+def read_cpu_seconds(stat_text: str) -> float:
+    """Parse utime+stime from /proc/<pid>/stat into seconds."""
+    rest = _stat_after_comm(stat_text)
+    # utime is field 14 and stime field 15, i.e. indices 11 and 12 of `rest`.
     if len(rest) < 13:
         return 0.0
     try:
         return (int(rest[11]) + int(rest[12])) / CLK_TCK
     except ValueError:
+        return 0.0
+
+
+def read_state(stat_text: str) -> str:
+    """Return the process state code (field 3: R/S/D/Z/…) from /proc/<pid>/stat."""
+    rest = _stat_after_comm(stat_text)
+    return rest[0] if rest else ""
+
+
+def read_starttime_ticks(stat_text: str) -> int:
+    """Return starttime (field 22) in clock ticks since boot, 0 if unparseable."""
+    rest = _stat_after_comm(stat_text)
+    if len(rest) < 20:
+        return 0
+    try:
+        return int(rest[19])
+    except ValueError:
+        return 0
+
+
+def read_uptime_seconds(proc_root: Path) -> float:
+    """Return system uptime (first field of /proc/uptime) in seconds."""
+    try:
+        return float(_read_text(proc_root / "uptime").split()[0])
+    except (ValueError, IndexError):
         return 0.0
 
 
@@ -172,21 +272,37 @@ def run_ss() -> str:
     return proc.stdout
 
 
-def iter_server_pids(proc_root: Path):
-    """Yield (pid, session) for every zellij server under proc_root."""
+def scan_proc(proc_root: Path) -> tuple[list[tuple[int, str]], dict[int, list[str]]]:
+    """One pass over /proc, identifying servers and mapping ppid -> child comms.
+
+    Returns ``(servers, children_by_ppid)`` where servers is ``[(pid, session),
+    …]`` and children_by_ppid maps a process's pid to the comms of its direct
+    children — the kernel here lacks ``task/*/children``, so the parent link is
+    read from each process's stat. Both ride this single readdir; no fork.
+    """
+    servers: list[tuple[int, str]] = []
+    children: dict[int, list[str]] = {}
     try:
         entries = list(proc_root.iterdir())
     except OSError:
-        return
+        return servers, children
     for entry in entries:
         if not _PID_DIR_RE.match(entry.name):
             continue
-        if _read_text(entry / "comm").strip() != "zellij":
-            continue
-        session = session_from_cmdline(_read_bytes(entry / "cmdline"))
-        if session is None:
-            continue
-        yield int(entry.name), session
+        comm = _read_text(entry / "comm").strip()
+        rest = _stat_after_comm(_read_text(entry / "stat"))
+        if len(rest) >= 2 and comm:
+            try:
+                ppid = int(rest[1])
+            except ValueError:
+                ppid = -1
+            if ppid >= 0:
+                children.setdefault(ppid, []).append(comm)
+        if comm == "zellij":
+            session = session_from_cmdline(_read_bytes(entry / "cmdline"))
+            if session is not None:
+                servers.append((int(entry.name), session))
+    return servers, children
 
 
 def collect(proc_root: Path = Path("/proc"), ss_text: str | None = None):
@@ -194,19 +310,24 @@ def collect(proc_root: Path = Path("/proc"), ss_text: str | None = None):
     if ss_text is None:
         ss_text = run_ss()
     ss_by_pid = parse_ss_unix(ss_text)
+    servers, children_by_ppid = scan_proc(proc_root)
+    system_uptime = read_uptime_seconds(proc_root)
     samples: list[ServerSample] = []
-    for pid, session in iter_server_pids(proc_root):
+    for pid, session in servers:
         pid_dir = proc_root / str(pid)
         s = ServerSample(pid=pid, session=session)
         s.threads, s.threads_by_comm, s.threads_by_wchan = collect_threads(
             pid_dir / "task"
         )
         s.rss_bytes = read_rss_bytes(_read_text(pid_dir / "status"))
-        s.cpu_seconds = read_cpu_seconds(_read_text(pid_dir / "stat"))
-        try:
-            s.open_fds = len(list((pid_dir / "fd").iterdir()))
-        except OSError:
-            s.open_fds = 0
+        stat_text = _read_text(pid_dir / "stat")
+        s.cpu_seconds = read_cpu_seconds(stat_text)
+        s.state = read_state(stat_text)
+        ticks = read_starttime_ticks(stat_text)
+        if ticks:
+            s.uptime_seconds = max(0.0, system_uptime - ticks / CLK_TCK)
+        s.open_fds, s.fds_by_type = collect_fds(pid_dir / "fd")
+        s.panes_by_class = classify_children(children_by_ppid.get(pid, []))
         s.connections, s.recvq_bytes, s.sendq_bytes = ss_by_pid.get(pid, (0, 0, 0))
         samples.append(s)
     return samples
@@ -288,6 +409,55 @@ def render(samples: list[ServerSample]) -> str:
     for s in samples:
         lbl = _labels({"session": s.session, "pid": str(s.pid)})
         lines.append(f"zellijstat_server_open_fds{{{lbl}}} {s.open_fds}")
+
+    metric(
+        "zellijstat_server_open_fds_by_type",
+        "gauge",
+        "Open file descriptors grouped by type (socket/pipe/pty/anon/file).",
+    )
+    for s in samples:
+        for fd_type, n in sorted(s.fds_by_type.items()):
+            lbl = _labels({"session": s.session, "pid": str(s.pid), "type": fd_type})
+            lines.append(f"zellijstat_server_open_fds_by_type{{{lbl}}} {n}")
+
+    metric(
+        "zellijstat_server_panes",
+        "gauge",
+        "Direct child processes of the server (one per pane command).",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(
+            f"zellijstat_server_panes{{{lbl}}} {sum(s.panes_by_class.values())}"
+        )
+
+    metric(
+        "zellijstat_server_panes_by_class",
+        "gauge",
+        "Server pane children grouped by command class (shell/claude/other).",
+    )
+    for s in samples:
+        for cls, n in sorted(s.panes_by_class.items()):
+            lbl = _labels({"session": s.session, "pid": str(s.pid), "class": cls})
+            lines.append(f"zellijstat_server_panes_by_class{{{lbl}}} {n}")
+
+    metric(
+        "zellijstat_server_uptime_seconds",
+        "gauge",
+        "Seconds since the server process started.",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid)})
+        lines.append(f"zellijstat_server_uptime_seconds{{{lbl}}} {s.uptime_seconds}")
+
+    metric(
+        "zellijstat_server_state",
+        "gauge",
+        "Liveness: 1 per server, labelled with its process state code (R/S/D/Z/…).",
+    )
+    for s in samples:
+        lbl = _labels({"session": s.session, "pid": str(s.pid), "state": s.state})
+        lines.append(f"zellijstat_server_state{{{lbl}}} 1")
 
     metric(
         "zellijstat_server_cpu_seconds_total",

--- a/dot_local/bin/zellijstat_test.py
+++ b/dot_local/bin/zellijstat_test.py
@@ -7,7 +7,9 @@ parsing, thread grouping, and exposition rendering — not stdlib behaviour.
 """
 
 import importlib.util
+import os
 import sys
+import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -86,7 +88,6 @@ class CollectThreads(unittest.TestCase):
         return task
 
     def test_groups_by_comm_and_wchan(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp:
             task = self._make_task(
@@ -107,11 +108,10 @@ class CollectThreads(unittest.TestCase):
 
 class CollectAndIter(unittest.TestCase):
     def test_only_servers_sampled(self):
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            # A server process.
+            root.joinpath("uptime").write_text("100000.00 50000.00\n")
+            # A server process. Field 22 (starttime) is the last stat field here.
             srv = root / "18533"
             (srv / "task" / "18533").mkdir(parents=True)
             (srv / "task" / "18533" / "comm").write_text("zellij\n")
@@ -122,10 +122,18 @@ class CollectAndIter(unittest.TestCase):
             )
             srv.joinpath("status").write_text("VmRSS:\t1024 kB\n")
             srv.joinpath("stat").write_text(
-                "18533 (zellij) S 1 1 1 0 -1 0 0 0 0 0 5 5 0 0"
+                "18533 (zellij) S 1 1 1 0 -1 0 0 0 0 0 5 5 0 0 20 0 1 0 8610872"
             )
-            (srv / "fd").mkdir()
-            (srv / "fd" / "0").write_text("")
+            fd = srv / "fd"
+            fd.mkdir()
+            os.symlink("socket:[12345]", fd / "0")
+            os.symlink("pipe:[999]", fd / "1")
+            os.symlink("/dev/pts/3", fd / "2")
+            # A pane child of the server, picked up by the ppid walk.
+            child = root / "18600"
+            child.mkdir()
+            child.joinpath("comm").write_text("bash\n")
+            child.joinpath("stat").write_text("18600 (bash) S 18533 18600 18600 0 -1")
             # A client process (no --server) must be skipped.
             cli = root / "18530"
             cli.mkdir()
@@ -140,7 +148,95 @@ class CollectAndIter(unittest.TestCase):
             self.assertEqual(s.session, "sess-a")
             self.assertEqual(s.rss_bytes, 1024 * 1024)
             self.assertEqual((s.connections, s.recvq_bytes, s.sendq_bytes), (1, 3, 4))
-            self.assertEqual(s.open_fds, 1)
+            self.assertEqual(s.open_fds, 3)
+            self.assertEqual(s.fds_by_type, {"socket": 1, "pipe": 1, "pty": 1})
+            self.assertEqual(s.panes_by_class, {"shell": 1})
+            self.assertEqual(s.state, "S")
+            self.assertAlmostEqual(s.uptime_seconds, 100000.0 - 8610872 / zs.CLK_TCK)
+
+
+class ClassifyFd(unittest.TestCase):
+    def test_buckets_by_readlink_prefix(self):
+        self.assertEqual(zs.classify_fd("socket:[12345]"), "socket")
+        self.assertEqual(zs.classify_fd("pipe:[999]"), "pipe")
+        self.assertEqual(zs.classify_fd("anon_inode:[eventpoll]"), "anon")
+        self.assertEqual(zs.classify_fd("/dev/pts/3"), "pty")
+        self.assertEqual(zs.classify_fd("/dev/ptmx"), "pty")
+        self.assertEqual(zs.classify_fd("/tmp/zellij-1000/zellij.log"), "file")
+
+
+class CollectFds(unittest.TestCase):
+    def test_counts_and_groups_symlinks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fd = Path(tmp) / "fd"
+            fd.mkdir()
+            os.symlink("socket:[1]", fd / "0")
+            os.symlink("socket:[2]", fd / "1")
+            os.symlink("pipe:[3]", fd / "2")
+            os.symlink("/dev/pts/4", fd / "3")
+            total, by_type = zs.collect_fds(fd)
+            # Total equals the sum of buckets, not the raw entry count.
+            self.assertEqual(total, 4)
+            self.assertEqual(by_type, {"socket": 2, "pipe": 1, "pty": 1})
+
+    def test_missing_dir_is_empty(self):
+        self.assertEqual(zs.collect_fds(Path("/nonexistent/fd")), (0, {}))
+
+
+class ClassifyChildren(unittest.TestCase):
+    def test_shell_claude_other(self):
+        self.assertEqual(zs.classify_child("bash"), "shell")
+        self.assertEqual(zs.classify_child("zsh"), "shell")
+        self.assertEqual(zs.classify_child("claude"), "claude")
+        self.assertEqual(zs.classify_child("lazygit"), "other")
+
+    def test_counts_by_class(self):
+        out = zs.classify_children(["bash", "claude", "bash", "lazygit"])
+        self.assertEqual(out, {"shell": 2, "claude": 1, "other": 1})
+
+
+class StatFields(unittest.TestCase):
+    # comm holds a ')' to prove the rfind split stays robust for every reader.
+    _STAT = "42 (we)ird) R 7 1 1 0 -1 0 0 0 0 0 10 20 0 0 20 0 1 0 8610872"
+
+    def test_state(self):
+        self.assertEqual(zs.read_state(self._STAT), "R")
+        self.assertEqual(zs.read_state("garbage"), "")
+
+    def test_starttime_ticks(self):
+        self.assertEqual(zs.read_starttime_ticks(self._STAT), 8610872)
+        # Truncated stat (no field 22) yields 0 rather than raising.
+        self.assertEqual(zs.read_starttime_ticks("42 (x) S 1 1"), 0)
+
+
+class ReadUptimeSeconds(unittest.TestCase):
+    def test_first_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "uptime").write_text("100000.50 50000.00\n")
+            self.assertAlmostEqual(zs.read_uptime_seconds(Path(tmp)), 100000.50)
+
+    def test_missing_returns_zero(self):
+        self.assertEqual(zs.read_uptime_seconds(Path("/nonexistent")), 0.0)
+
+
+class ScanProc(unittest.TestCase):
+    def test_servers_and_child_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            srv = root / "100"
+            srv.mkdir()
+            srv.joinpath("comm").write_text("zellij\n")
+            srv.joinpath("stat").write_text("100 (zellij) S 1 1")
+            srv.joinpath("cmdline").write_bytes(
+                b"zellij\x00--server\x00/run/user/1000/zellij/0.43.1/sess\x00"
+            )
+            kid = root / "200"
+            kid.mkdir()
+            kid.joinpath("comm").write_text("claude\n")
+            kid.joinpath("stat").write_text("200 (claude) S 100 200")
+            servers, children = zs.scan_proc(root)
+            self.assertEqual(servers, [(100, "sess")])
+            self.assertEqual(children[100], ["claude"])
 
 
 class Render(unittest.TestCase):
@@ -156,6 +252,33 @@ class Render(unittest.TestCase):
         self.assertIn('session="we\\"ird"', out)
         self.assertIn("zellijstat_servers 1", out)
         self.assertTrue(out.endswith("\n"))
+
+    def test_renders_census_metrics(self):
+        s = zs.ServerSample(
+            pid=7,
+            session="sess",
+            open_fds=4,
+            fds_by_type={"socket": 3, "pty": 1},
+            panes_by_class={"shell": 2, "claude": 1},
+            uptime_seconds=1234.5,
+            state="S",
+        )
+        out = zs.render([s])
+        self.assertIn(
+            'zellijstat_server_open_fds_by_type{session="sess",pid="7",type="socket"} 3',
+            out,
+        )
+        self.assertIn('zellijstat_server_panes{session="sess",pid="7"} 3', out)
+        self.assertIn(
+            'zellijstat_server_panes_by_class{session="sess",pid="7",class="claude"} 1',
+            out,
+        )
+        self.assertIn(
+            'zellijstat_server_uptime_seconds{session="sess",pid="7"} 1234.5', out
+        )
+        self.assertIn(
+            'zellijstat_server_state{session="sess",pid="7",state="S"} 1', out
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
zellijstat now exposes the rest of the per-server census the zellij-freeze retrospective needs: pane child processes per session (classified shell/claude/other), `open_fds` split by descriptor type, and per-session uptime plus process state. Each rides the same fork-free `/proc` walk already in place.

Closes #319

## Gotchas
- This kernel doesn't compile `task/*/children`, so children come from a PPID walk over `/proc` (confirmed: `cat /proc/<pid>/task/*/children` is ENOENT here). `scan_proc` folds that walk into the same pass that finds servers, so it's one readdir, no extra fork. Worth a look that you agree the single-walk merge reads cleanly versus the old `iter_server_pids` generator it replaces.
- fd-type buckets put both `/dev/ptmx` (master) and `/dev/pts/N` (slave) under `pty`; `_by_type` totals therefore equal `open_fds`, and the old "file" count drops by the ptmx fds. Intentional — flag if you'd rather ptmx stay under `file`.

## Verification
- `just check` green (23 unit tests incl. fd-classification and pane-child enumeration, prometheus/systemd/apply checks).
- Ran `executable_zellijstat --once` against the live host: pane classes matched `ps --ppid` (bash→shell, claude→claude, lazygit→other), fd split socket/pipe/pty/anon/file, uptime and state populated.