### PR TITLE
Disable fullscreen TUI to drop clickable prompts

### DIFF
--- a/dot_claude/modify_private_settings.json.tmpl
+++ b/dot_claude/modify_private_settings.json.tmpl
@@ -9,6 +9,9 @@ set -euo pipefail
 
 jq --slurp '(.[0] // {}) + {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": "1"
+  },
   "permissions": {
     "allow": [
       "BashOutput(*)",


### PR DESCRIPTION
## Summary

The new fullscreen renderer makes submitted prompts clickable widgets, which is disruptive. This sets `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` in the host-wide `~/.claude/settings.json` to fall back to the classic renderer.

The classic renderer drops all clickable/interactive elements *and* hands scrolling back to the terminal's native scrollback, so the mouse wheel keeps working. The alternative (`CLAUDE_CODE_DISABLE_MOUSE=1`) was rejected because it kills wheel scrolling too, leaving only `PgUp`/`PgDn`.

## Gotchas

- This is a new owned `env` key in the `modify_` merge. The merge is shallow (`+`), so this block now fully owns `env` — if you ever add other env vars at runtime via Claude, set them here instead.
- Tradeoff accepted: classic renderer loses fullscreen's flicker-free drawing.
- Host-wide: takes effect on next `chezmoi apply`.

## Verification

- Rendered the `modify_` script with the homeDir template var substituted and ran it over `{}`: output is valid JSON with `env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN == "1"`, and the existing 114 `permissions.allow` entries and 10 hook groups are intact.
- `pre-commit run --files dot_claude/modify_private_settings.json.tmpl` passed (json/whitespace hooks; shell hooks skip the `.tmpl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)