### PR TITLE
dev-cache-gc: sweep daily, matching docker-prune

### DIFF
--- a/dot_config/systemd/user/dev-cache-gc.timer
+++ b/dot_config/systemd/user/dev-cache-gc.timer
@@ -1,10 +1,14 @@
 [Unit]
-Description=Weekly GC of out-of-~/.cache dev tool caches
+Description=Daily GC of out-of-~/.cache dev tool caches
 
 [Timer]
-OnCalendar=Sun *-*-* 04:00:00
-# This host (Crostini) is frequently suspended; without Persistent a missed
-# window is lost. Persistent runs the catch-up on next wake.
+OnCalendar=*-*-* 04:00:00
+# Daily, matching docker-prune. These tools reclaim unreferenced/regenerable
+# data (not recency-based), so daily never spares something weekly would have
+# kept — it just collects the same eligible junk sooner, tightening the disk
+# high-water mark. This host (Crostini) is frequently suspended; without
+# Persistent a missed window is lost, so Persistent runs the catch-up on next
+# wake. 04:00 keeps it an hour clear of the docker-prune sweep.
 Persistent=true
 
 [Install]

--- a/dot_local/bin/executable_dev-cache-gc
+++ b/dot_local/bin/executable_dev-cache-gc
@@ -17,7 +17,7 @@ Usage: dev-cache-gc
   untouched by design.
 
   A tool whose binary is absent is skipped cleanly; a tool that errors is
-  reported without aborting the rest. Run weekly by dev-cache-gc.timer; safe to
+  reported without aborting the rest. Run daily by dev-cache-gc.timer; safe to
   run by hand any time.
 
 Options:

--- a/etc/systemd/system/docker-prune.timer
+++ b/etc/systemd/system/docker-prune.timer
@@ -7,7 +7,7 @@ OnCalendar=*-*-* 05:00:00
 # becoming eligible, rather than letting it linger up to another week. This host
 # (Crostini) is frequently suspended; without Persistent a missed window is
 # lost, so Persistent runs the catch-up on next wake. 05:00 keeps it an hour
-# clear of the dev-cache-gc sweep on the days they overlap.
+# clear of the daily dev-cache-gc sweep.
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Summary
Resolves the #332 decision: `dev-cache-gc.timer` now sweeps daily instead of Sunday-weekly, matching docker-prune (#330). Out-of-`~/.cache` dev caches are now reclaimed within a day of becoming eligible instead of lingering up to a week.

The tools dev-cache-gc runs (`ghcup gc`, `npm cache verify`, `cargo cache --autoclean`, `pnpm store prune`) reclaim *unreferenced/regenerable* data, not by recency — so daily never spares something weekly would have kept. It collects the same eligible junk sooner, tightening the disk high-water mark. The only cost is the cargo/pnpm store walks, seconds on this single host.

## Gotchas
- The #332 framing flagged the missing `until`-floor (vs docker-prune) as a risk that daily could change *what* is reclaimed. Worth confirming you agree it dissolves: none of these tools delete by age, so there's no "about to use it" data daily would reap that weekly spared — `cargo`'s removed src checkouts re-extract from the local `.crate` (no network), `pnpm` only prunes packages no project references. If you disagree, the subset-split option is still on the table.
- Decided against splitting cheap (npm/ghcup) from store-walking (cargo/pnpm) tools into two timers — two units for marginal gain failed the simplicity test.

## Verification
- `just check` — all sensors green.
- `systemd-analyze calendar '*-*-* 04:00:00'` and `systemd-analyze verify dev-cache-gc.timer` — both clean.

Closes #332