### PR TITLE
git-repo-picker: recover from a stale origin/HEAD

### DIFF
--- a/dot_local/bin/executable_git-repo-picker
+++ b/dot_local/bin/executable_git-repo-picker
@@ -350,19 +350,28 @@ ensure_canonical() {
 # not the local default branch. The canonical is a clone the human also works
 # in, so its checked-out branch and local main can be on anything (or main may
 # be absent, or carry stale upstream config from a deleted branch). Fetch never
-# touches the current branch and the remote-tracking ref always resolves, so
-# neither failure mode reaches the worktree. --no-track keeps the new branch
-# upstream-free, matching the old branch-off-local-main behavior. The
-# user/worktree/ prefix scopes picker-created branches into a personal
-# namespace, distinct from upstream branches in `git branch` and remote refs.
+# touches the current branch. --no-track keeps the new branch upstream-free,
+# matching the old branch-off-local-main behavior. The user/worktree/ prefix
+# scopes picker-created branches into a personal namespace, distinct from
+# upstream branches in `git branch` and remote refs.
+#
+# origin/HEAD can dangle: after a default-branch rename/delete upstream (e.g.
+# develop -> main) a prune drops refs/remotes/origin/develop but leaves the
+# symref pointing at it, so branching off origin/HEAD fails with "not a valid
+# object name". Refresh it with `set-head --auto`, which re-points the symref at
+# the remote's current default; that needs the tracking ref present, which the
+# fetch just ensured. Gated behind a successful fetch since set-head also queries
+# the remote — offline, we keep the existing (possibly stale) symref and let the
+# worktree add surface any breakage rather than masking the offline cause.
 make_worktree() {
     local canonical=$1 wt_dir=$2 petname=$3
     local default_ref
-    default_ref=$(git -C "$canonical" symbolic-ref --short refs/remotes/origin/HEAD)
-    if ! git -C "$canonical" fetch --quiet origin; then
-        printf 'git-repo-picker: fetch failed; branching off possibly stale %s\n' \
-            "$default_ref" >&2
+    if git -C "$canonical" fetch --quiet origin; then
+        git -C "$canonical" remote set-head origin --auto >/dev/null 2>&1 || true
+    else
+        printf 'git-repo-picker: fetch failed; branching off possibly stale default branch\n' >&2
     fi
+    default_ref=$(git -C "$canonical" symbolic-ref --short refs/remotes/origin/HEAD)
     mkdir -p "$(dirname "$wt_dir")"
     git -C "$canonical" worktree add --no-track "$wt_dir" \
         -b "$ME/worktree/$petname" "$default_ref"

--- a/dot_local/bin/git_repo_picker.bats
+++ b/dot_local/bin/git_repo_picker.bats
@@ -220,6 +220,25 @@ mkcanonical() {
   assert_spawn me hello fresh-petname
 }
 
+@test "dispatch spawn-fresh: recovers from a stale origin/HEAD" {
+  mkcanonical "$HOME/hello" hello >/dev/null
+  # Simulate a default-branch rename upstream (develop -> main): origin/HEAD
+  # dangles at a tracking ref that no longer exists. Pre-fix this aborts
+  # worktree add with "not a valid object name: origin/develop".
+  git -C "$HOME/hello" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+  export PETNAME=stale-petname
+  export FZF_OUTPUT=$'local:hello\tspawn-fresh\tme\thello\t'"$HOME/hello"
+  run bash "$PICKER"
+  assert_success
+
+  local wt; wt="$(petdir me hello stale-petname)"
+  [ -d "$wt" ]
+  [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "me/worktree/stale-petname" ]
+  # Branched off the remote's real default (main), not the dangling develop.
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$(git -C "$HOME/hello" rev-parse origin/main)" ]
+  assert_spawn me hello stale-petname
+}
+
 # --- print_worktrees_with_prs: pr:<N>-tagged worktree rows ---
 
 @test "print_worktrees_with_prs: tags worktree with the branch's PR number" {


### PR DESCRIPTION
## Summary

Creating a fresh worktree now works when a canonical clone's `origin/HEAD` dangles. After an upstream default-branch rename or delete (the classic `develop`→`main`), a prune drops `refs/remotes/origin/develop` but leaves the symref pointing at it, so `make_worktree` branched off a ref that no longer resolves and the picker died with `fatal: not a valid object name: 'origin/develop'` (exit 255). Follow-up to 13e2097, which moved worktrees onto `origin/<default>`.

## Gotchas

- The refresh is gated behind a successful fetch on purpose: `set-head --auto` also queries the remote, so offline we keep the existing (possibly stale) symref rather than masking the offline cause. Decide whether that degradation is what you want.

## Verification

- Reproduced on the host: `~/collection-json.hs` and `~/network-uri-json` both have `origin/HEAD → origin/develop` with no such tracking ref — the two repos that triggered the report.
- Added a bats regression test that dangles `origin/HEAD` on a real canonical and asserts the worktree lands on the remote's real default. Full suite (24) green; shellcheck/shfmt/vale clean.