### PR TITLE
issue-work: gate on the current milestone

### DIFF
--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -14,6 +14,11 @@ gh pr list --state all --limit 20 \
   --search "(<N> in:body) OR (<keywords> in:title,body)" \
   --json number,title,state,url
 # state=OPEN → in-flight PR (takeover candidate); state=MERGED → scope already covered, even if unlinked
+
+# Milestone gate: issue's milestone vs the current (earliest-due open) milestone
+gh issue view <N> --json milestone --jq '.milestone.title // "none"'
+gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // "9999")[0].title'
+# none or current → fine to work; a different (later) milestone → no-go
 ```
 
 For recent commits in the area:
@@ -39,6 +44,7 @@ Any one fires a go/no-go before writing code:
 - The issue assumes tooling/files that have since been replaced or removed.
 - The motivating dependency resolved differently (e.g. "waiting on upstream X" — X shipped via a different mechanism).
 - A maintainer comment narrows or vetoes the original scope and the body wasn't updated.
+- The issue is parked on a *later* milestone (not the current, earliest-due open one). Deferred work — don't pull it forward. No milestone or the current milestone is fine to work.
 - Repro fails on the default branch.
 - The issue lacks enough detail to start without guessing.
 

--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -15,9 +15,9 @@ gh pr list --state all --limit 20 \
   --json number,title,state,url
 # state=OPEN → in-flight PR (takeover candidate); state=MERGED → scope already covered, even if unlinked
 
-# Milestone gate: issue's milestone vs the current (earliest-due open) milestone
+# Milestone gate: issue's milestone vs the current (lowest-version open) milestone
 gh issue view <N> --json milestone --jq '.milestone.title // "none"'
-gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // "9999")[0].title'
+gh api repos/:owner/:repo/milestones --jq '.[].title' | sort -V | head -1
 # none or current → fine to work; a different (later) milestone → no-go
 ```
 
@@ -44,7 +44,7 @@ Any one fires a go/no-go before writing code:
 - The issue assumes tooling/files that have since been replaced or removed.
 - The motivating dependency resolved differently (e.g. "waiting on upstream X" — X shipped via a different mechanism).
 - A maintainer comment narrows or vetoes the original scope and the body wasn't updated.
-- The issue is parked on a *later* milestone (not the current, earliest-due open one). Deferred work — don't pull it forward. No milestone or the current milestone is fine to work.
+- The issue is parked on a *later* milestone (not the current, lowest-version open one). Deferred work — don't pull it forward. No milestone or the current milestone is fine to work.
 - Repro fails on the default branch.
 - The issue lacks enough detail to start without guessing.
 


### PR DESCRIPTION
## Summary

`issue-work` now refuses to pull forward an issue parked on a later milestone. Before writing code it compares the issue's milestone against the repo's current milestone — the lowest-version open one (`sort -V`, which handles both semver2 and PVP and the optional `v` prefix). A later milestone fires a no-go; no milestone or the current one is free to work.

## Gotchas

"Current" is defined as the lowest open version name, matching this repo's milestone scheme (semver2/PVP, no due dates). If a milestone ever gets a non-version name, `sort -V` will order it lexically alongside the versions — worth knowing, but out of scope here.

## Verification

`pre-commit run --files dot_claude/skills/issue-work/SKILL.md` — passed (markdownlint included). Sanity-checked `sort -V` against mixed semver (`v0.1.0` < `v1.1.0` < `v1.2.0`) and PVP (`0.0.1.0` < `0.1.0.0` < `1.0.0.0`); lowest sorts first in both.