### PR TITLE
Prefer REST over GraphQL for GitHub reads

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -75,6 +75,20 @@ A per-repo `CLAUDE.md` overrides anything here.
   `issue-work` skill. Carries the inspect commands, staleness signals,
   and go/no-go format.
 
+## GitHub API budget
+
+- GraphQL is a per-account ~5000pt/hr bucket shared across every
+  session, every parallel agent, and the `git-*-poi` timers; REST is
+  a separate bucket. Parallel agents exhaust GraphQL fast — a depleted
+  bucket also makes `gh auth status` misreport the token as invalid.
+  Prefer REST-backed reads: `mcp__github__issue_read` /
+  `pull_request_read` / `list_pull_requests` / `search_*`, `gh search`,
+  and `gh api` REST endpoints. Avoid GraphQL-backed
+  `gh issue|pr list|view|status`.
+- GraphQL-only, unavoidable: blocked-by edges and Projects v2 (the
+  inbox dashboard). `list_issues` (MCP) is GraphQL too — list issues
+  with `gh search issues` or `gh api .../issues` instead.
+
 ## Feedback preference
 
 - Run the project's computational sensors (tests, linters, type

--- a/dot_claude/skills/issue-create/SKILL.md
+++ b/dot_claude/skills/issue-create/SKILL.md
@@ -15,7 +15,8 @@ Open *and* closed:
 gh search issues "<keywords>" --repo <owner>/<repo> --state all --limit 20
 ```
 
-Read near-matches with `gh issue view <N>`. Decide:
+Read near-matches with `gh api repos/:owner/:repo/issues/<N>` (REST;
+`gh issue view` is GraphQL). Decide:
 
 - **Same outcome already open** — update the existing one
   (`gh issue edit <N>` for body, `gh issue comment <N>` for new
@@ -36,7 +37,8 @@ If torn, surface the call rather than silently pick.
 ls .github/ISSUE_TEMPLATE/ 2>/dev/null
 gh label list --limit 100
 gh api repos/:owner/:repo/milestones --jq '.[] | "\(.title)\t\(.state)"'
-gh issue list --limit 5      # skim recent house style
+gh api 'repos/:owner/:repo/issues?per_page=5&state=all' \
+  --jq '.[].title'           # skim recent house style (REST; gh issue list is GraphQL)
 ```
 
 Template present → `gh issue create --template <name>`. Templates

--- a/dot_claude/skills/issue-create/SKILL.md
+++ b/dot_claude/skills/issue-create/SKILL.md
@@ -15,8 +15,7 @@ Open *and* closed:
 gh search issues "<keywords>" --repo <owner>/<repo> --state all --limit 20
 ```
 
-Read near-matches with `gh api repos/:owner/:repo/issues/<N>` (REST;
-`gh issue view` is GraphQL). Decide:
+Read near-matches with `gh api repos/:owner/:repo/issues/<N>`. Decide:
 
 - **Same outcome already open** — update the existing one
   (`gh issue edit <N>` for body, `gh issue comment <N>` for new
@@ -38,7 +37,7 @@ ls .github/ISSUE_TEMPLATE/ 2>/dev/null
 gh label list --limit 100
 gh api repos/:owner/:repo/milestones --jq '.[] | "\(.title)\t\(.state)"'
 gh api 'repos/:owner/:repo/issues?per_page=5&state=all' \
-  --jq '.[].title'           # skim recent house style (REST; gh issue list is GraphQL)
+  --jq '.[].title'           # skim recent house style
 ```
 
 Template present → `gh issue create --template <name>`. Templates

--- a/dot_claude/skills/issue-links/SKILL.md
+++ b/dot_claude/skills/issue-links/SKILL.md
@@ -79,30 +79,22 @@ Use `-f` (not `-F`) for `ID!` variables — `-F` coerces to Int/Bool.
 
 ### Parent / sub-issue
 
-Same shape as blocked-by — aliased lookup, then mutation.
+REST — no GraphQL needed (unlike blocked-by). `sub_issue_id` is the
+sub's **database id** (`.id` from the REST issue endpoint), not its
+number or node id; one extra GET resolves it.
 
 ```bash
-read P_ID S_ID <<<"$(gh api graphql \
-  -F owner=OWNER -F repo=REPO -F p=<parent> -F s=<sub> \
-  -f query='
-    query($owner: String!, $repo: String!, $p: Int!, $s: Int!) {
-      repository(owner: $owner, name: $repo) {
-        p: issue(number: $p) { id }
-        s: issue(number: $s) { id }
-      }
-    }' --jq '.data.repository | "\(.p.id) \(.s.id)"')"
-
-gh api graphql -f p="$P_ID" -f s="$S_ID" -f query='
-  mutation($p: ID!, $s: ID!) {
-    addSubIssue(input: { issueId: $p, subIssueId: $s }) {
-      issue { number }
-    }
-  }'
+SUB_ID=$(gh api repos/OWNER/REPO/issues/<sub> --jq '.id')
+gh api --method POST repos/OWNER/REPO/issues/<parent>/sub_issues \
+  -F sub_issue_id="$SUB_ID"
 ```
 
-Removal: `removeSubIssue`. Reorder: `reprioritizeSubIssue`. Reparent
-an existing sub: `addSubIssue` with `replaceParent: true`. Read:
-`Issue.parent`, `Issue.subIssues`, `Issue.subIssuesSummary`.
+Removal: `DELETE .../issues/<parent>/sub_issue` (singular) with the
+same `sub_issue_id`. Reorder: `PATCH .../sub_issues/priority`.
+Reparent: re-add with `-F replace_parent=true`. Read children:
+`gh api repos/OWNER/REPO/issues/<parent>/sub_issues`. The MCP REST
+tools `sub_issue_write` / `issue_read` (get_sub_issues) wrap the same
+endpoints.
 
 ### Plain mention
 

--- a/dot_claude/skills/issue-links/SKILL.md
+++ b/dot_claude/skills/issue-links/SKILL.md
@@ -79,9 +79,9 @@ Use `-f` (not `-F`) for `ID!` variables — `-F` coerces to Int/Bool.
 
 ### Parent / sub-issue
 
-REST — no GraphQL needed (unlike blocked-by). `sub_issue_id` is the
-sub's **database id** (`.id` from the REST issue endpoint), not its
-number or node id; one extra GET resolves it.
+REST (no GraphQL needed). `sub_issue_id` is the sub's **database id**
+(`.id` from the REST issue endpoint), not its number or node id; one
+extra GET resolves it.
 
 ```bash
 SUB_ID=$(gh api repos/OWNER/REPO/issues/<sub> --jq '.id')

--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -8,15 +8,18 @@ description: Pick up an existing GitHub issue in the checked-out repo — implem
 ## Inspect
 
 ```bash
-gh issue view <N> --comments                                # body + comments + cross-refs
-gh issue develop <N> --list                                 # branches linked to this issue
-gh pr list --state all --limit 20 \
-  --search "(<N> in:body) OR (<keywords> in:title,body)" \
+# REST to spare the shared GraphQL bucket — gh api / gh search, not
+# gh issue|pr view|list. See ~/.claude/CLAUDE.md "GitHub API budget".
+gh api repos/:owner/:repo/issues/<N> \
+  --jq '{title, body, milestone: .milestone.title}'         # body + milestone
+gh api repos/:owner/:repo/issues/<N>/comments --jq '.[].body'  # comments
+gh issue develop <N> --list                                 # linked branches (GraphQL; no REST equivalent, one call/pickup)
+gh search prs "(<N> in:body) OR (<keywords> in:title,body)" \
+  --repo <owner>/<repo> --state all --limit 20 \
   --json number,title,state,url
-# state=OPEN → in-flight PR (takeover candidate); state=MERGED → scope already covered, even if unlinked
+# open → in-flight PR (takeover candidate); merged → scope already covered, even if unlinked
 
-# Milestone gate: issue's milestone vs the current (lowest-version open) milestone
-gh issue view <N> --json milestone --jq '.milestone.title // "none"'
+# Milestone gate: issue's milestone (above) vs the current (lowest-version open) one
 gh api repos/:owner/:repo/milestones --jq '.[].title' | sort -V | head -1
 # none or current → fine to work; a different (later) milestone → no-go
 ```

--- a/dot_claude/skills/issue-work/SKILL.md
+++ b/dot_claude/skills/issue-work/SKILL.md
@@ -8,12 +8,11 @@ description: Pick up an existing GitHub issue in the checked-out repo — implem
 ## Inspect
 
 ```bash
-# REST to spare the shared GraphQL bucket — gh api / gh search, not
-# gh issue|pr view|list. See ~/.claude/CLAUDE.md "GitHub API budget".
+# REST reads — see ~/.claude/CLAUDE.md "GitHub API budget".
 gh api repos/:owner/:repo/issues/<N> \
   --jq '{title, body, milestone: .milestone.title}'         # body + milestone
 gh api repos/:owner/:repo/issues/<N>/comments --jq '.[].body'  # comments
-gh issue develop <N> --list                                 # linked branches (GraphQL; no REST equivalent, one call/pickup)
+gh issue develop <N> --list                                 # linked branches (no REST equivalent, one call/pickup)
 gh search prs "(<N> in:body) OR (<keywords> in:title,body)" \
   --repo <owner>/<repo> --state all --limit 20 \
   --json number,title,state,url

--- a/dot_claude/skills/pr-create/SKILL.md
+++ b/dot_claude/skills/pr-create/SKILL.md
@@ -12,8 +12,7 @@ context — write it for the reviewer first, the future reader of
 ## Pre-flight
 
 ```bash
-# REST to spare the shared GraphQL bucket, not gh pr status|view.
-# See ~/.claude/CLAUDE.md "GitHub API budget".
+# REST reads — see ~/.claude/CLAUDE.md "GitHub API budget".
 branch=$(git branch --show-current)
 gh api repos/:owner/:repo/pulls \
   --jq ".[] | select(.head.ref==\"$branch\") | {number, state, url}"  # existing PR for this branch?

--- a/dot_claude/skills/pr-create/SKILL.md
+++ b/dot_claude/skills/pr-create/SKILL.md
@@ -12,9 +12,13 @@ context — write it for the reviewer first, the future reader of
 ## Pre-flight
 
 ```bash
-gh pr status                          # already a PR for this branch?
+# REST to spare the shared GraphQL bucket, not gh pr status|view.
+# See ~/.claude/CLAUDE.md "GitHub API budget".
+branch=$(git branch --show-current)
+gh api repos/:owner/:repo/pulls \
+  --jq ".[] | select(.head.ref==\"$branch\") | {number, state, url}"  # existing PR for this branch?
 git log --oneline main..HEAD          # what this PR actually contains
-gh pr view --json body 2>/dev/null    # iterating? read the current body
+gh api repos/:owner/:repo/pulls/<N> --jq '.body'   # iterating? read the current body
 ```
 
 - Existing PR for the branch → iterate on it, don't open a second.


### PR DESCRIPTION
## Summary

GitHub GraphQL is a per-account ~5000pt/hr bucket shared across every session, every parallel agent, and the `git-*-poi` timers; REST is a separate bucket. Parallel agents running `gh issue|pr list|view|status` exhaust GraphQL — and a depleted bucket then makes `gh auth status` misreport the token as invalid, locking out `gh auth login` (its device flow ends in a GraphQL `viewer` query). This steers the repeated GitHub reads onto REST so the GraphQL bucket stops being the bottleneck.

## Gotchas

- The premise inverted under checking: the GitHub MCP read tools are *mostly REST* (`issue_read`, `pull_request_read`, `list_pull_requests`, `search_*`); it's the `gh issue|pr list|view|status` subcommands that are GraphQL-backed. Verified against `cli/cli` and `github-mcp-server` source, not memory. Review the swaps with that direction in mind.
- `issue-links` parent/sub now uses the REST `sub_issues` endpoints, which key on the sub-issue's **database id** (`.id` from the REST issue endpoint), not its number or node id — the one easy-to-get-wrong spot.
- `blocked-by` edges and the Projects v2 inbox dashboard stay GraphQL on purpose; no REST equivalent exists. `list_issues` (MCP) is also GraphQL, so the new guidance lists issues via `gh search`/`gh api` instead.
- The new `gh api`/`gh search` recipes are unexecuted — `gh` is currently down on this host from the same exhausted bucket. They're skill recipe text, and the underlying REST endpoints were confirmed to exist; behaviour is inferential until `gh` recovers.

## Verification

- `pre-commit run --files` on all five changed files passed (markdownlint, trailing-whitespace, eof); vale correctly skipped the AI-targeted docs.
- REST endpoints confirmed by reading `github-mcp-server`: `sub_issue_write`/`issue_read` (get_sub_issues) call `client.SubIssue.*`; the list/read/search tools use the REST client.