### PR TITLE
Add a daily docker-prune system timer

### DIFF
--- a/.github/workflows/systemd.yml
+++ b/.github/workflows/systemd.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths: &paths
       - 'dot_config/systemd/user/**'
+      - 'etc/systemd/system/**'
       - 'dot_local/bin/executable_zellijstat'
       - 'dot_local/bin/executable_git-poi-all'
       - 'dot_local/bin/executable_git-worktree-poi'

--- a/etc/systemd/system/docker-prune.service
+++ b/etc/systemd/system/docker-prune.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Reclaim Docker disk (docker system prune)
+
+[Service]
+Type=oneshot
+# Skip cleanly when the daemon is unreachable -- socket absent or daemon down.
+# A non-zero ExecCondition marks the unit skipped, not failed; only an ExecStart
+# failure fails it. Redirect docker info's output so the journal keeps just the
+# prune summary. Runs as root (system unit), so reachability, not docker-group
+# membership, is what's gated.
+ExecCondition=/bin/sh -c 'docker info >/dev/null 2>&1'
+# --all prunes unused (not only dangling) images; until=168h spares anything
+# pulled in the last week, so the weekly sweep never deletes today's images. No
+# --volumes -- that risks data loss.
+ExecStart=/usr/bin/docker system prune --all --force --filter until=168h

--- a/etc/systemd/system/docker-prune.timer
+++ b/etc/systemd/system/docker-prune.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Weekly Docker disk reclamation (docker system prune)
+
+[Timer]
+OnCalendar=Sun *-*-* 05:00:00
+# This host (Crostini) is frequently suspended; without Persistent a missed
+# window is lost. Persistent runs the catch-up on next wake. An hour after the
+# user-scope dev-cache-gc sweep so the two don't churn disk at once.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/docker-prune.timer
+++ b/etc/systemd/system/docker-prune.timer
@@ -2,10 +2,12 @@
 Description=Weekly Docker disk reclamation (docker system prune)
 
 [Timer]
-OnCalendar=Sun *-*-* 05:00:00
-# This host (Crostini) is frequently suspended; without Persistent a missed
-# window is lost. Persistent runs the catch-up on next wake. An hour after the
-# user-scope dev-cache-gc sweep so the two don't churn disk at once.
+OnCalendar=*-*-* 05:00:00
+# Daily so the until=168h floor collects week-old junk within a day of it
+# becoming eligible, rather than letting it linger up to another week. This host
+# (Crostini) is frequently suspended; without Persistent a missed window is
+# lost, so Persistent runs the catch-up on next wake. 05:00 keeps it an hour
+# clear of the dev-cache-gc sweep on the days they overlap.
 Persistent=true
 
 [Install]

--- a/run_onchange_after_14-enable-docker-prune.sh.tmpl
+++ b/run_onchange_after_14-enable-docker-prune.sh.tmpl
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Installs the docker-prune system units into /etc and enables the weekly timer.
+# Docker is a rootful system daemon here, so the prune runs as root on a system
+# timer rather than the per-user pattern of dev-cache-gc -- chezmoi targets
+# $HOME, not /etc, so the units live in etc/ and are copied in with sudo (same
+# shape as the unattended-upgrades config). See #312.
+#
+# run_onchange hashes the rendered script; the unit files alone would not
+# re-trigger it. Embed their hashes so an edit re-applies:
+# docker-prune service: {{ include "etc/systemd/system/docker-prune.service" | sha256sum }}
+# docker-prune timer:   {{ include "etc/systemd/system/docker-prune.timer" | sha256sum }}
+
+set -euo pipefail
+
+log() { printf '==> %s\n' "$*" >&2; }
+
+# Docker is the whole point; a host without it has nothing to prune.
+if ! command -v docker >/dev/null 2>&1; then
+  log "docker-prune: docker absent; skipping"
+  exit 0
+fi
+
+UNIT_SRC="{{ .chezmoi.sourceDir }}/etc/systemd/system"
+
+log "docker-prune: installing system units"
+sudo install -m 0644 "$UNIT_SRC/docker-prune.service" /etc/systemd/system/docker-prune.service
+sudo install -m 0644 "$UNIT_SRC/docker-prune.timer" /etc/systemd/system/docker-prune.timer
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker-prune.timer

--- a/script/checks/systemd-units
+++ b/script/checks/systemd-units
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Validate the systemd user units with `systemd-analyze verify`: every
-# directive must be known and every ExecStart binary must resolve. verify
-# resolves %h/%S against the calling user, so the binaries the units reference
-# must exist at their real paths first — systemd.yml installs them in CI.
+# Validate the systemd units with `systemd-analyze verify`: every directive must
+# be known and every ExecStart binary must resolve. verify resolves %h/%S
+# against the calling user, so the binaries the units reference must exist at
+# their real paths first — systemd.yml installs them in CI.
+#
+# Two scopes: user units under dot_config/systemd/user (verified --user) and
+# root units under etc/systemd/system (verified system-scope). docker-prune is
+# the only system unit; its /usr/bin/docker is preinstalled on the CI runner.
 #
 # verify only *warns* (and still exits 0) on an unknown directive, so any
 # stderr is treated as failure; a missing ExecStart already exits non-zero.
@@ -16,7 +20,8 @@ if ! command -v systemd-analyze >/dev/null 2>&1; then
   exit 0
 fi
 
-units_dir="dot_config/systemd/user"
+user_dir="dot_config/systemd/user"
+system_dir="etc/systemd/system"
 
 # verify needs every ExecStart binary present. Derive them from the units
 # (the first token after ExecStart=, %h expanded) instead of a hand-kept list,
@@ -33,18 +38,23 @@ while IFS= read -r bin; do
   fi
   printf '==> systemd-units: %s not installed; skipping\n' "$bin" >&2
   exit 0
-done < <(grep -hoP '^ExecStart=\K[^ ]+' "$units_dir"/*.service)
-
-units=("$units_dir"/*.service "$units_dir"/*.target "$units_dir"/*.timer)
+done < <(grep -hoP '^ExecStart=\K[^ ]+' "$user_dir"/*.service "$system_dir"/*.service)
 
 errfile="$(mktemp)"
 trap 'rm -f "$errfile"' EXIT
-systemd-analyze --user verify "${units[@]}" >/dev/null 2>"$errfile"
+# User units carry %h/%S specifiers, so they verify in --user mode; the root
+# units verify system-scope. Both runs append stderr so either scope's warning
+# fails the check.
+systemd-analyze --user verify \
+  "$user_dir"/*.service "$user_dir"/*.target "$user_dir"/*.timer >/dev/null 2>"$errfile"
 rc=$?
+systemd-analyze verify \
+  "$system_dir"/*.service "$system_dir"/*.timer >/dev/null 2>>"$errfile"
+rc=$((rc | $?))
 if [ "$rc" -ne 0 ] || [ -s "$errfile" ]; then
   printf 'FAIL: systemd unit verification\n' >&2
   cat "$errfile" >&2
   exit 1
 fi
 
-printf 'OK: systemd user units verify\n'
+printf 'OK: systemd user and system units verify\n'


### PR DESCRIPTION
## Summary

Docker disk now gets reclaimed on a daily `docker-prune.timer` running `docker system prune --all --force --filter until=168h`, gated on the daemon being reachable. The `until=168h` floor is the safety net (nothing younger than a week is ever pruned), so daily just keeps the disk high-water mark tighter than weekly without touching recent images. Closes #312.

## Gotchas

- The issue left two open questions; both were decided with the user before coding. **Prune aggressiveness:** `--all` + `until=168h` (unused images, but only objects older than a week — today's pulls survive; no `--volumes`). **Unit scope:** system, not the `--user` pattern the issue defaulted to from #289 — I checked the host and Docker is rootful, so a per-user timer would prune a root-owned resource on a session-gated schedule by accident of docker-group membership. Worth a look if you'd rather take the simpler user-timer route.
- This is the repo's first **system** systemd unit, so it diverges from the three sibling user timers: units live under `etc/` and a sudo'd `run_onchange` copies them into `/etc/systemd/system` (same shape as the unattended-upgrades config), enabled with `sudo systemctl`. `script/checks/systemd-units` now runs a second `systemd-analyze verify` (no `--user`) for the system scope.
- No bespoke prune script: `ExecCondition=docker info` is systemd's native "skip cleanly, don't fail" mechanism, which covers the issue's daemon-down skip requirement declaratively — so there's nothing script-shaped left to unit-test (the gating is systemd's behavior, not ours). The issue's AC anticipated a script + a CI binary install; neither is needed since the unit references the preinstalled `/usr/bin/docker`.

## Verification

- `systemd-analyze verify etc/systemd/system/docker-prune.{service,timer}` clean locally.
- `pre-commit run --all-files` and `just check` pass (the systemd check skips locally because the observability stack isn't installed; CI runs it for real with the full stack + preinstalled docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)