### PR TITLE
Add comply-over-demote principle to vale skill

### DIFF
--- a/dot_claude/skills/vale/SKILL.md
+++ b/dot_claude/skills/vale/SKILL.md
@@ -7,6 +7,17 @@ description: Audit, write, or revise .vale.ini, or work through vale findings on
 
 Config keys: <https://vale.sh/docs/keys/>. Current Vale 3.x key set is: `BasedOnStyles, BlockIgnores, CommentDelimiters, IgnoredClasses, IgnoredScopes, MinAlertLevel, Packages, SkippedScopes, StylesPath, TokenIgnores, Transform, Vocab`. Anything else is stale.
 
+## Comply, don't demote
+
+When a loaded rule fires, the default fix is to **rewrite the prose to comply**, not to demote or disable the rule. A firing rule is usually the writing improving on contact — the finding is a real style nit worth adopting. Restoring a package default typically costs zero current findings and often surfaces a legitimate fix (`Microsoft.Contractions` catching `does not` → `doesn't`).
+
+Demotion (`= suggestion`), disable (`= NO`), and scoping are the last resort, reserved for rules that are wrong for the writing style itself:
+
+- `Microsoft.Dashes` wanting tight em-dashes when the project's style uses spaced.
+- `Microsoft.HeadingColons` demanding sentence case after a colon when ADR/Nygard convention differs.
+
+Reach for them only after confirming the rule contradicts an intentional style choice — not merely that complying is inconvenient. Tuning from the issue framing ("Vale fights writing, silence the noisy rules") instead of the actual per-finding cost is the failure mode this guards against.
+
 ## Defaults
 
 ```ini
@@ -99,6 +110,8 @@ Default package rules trip on inline code, tables, and technical strings. Scope 
 - `BlockIgnores` / `TokenIgnores` — regex escape hatches for block and inline content with no HTML tag. **Markdown, reStructuredText, AsciiDoc, Org only.** Use for fenced shell prompts, custom MDX directives, file paths.
 - `IgnoredClasses` — by HTML class. Useful for rendered output linting.
 - `CommentDelimiters` — comment markers Vale honours for `<!-- vale off -->` directives. Default `<!-- -->`; set to `{/* */}` for MDX where HTML comments don't render.
+- `BasedOnStyles` is **additive across sections, not overriding**: a child block's `BasedOnStyles = X, Y` does not remove `Z` inherited from a broader block's `BasedOnStyles = X, Y, Z`. To silence a package's rules inside a sub-block, disable each rule explicitly (`Readability.LIX = NO`), not by dropping it from the child's list.
+- **Don't lint machine-generated prose.** Auto-managed files (release-please `CHANGELOG.md`, changesets entries, towncrier fragments) are dense and structured by design. Scope them out with a `[CHANGELOG.md]` block disabling `Readability.*` and the stylistic `Microsoft.*` rules (`Contractions`, `FirstPerson`, `HeadingColons`, `Dashes`).
 
 ## Vocabularies
 
@@ -108,6 +121,8 @@ Default package rules trip on inline code, tables, and technical strings. Scope 
 - `reject.txt` → `Vale.Avoid`. Flags banned terms.
 
 Both files: one regex per line, case-sensitive (prefix `(?i)` for case-insensitive), `#` for comments. The built-in `Vale` style must be in `BasedOnStyles` for these rules to fire.
+
+Backticked tokens skip `Vale.Terms`, so prefer wrapping a package ID or code symbol in backticks (`magpie-root`) over whitelisting the bare token in `accept.txt`. Reserve `accept.txt` for terms that appear unbackticked in prose.
 
 A starter `accept.txt` ships next to this skill at `~/.claude/skills/vale/accept.txt` with cross-repo terms (project names, host tooling, languages). Copy into `<StylesPath>/config/vocabularies/<Project>/` on greenfield; extend per-project.
 
@@ -127,6 +142,7 @@ Two hooks, both `id: vale`. The first runs `vale sync` to install declared `Pack
 ```
 
 - `sync` first — without it, packages declared in `.vale.ini` aren't installed in the hook's cached env and the lint produces zero findings (silent pass that looks clean).
+- **Vendored styles → drop the sync hook.** If the repo commits its packages under `<StylesPath>/` and excludes that path from pre-commit, `sync` has nothing to fetch — keep only the lint hook.
 - `--minAlertLevel=error` — overrides the file's `warning` default so only errors block commits.
 - `errata-ai/*` repos resolve to `vale-cli/*` on GitHub; vale.sh still publishes `errata-ai/vale` in the canonical example. Both work — match the upstream docs rather than chase the rename in every repo.
 - Pair with `markdownlint-cli2` for prose-heavy repos. Vale catches voice/usage; markdownlint catches structure (heading hierarchy, link syntax). No overlap; wire as separate hooks.

--- a/dot_claude/skills/vale/SKILL.md
+++ b/dot_claude/skills/vale/SKILL.md
@@ -9,14 +9,14 @@ Config keys: <https://vale.sh/docs/keys/>. Current Vale 3.x key set is: `BasedOn
 
 ## Comply, don't demote
 
-When a loaded rule fires, the default fix is to **rewrite the prose to comply**, not to demote or disable the rule. A firing rule is usually the writing improving on contact — the finding is a real style nit worth adopting. Restoring a package default typically costs zero current findings and often surfaces a legitimate fix (`Microsoft.Contractions` catching `does not` → `doesn't`).
+When a loaded rule fires, **rewrite the prose to comply** — don't demote or disable the rule. A firing rule is usually a real style nit worth adopting; restoring a package default typically costs zero current findings and often surfaces a legitimate fix (`Microsoft.Contractions` catching `does not` → `doesn't`).
 
-Demotion (`= suggestion`), disable (`= NO`), and scoping are the last resort, reserved for rules that are wrong for the writing style itself:
+Demotion (`= suggestion`), disable (`= NO`), and scoping are the last resort, reserved for rules wrong for the writing style itself:
 
 - `Microsoft.Dashes` wanting tight em-dashes when the project's style uses spaced.
 - `Microsoft.HeadingColons` demanding sentence case after a colon when ADR/Nygard convention differs.
 
-Reach for them only after confirming the rule contradicts an intentional style choice — not merely that complying is inconvenient. Tuning from the issue framing ("Vale fights writing, silence the noisy rules") instead of the actual per-finding cost is the failure mode this guards against.
+Confirm the rule contradicts an intentional style choice before silencing it — inconvenience isn't enough. Tuning from the issue framing ("Vale fights writing, silence the noisy rules") rather than the actual per-finding cost is the failure mode this guards against.
 
 ## Defaults
 
@@ -110,7 +110,7 @@ Default package rules trip on inline code, tables, and technical strings. Scope 
 - `BlockIgnores` / `TokenIgnores` — regex escape hatches for block and inline content with no HTML tag. **Markdown, reStructuredText, AsciiDoc, Org only.** Use for fenced shell prompts, custom MDX directives, file paths.
 - `IgnoredClasses` — by HTML class. Useful for rendered output linting.
 - `CommentDelimiters` — comment markers Vale honours for `<!-- vale off -->` directives. Default `<!-- -->`; set to `{/* */}` for MDX where HTML comments don't render.
-- `BasedOnStyles` is **additive across sections, not overriding**: a child block's `BasedOnStyles = X, Y` does not remove `Z` inherited from a broader block's `BasedOnStyles = X, Y, Z`. To silence a package's rules inside a sub-block, disable each rule explicitly (`Readability.LIX = NO`), not by dropping it from the child's list.
+- `BasedOnStyles` is **additive across sections, not overriding**: a child block's `BasedOnStyles = X, Y` doesn't remove `Z` inherited from a broader block's `BasedOnStyles = X, Y, Z`. To silence a package's rules inside a sub-block, disable each rule explicitly (`Readability.LIX = NO`), not by dropping it from the child's list.
 - **Don't lint machine-generated prose.** Auto-managed files (release-please `CHANGELOG.md`, changesets entries, towncrier fragments) are dense and structured by design. Scope them out with a `[CHANGELOG.md]` block disabling `Readability.*` and the stylistic `Microsoft.*` rules (`Contractions`, `FirstPerson`, `HeadingColons`, `Dashes`).
 
 ## Vocabularies

--- a/dot_claude/skills/vale/accept.txt
+++ b/dot_claude/skills/vale/accept.txt
@@ -1,6 +1,22 @@
 # Starter Vale.Terms list. Copy into <StylesPath>/config/vocabularies/<Project>/
-# and extend per-project. One regex per line; case-sensitive; prefix (?i) for
-# case-insensitive. Lines starting with # are comments.
+# and extend per-project.
+#
+# When to add a term here:
+#   - Proper nouns: product names, people, places, organizations.
+#   - Terms that appear unbackticked in prose (rare — prefer backticks for
+#     package IDs and code symbols).
+#   - Established acronyms with no surrounding-text rewrite available
+#     (ADR, MADR).
+#
+# When NOT to add a term here:
+#   - A package ID flagged by Vale.Terms — wrap in backticks instead
+#     (`magpie-root`). Backticked tokens skip Terms.
+#   - A rule fired on standard English the doc should comply with — rewrite
+#     to comply, not whitelist the wording. Demoting a rule so it stops
+#     firing is the wrong fix.
+#
+# One regex per line; case-sensitive; prefix (?i) for case-insensitive.
+# Lines starting with # are comments.
 
 # Identity
 Alunduil


### PR DESCRIPTION
## Summary

The vale skill now tells the next config-tuning task to comply with a firing rule (rewrite the prose) before reaching for demote/disable — the demote-first failure mode that [woodland-generators#322](https://github.com/alunduil/woodland-generators/pull/322) hit and had to reverse in review. Five smaller patterns from the same PR land alongside.

Closes #190

## Gotchas

- The "Comply, don't demote" section is placed *before* Defaults, per the issue — it's framed as the dominant principle, not one recipe among many.
- `accept.txt`'s policy header is a generalized port of #322's (dropped the Woodland/Magpie-specific examples); the SKILL.md prose keeps `magpie-root` as the backtick example since it reads as an obvious placeholder.

## Verification

- `pre-commit run --files` on both changed files passed (vale itself skips these AI-targeted docs by design, so no self-lint).
- Cross-checked all six acceptance-criteria checkboxes against the diff.