### PR TITLE
Add CI check for settings.json permission-rule grammar

### DIFF
--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Check script templates render
         run: script/checks/chezmoi-template
+
+      - name: Check settings permission grammar
+        run: script/checks/settings-permissions

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ check:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
-    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi check-chezmoi-templates check-observability check-systemd; do
+    for c in check-pre-commit check-bats check-python check-zellij check-chezmoi check-chezmoi-templates check-settings-permissions check-observability check-systemd; do
       just "$c" || rc=1
     done
     exit "$rc"
@@ -49,6 +49,10 @@ check-chezmoi:
 # Render run_*.sh.tmpl script templates (needs chezmoi on PATH).
 check-chezmoi-templates:
     script/checks/chezmoi-template
+
+# Validate settings.json permission-rule grammar (needs chezmoi + age on PATH).
+check-settings-permissions:
+    script/checks/settings-permissions
 
 # Observability config validation (skips when the stack binaries are absent;
 # the live metrics smoke is CI-only — it binds the running stack's ports).

--- a/script/checks/settings-permissions
+++ b/script/checks/settings-permissions
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reject permissions.allow MCP rules the Claude Code loader silently drops.
+# Valid MCP forms are mcp__<server>, mcp__<server>__<tool>, and the
+# whole-server wildcard mcp__<server>__*. A * anywhere else (e.g. the prefix
+# glob mcp__github__get_*) is not a recognized form: the loader skips the rule
+# at load with only a /doctor warning, so the read-only tool prompts on every
+# call. Non-MCP entries (Bash(...), Read(*), bare tool names) use the loader's
+# lenient anywhere-wildcard grammar and are out of scope.
+
+set -euo pipefail
+
+SOURCE_DIR="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+dest="$(mktemp -d)"
+trap 'rm -rf "$dest"' EXIT
+
+chezmoi apply --source="$SOURCE_DIR" --destination="$dest" --exclude=scripts,encrypted
+
+fail=0
+while IFS= read -r rule; do
+  case "$rule" in
+    mcp__*) ;;
+    *) continue ;;
+  esac
+
+  stars="${rule//[!*]/}"
+  # No wildcard is always an exact tool or whole-server form. The only legal
+  # glob is a single trailing __* on a non-empty server (mcp__server__*);
+  # anything else the loader drops.
+  if [ -z "$stars" ]; then
+    continue
+  fi
+  base="${rule%__\*}"
+  if [ "$stars" = "*" ] && [ "$base" != "$rule" ]; then
+    case "$base" in
+      mcp__?*) continue ;;
+    esac
+  fi
+
+  printf 'FAIL: permission rule %s has a glob the loader silently drops; MCP allows only mcp__server, mcp__server__tool, or mcp__server__*\n' "$rule" >&2
+  fail=1
+done < <(jq -r '.permissions.allow[]?' "$dest/.claude/settings.json")
+
+exit "$fail"


### PR DESCRIPTION
## Summary

CI now rejects a `permissions.allow` MCP rule that the Claude Code loader would silently skip, so the kind of breakage #333 fixed (ten prefix-glob entries like `mcp__github__get_*` that loaded as no-ops, leaving read-only tools prompting on every call) surfaces at PR time instead of only when a human runs `/doctor`. Closes #335.

The new `script/checks/settings-permissions` renders `settings.json` the same way `chezmoi-apply` does (apply to a temp destination, then `jq` the result) and validates every `mcp__`-prefixed allow entry: valid forms are `mcp__server`, `mcp__server__tool`, and the whole-server wildcard `mcp__server__*`; any other `*` exits nonzero and names the offending rule. It's wired into `just check` and the existing `Chezmoi` CI workflow (reusing its chezmoi + ephemeral-age setup).

## Gotchas

- Two scoping calls to weigh in review. First, the check validates only `mcp__`-prefixed entries — non-MCP rules (`Bash(...)`, `Read(*)`, bare names) use the loader's lenient anywhere-wildcard grammar where there's no silent-drop failure mode to catch, so they pass through. Second, I went with the issue's "bespoke replica" option rather than invoking the real loader, to keep the check self-contained and auth-free like the other `script/checks/*`; the tradeoff is drift if the MCP grammar changes, which I judged low.
- The grammar is sourced from the current docs (`mcp__server__*` *is* an accepted wildcard; a partial glob like `mcp__server__get_*` is not), quoted under the MCP heading at https://code.claude.com/docs/en/permissions — worth a sanity check if you read it differently.
- I put it as a step in `chezmoi.yml` rather than a standalone workflow because it needs the identical chezmoi + age render setup `chezmoi-apply` already establishes there; a separate workflow would duplicate all of it.

## Verification

- Ran `script/checks/settings-permissions` against the current rendered config: exits 0.
- Injected `mcp__github__get_*` into the rendered allow list and re-ran the matcher: exits 1, naming the rule.
- Exercised the matcher across valid forms (`mcp__github`, `mcp__github__get_commit`, `mcp__github__*`) and invalid ones (`mcp__github__get_*`, `mcp__github__**`, `mcp__*`, `mcp__*__tool`) — all classified as expected.
- `shellcheck` clean; `just check-settings-permissions` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)