### PR TITLE
Stop advertising the gh draft-guard bypass

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -31,9 +31,8 @@ A per-repo `CLAUDE.md` overrides anything here.
   Enforced by `~/.claude/hooks/pr-draft-guard.sh` (blocks GitHub MCP
   `create_pull_request` and its copilot variant when `draft=true` is
   missing) and `~/.local/bin/gh` (shadows `gh`, requires
-  `--draft`/`-d` on `gh pr create`). Always pass `--draft`; never reach
-  for the override. Opening a ready PR is a human-only action done
-  outside Claude.
+  `--draft`/`-d` on `gh pr create`). Always pass `--draft`; opening a
+  ready PR is a human-only action done outside Claude.
 - Composing a PR body, opening a PR, or adding a PR template to a
   repo: `pr-create` skill. Holds the tight Summary (why) / Gotchas
   (surprises) / Verification (how we know it's correct) structure, the

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -31,8 +31,9 @@ A per-repo `CLAUDE.md` overrides anything here.
   Enforced by `~/.claude/hooks/pr-draft-guard.sh` (blocks GitHub MCP
   `create_pull_request` and its copilot variant when `draft=true` is
   missing) and `~/.local/bin/gh` (shadows `gh`, requires
-  `--draft`/`-d` on `gh pr create`). Override with
-  `GH_DRAFT_GUARD=off gh pr create ...`.
+  `--draft`/`-d` on `gh pr create`). Always pass `--draft`; never reach
+  for the override. Opening a ready PR is a human-only action done
+  outside Claude.
 - Composing a PR body, opening a PR, or adding a PR template to a
   repo: `pr-create` skill. Holds the tight Summary (why) / Gotchas
   (surprises) / Verification (how we know it's correct) structure, the

--- a/dot_local/bin/executable_gh
+++ b/dot_local/bin/executable_gh
@@ -30,8 +30,8 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ] && [ "${GH_DRAFT_GUARD:-}" != 
   if [ "$has_draft" -eq 0 ]; then
     cat >&2 <<'EOF'
 gh wrapper (~/.local/bin/gh): `gh pr create` must include --draft (or -d).
-Retry with the flag, or, to open a ready PR on purpose:
-  GH_DRAFT_GUARD=off gh pr create ...
+Retry with the flag. Opening a ready PR is a deliberate human action; the
+override lives in this script's header comment, not for automated use.
 EOF
     exit 1
   fi


### PR DESCRIPTION
## Summary

`GH_DRAFT_GUARD=off` kept appearing in Claude's sessions because the two places it reads at the point of friction handed it the recipe — the `gh` wrapper printed the override on stderr when it blocked a non-draft `gh pr create`, and `~/.claude/CLAUDE.md` documented the same override in Claude's standing instructions. Both now omit it: the wrapper says retry with `--draft`, the instructions say always pass `--draft` and treat opening a ready PR as a human-only action.

## Gotchas

- Soft fix by design — removes the temptation, not the capability. The override still works at the wrapper level for humans, and the wrapper header comment plus `architecture.md` still document it. If the bypass keeps showing up it's coming from the model prior rather than config; escalate to a `settings.json` deny line or a PreToolUse hook.
- `dot_claude/CLAUDE.md` deploys to the host-wide `~/.claude/CLAUDE.md`, so the instruction change takes effect on next `chezmoi apply`.

## Verification

- `bats dot_local/bin/gh_wrapper.bats` — 8/8 pass; the block message still asserts `must include --draft`.
- `pre-commit run --files dot_local/bin/executable_gh dot_claude/CLAUDE.md` — shellcheck, shfmt, vale, markdownlint clean.