### PR TITLE
Record ADR rejecting chezmoi-external migration

### DIFF
--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -8,6 +8,8 @@ alunduil
 
 # Host tooling
 chezmoi
+lazygit
+datasource
 Crostini
 Zellij
 TrueNAS
@@ -77,6 +79,7 @@ worktrees
 
 # Common tech terms
 config
+reimplement
 justfile
 dev
 dotfile

--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -79,7 +79,6 @@ worktrees
 
 # Common tech terms
 config
-reimplement
 justfile
 dev
 dotfile

--- a/docs/adr/0003-keep-bash-installers-over-chezmoi-externals.md
+++ b/docs/adr/0003-keep-bash-installers-over-chezmoi-externals.md
@@ -6,64 +6,56 @@ Accepted
 
 ## Context
 
-`script/install/*` plus `lib.sh` reimplement a download, verify, extract,
-install pipeline. chezmoi ships that pipeline natively as `.chezmoiexternal`
-externals, with built-in caching, `refreshPeriod`, and `sha256` checks. For
-the tools that are a single binary in a public release tarball, one external
-stanza would replace a whole installer. #309 asked whether to migrate,
-and #295 is poised to add yet another script on the current pattern.
-So the question is worth a recorded answer, not a per-tool reflex.
+`script/install/*` plus `lib.sh` duplicate a download-verify-extract
+pipeline that chezmoi ships natively as `.chezmoiexternal` externals.
+For a single binary from a public release tarball, one external stanza
+would replace a whole installer. #309 asked whether to migrate, and #295
+is poised to add another script on the pattern. So the question wants a
+recorded answer, not a per-tool reflex.
 
-Twelve tools fit an external on the surface: `act`, `alloy`, `gcx`, `just`,
-`lazygit`, `loki`, `lychee`, `tempo`, `trivy`, `truenas-mcp`, `uv`, `vale`. Six
-can't move regardless: `signal-cli` (GPG-pinned), `grafana` (multi-file tree
-plus a symlink), `prometheus` (two binaries), `yq` (raw binary, odd checksum
-format), `zellij` (source-build fallback), and `bats-libs` (two linked
-libraries). Those keep `lib.sh` alive no matter what.
+Of the eighteen installers, six can't move regardless: `signal-cli`
+(GPG-pinned), `grafana` (multi-file tree), `prometheus` (two binaries),
+`yq` (raw binary, odd checksum), `zellij` (source-build fallback), and
+`bats-libs` (two linked libraries). They keep `lib.sh` alive either way.
 
-Three forces decide the rest:
+The other twelve fit an external on the surface, but two forces sink the
+move:
 
-- **CI reuse.** Five workflows call `script/install/<tool> --bin-dir` to drop
-  one binary on a runner. Externals only appear on `chezmoi apply`, which needs
-  the full dest-dir and age-secret setup. Migrating forces CI to run a full
-  apply or to keep the scripts anyway. Keeping both is strictly worse.
+- **CI reuse.** Five workflows call `script/install/<tool> --bin-dir` to
+  drop one binary on a runner. Externals only appear on `chezmoi apply`,
+  which needs the full dest-dir and age-secret setup. Migrating forces a
+  heavy apply in CI or keeping the scripts anyway.
+- **Checksum pinning.** The scripts fetch upstream `checksums.txt` and
+  verify at install, so Renovate bumps only the version. Externals take
+  only an inline `sha256`, and Renovate has no datasource to bump that
+  hash, so each version bump turns manual or drops verification.
 
-- **Checksum pinning.** The script tools fetch upstream `checksums.txt` at
-  install and verify the match, so Renovate bumps only the version string.
-  Externals take only an inline `sha256`; there is no remote lookup. Renovate
-  has no chezmoi-external manager and no datasource that yields a release
-  asset hash, so each bump becomes a manual hash chore or drops verification.
-
-- **Prototype.** lazygit as an `archive-file` external applied in under a second
-  with an inline `sha256`. It works, but getting the pin meant fetching
-  `checksums.txt` by hand, which is the manual step Renovate can't automate.
+A lazygit prototype confirmed both: the `archive-file` external applied
+in under a second, but the `sha256` had to come from `checksums.txt` by
+hand, the step Renovate can't automate.
 
 ## Decision
 
-We keep the bash installers and reject the move to `.chezmoiexternal`. New
-tools land as a `script/install/*` script on the shared `lib.sh` pattern.
-
-The win was never whole: six tools stay scripts, so `lib.sh` stays too.
-Migrating the other twelve would split the install model in two, drop dynamic
-verification or add manual hash work per bump, and still not replace the
-scripts CI depends on.
+We keep the bash installers and reject the move to `.chezmoiexternal`.
+New tools land as a `script/install/*` script on the `lib.sh` pattern.
+Migrating only splits the install model in two, since six tools stay
+scripts regardless, and still can't replace the scripts CI depends on.
 
 We revisit when any trigger fires:
 
 - chezmoi gains remote checksum verification, so a pin can match a
   `checksums.txt` entry instead of a hand-copied hash.
 - Renovate gains a chezmoi-external manager or a release-asset hash
-  datasource that updates the inline `sha256` on a bump.
-- CI stops needing standalone binary installs, for example by routing every
-  binary check through one cached `chezmoi apply`.
+  datasource that bumps the inline `sha256`.
+- CI stops needing standalone binary installs, for example by routing
+  binary checks through one cached `chezmoi apply`.
 
 ## Consequences
 
-- The single `lib.sh` plus per-tool pin plus Renovate regex manager stays the
-  one install model. Bumps stay automated and verification stays dynamic.
-- CI keeps calling the scripts directly, with no apply or secret setup on a
-  runner that only needs one binary.
-- New tools keep paying the small cost of a new script rather than a one-line
-  external. That cost is the price of staying on a single, CI-reusable model.
-- The triggers are the load-bearing part: without them this reads as "stay
-  bash forever," which isn't the decision being made.
+- One install model stays: `lib.sh` plus per-tool pin plus Renovate
+  regex manager, with automated bumps and dynamic verification.
+- CI keeps calling the scripts directly, with no apply or secret setup
+  on a runner that needs one binary.
+- New tools keep paying for a script, not a one-line external. The
+  triggers are load-bearing: without them this is "stay bash forever,"
+  which isn't the decision.

--- a/docs/adr/0003-keep-bash-installers-over-chezmoi-externals.md
+++ b/docs/adr/0003-keep-bash-installers-over-chezmoi-externals.md
@@ -1,0 +1,69 @@
+# 3. Keep bash installers over chezmoi externals
+
+## Status
+
+Accepted
+
+## Context
+
+`script/install/*` plus `lib.sh` reimplement a download, verify, extract,
+install pipeline. chezmoi ships that pipeline natively as `.chezmoiexternal`
+externals, with built-in caching, `refreshPeriod`, and `sha256` checks. For
+the tools that are a single binary in a public release tarball, one external
+stanza would replace a whole installer. #309 asked whether to migrate,
+and #295 is poised to add yet another script on the current pattern.
+So the question is worth a recorded answer, not a per-tool reflex.
+
+Twelve tools fit an external on the surface: `act`, `alloy`, `gcx`, `just`,
+`lazygit`, `loki`, `lychee`, `tempo`, `trivy`, `truenas-mcp`, `uv`, `vale`. Six
+can't move regardless: `signal-cli` (GPG-pinned), `grafana` (multi-file tree
+plus a symlink), `prometheus` (two binaries), `yq` (raw binary, odd checksum
+format), `zellij` (source-build fallback), and `bats-libs` (two linked
+libraries). Those keep `lib.sh` alive no matter what.
+
+Three forces decide the rest:
+
+- **CI reuse.** Five workflows call `script/install/<tool> --bin-dir` to drop
+  one binary on a runner. Externals only appear on `chezmoi apply`, which needs
+  the full dest-dir and age-secret setup. Migrating forces CI to run a full
+  apply or to keep the scripts anyway. Keeping both is strictly worse.
+
+- **Checksum pinning.** The script tools fetch upstream `checksums.txt` at
+  install and verify the match, so Renovate bumps only the version string.
+  Externals take only an inline `sha256`; there is no remote lookup. Renovate
+  has no chezmoi-external manager and no datasource that yields a release
+  asset hash, so each bump becomes a manual hash chore or drops verification.
+
+- **Prototype.** lazygit as an `archive-file` external applied in under a second
+  with an inline `sha256`. It works, but getting the pin meant fetching
+  `checksums.txt` by hand, which is the manual step Renovate can't automate.
+
+## Decision
+
+We keep the bash installers and reject the move to `.chezmoiexternal`. New
+tools land as a `script/install/*` script on the shared `lib.sh` pattern.
+
+The win was never whole: six tools stay scripts, so `lib.sh` stays too.
+Migrating the other twelve would split the install model in two, drop dynamic
+verification or add manual hash work per bump, and still not replace the
+scripts CI depends on.
+
+We revisit when any trigger fires:
+
+- chezmoi gains remote checksum verification, so a pin can match a
+  `checksums.txt` entry instead of a hand-copied hash.
+- Renovate gains a chezmoi-external manager or a release-asset hash
+  datasource that updates the inline `sha256` on a bump.
+- CI stops needing standalone binary installs, for example by routing every
+  binary check through one cached `chezmoi apply`.
+
+## Consequences
+
+- The single `lib.sh` plus per-tool pin plus Renovate regex manager stays the
+  one install model. Bumps stay automated and verification stays dynamic.
+- CI keeps calling the scripts directly, with no apply or secret setup on a
+  runner that only needs one binary.
+- New tools keep paying the small cost of a new script rather than a one-line
+  external. That cost is the price of staying on a single, CI-reusable model.
+- The triggers are the load-bearing part: without them this reads as "stay
+  bash forever," which isn't the decision being made.


### PR DESCRIPTION
## Summary

#309 asked whether the single-binary installers under `script/install/*` should move to chezmoi's native `.chezmoiexternal` `archive-file` externals. The answer is no-go, recorded as ADR 0003 in the established Nygard form with revisit triggers. New tools (including #295) keep landing as `script/install/*` scripts on the shared `lib.sh` pattern.

Two forces decide it. CI invokes the scripts directly to drop one binary on a runner without a full `chezmoi apply`, so externals would force a heavy secret-coupled apply in CI or keeping both mechanisms. And externals take only an inline `sha256` with no remote lookup, while Renovate has no datasource to auto-bump that hash, turning every version bump into a manual chore or dropping the dynamic verification the scripts do today. Six of the eighteen tools (GPG, multi-binary, source-build) must stay scripts regardless, keeping `lib.sh` alive either way.

## Gotchas

- The verdict reverses the issue's implicit "maybe migrate" framing — review the two blockers in the Context section, especially CI reuse, since that's the decisive one.
- `accept.txt` gains `lazygit` and `datasource` so the ADR clears the Vale spelling + grade-12 readability gate; confirm those belong in the shared vocabulary.

## Verification

- Prototyped lazygit as an `archive-file` external in an isolated temp source/dest: `chezmoi apply` materialized the verified binary in 0.68s with an inline `sha256`. Confirms the tool is technically external-friendly while showing the pin had to be fetched from `checksums.txt` by hand — the step Renovate can't automate.
- `pre-commit run` (vale incl. ADR readability gate, markdownlint) passes on the changed files.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)