### PR TITLE
git-repo-picker: base worktrees on origin/<default>, not local main

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -345,23 +345,27 @@ ensure_canonical() {
 }
 
 # Create a fresh worktree off the canonical's default branch on a new branch
-# <ME>/worktree/<petname>. Pulls the canonical first (best-effort) so the
-# worktree starts on a current base; on failure we branch from whatever the
-# local default ref points at, which both manual pulls and prior picker runs
-# keep current. The user/worktree/ prefix scopes picker-created branches
-# into a personal namespace, distinct from upstream branches in `git branch`
-# and remote refs.
+# <ME>/worktree/<petname>. Fetches origin first (best-effort) so the worktree
+# starts current, then branches off the origin/<default> remote-tracking ref —
+# not the local default branch. The canonical is a clone the human also works
+# in, so its checked-out branch and local main can be on anything (or main may
+# be absent, or carry stale upstream config from a deleted branch). Fetch never
+# touches the current branch and the remote-tracking ref always resolves, so
+# neither failure mode reaches the worktree. --no-track keeps the new branch
+# upstream-free, matching the old branch-off-local-main behavior. The
+# user/worktree/ prefix scopes picker-created branches into a personal
+# namespace, distinct from upstream branches in `git branch` and remote refs.
 make_worktree() {
     local canonical=$1 wt_dir=$2 petname=$3
-    local default_ref default_branch
+    local default_ref
     default_ref=$(git -C "$canonical" symbolic-ref --short refs/remotes/origin/HEAD)
-    default_branch=${default_ref#origin/}
-    if ! git -C "$canonical" pull --ff-only --quiet; then
-        printf 'git-repo-picker: pull failed; branching off possibly stale local %s\n' \
-            "$default_branch" >&2
+    if ! git -C "$canonical" fetch --quiet origin; then
+        printf 'git-repo-picker: fetch failed; branching off possibly stale %s\n' \
+            "$default_ref" >&2
     fi
     mkdir -p "$(dirname "$wt_dir")"
-    git -C "$canonical" worktree add "$wt_dir" -b "$ME/worktree/$petname" "$default_branch"
+    git -C "$canonical" worktree add --no-track "$wt_dir" \
+        -b "$ME/worktree/$petname" "$default_ref"
 }
 
 # fzf reads its initial candidates from STATIC_FILE — no upstream pipeline


### PR DESCRIPTION
## Summary

Opening a pair on a repo whose canonical clone had stale `branch.main.merge` config (a deleted-branch upstream, left over from the zjstatus-freeze investigation) failed worktree creation. `make_worktree` now fetches `origin` and bases the new worktree on the `origin/<default>` remote-tracking ref instead of pulling the canonical's current branch and basing on local `main`.

The canonical is a clone the human also works in, so its checked-out branch is rarely the default and its local `main` can be missing or carry stale upstream config. Two failure modes followed: a dangling `branch.main.merge` failed the `pull` (`no such ref was fetched`), and an absent local `main` failed `git worktree add ... main` (`not a valid object name: 'main'`). Fetch is branch-agnostic and the remote-tracking ref always resolves, so neither reaches the worktree.

## Gotchas

- `--no-track` is load-bearing: branching off a remote-tracking ref would otherwise auto-set the new branch's upstream to `origin/main`. The flag keeps it upstream-free, matching the prior branch-off-local-main behavior — confirm that's still the intent for the PR-push flow.

## Verification

- Reproduced both original errors against a scratch clone with a dangling `branch.main.merge` and an absent local `main`; confirmed the new `fetch` + `origin/main` + `--no-track` path succeeds where the old one failed and leaves the new branch with no upstream.
- `pre-commit run` (shellcheck, shfmt) clean; all 23 `git_repo_picker.bats` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)