### PR TITLE
Route both picker worktree walks through one helper

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -92,12 +92,23 @@ collect_locals() {
         | sort -u
 }
 
+# walk_worktrees: emit each `.git`-bearing worktree dir under $WORKTREE_ROOT,
+# one per line, sorted. Worktrees sit at <root>/<org>/<repo>/<petname> (depth
+# 3); other dirs at that depth are skipped. Both print_worktrees passes iterate
+# this set. Mirrors git-worktree-poi's walk_worktrees().
+walk_worktrees() {
+    local petdir
+    while IFS= read -r petdir; do
+        [[ -e "$petdir/.git" ]] || continue
+        printf '%s\n' "$petdir"
+    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+}
+
 print_worktrees() {
     [[ -d "$WORKTREE_ROOT" ]] || return 0
     local opens petdir petname repo org tab display
     opens=$(open_tabs)
     while IFS= read -r petdir; do
-        [[ -e "$petdir/.git" ]] || continue
         IFS=$'\t' read -r org repo petname <<<"$(split_petdir "$petdir")"
         tab=$(fmt_tab "$org" "$repo" "$petname")
         if grep -Fxq "$tab" <<<"$opens"; then
@@ -107,7 +118,7 @@ print_worktrees() {
             display="worktree:$tab"
             printf '%s\tspawn\t%s\t%s\n' "$display" "$petdir" "$tab"
         fi
-    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+    done < <(walk_worktrees)
 }
 
 # Worktree rows enriched with their associated PR number. Walks
@@ -124,8 +135,8 @@ print_worktrees_with_prs() {
     local petdir
     local -a petdirs=()
     while IFS= read -r petdir; do
-        [[ -e "$petdir/.git" ]] && petdirs+=("$petdir")
-    done < <(find "$WORKTREE_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null | sort)
+        petdirs+=("$petdir")
+    done < <(walk_worktrees)
     ((${#petdirs[@]})) || return 0
 
     local -A pr_for=()


### PR DESCRIPTION
## Summary
`git-repo-picker` named its depth-3 worktree walk twice — once in `print_worktrees`, once in `print_worktrees_with_prs`. Both now route through a single picker-local `walk_worktrees()` that emits each `.git`-bearing worktree dir, sorted, mirroring git-worktree-poi's helper of the same name.

## Gotchas
This is the within-file rule-of-three from #290, not a reopening of #206 — the cross-file shared `bin/` library that #206 declined stays declined. The helper lives inside the picker only.

## Verification
- `bats dot_local/bin/git_repo_picker.bats` — all 23 pass (the `print_worktrees`/`print_worktrees_with_prs` assertions still hold).
- `pre-commit` (shellcheck, shfmt) clean on the file.
- Confirmed the `find … -mindepth 3 -maxdepth 3 …` walk now appears exactly once.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)