### PR TITLE
Note keyless Context7 is a deliberate choice

### DIFF
--- a/run_once_before_07-register-claude-mcp-servers.sh.tmpl
+++ b/run_once_before_07-register-claude-mcp-servers.sh.tmpl
@@ -31,9 +31,9 @@ for name in "${!CLOUDFLARE_MCP[@]}"; do
 done
 
 # ------------------------------------------------------------------- Context7
-# Upstash's docs-for-LLMs MCP. Anonymous use is rate-limited; an API key would
-# raise the ceiling and unlock usage analytics. Tracked in the repo issues for
-# a future switch to the encrypted-token pattern (see uptimerobot).
+# Upstash's docs-for-LLMs MCP. Anonymous use is rate-limited; a key would raise
+# the ceiling, but no limit pressure has shown up, so we run keyless by choice.
+# The encrypted-token pattern (see uptimerobot) is the path if that changes.
 if claude mcp list 2>/dev/null | grep -q "^context7:"; then
   log "context7: already registered"
 else


### PR DESCRIPTION
## Summary

The Context7 registration comment framed anonymous use as *"tracked in the repo issues for a future switch"* to an API key, implying open work. No rate-limit pressure has shown up, so keyless is the standing decision rather than a placeholder. This rewords the comment to say so and closes the tracking issue.

## Gotchas

- Decide whether you agree keyless stays the default. Merging closes #188 as not-planned; if you'd rather keep the API-key switch on the backlog, don't merge.

## Verification

- `pre-commit run --files run_once_before_07-register-claude-mcp-servers.sh.tmpl` — shellcheck, shfmt, vale all pass. Comment-only change; no behaviour touched (registration still `claude mcp add context7 ... https://mcp.context7.com/mcp`).

Closes #188