### PR TITLE
Let Renovate track zellij and zjstatus again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -240,12 +240,5 @@
       "depNameTemplate": "twpayne/chezmoi",
       "datasourceTemplate": "github-releases"
     }
-  ],
-  "packageRules": [
-    {
-      "description": "Pinned: zellij 0.44.x panics in wasm_bridge.rs:903 under concurrent plugin instantiation (upstream zellij-org/zellij#4960). zjstatus 0.23+ requires zellij-tile 0.44.1, so it pins alongside zellij. Re-enable once #4960 is fixed.",
-      "matchPackageNames": ["zellij-org/zellij", "dj95/zjstatus"],
-      "enabled": false
-    }
   ]
 }


### PR DESCRIPTION
## Summary

Drops the `renovate.json` `packageRules` ignore for `zellij-org/zellij`
and `dj95/zjstatus` so both flow through Renovate like every other dep.

## Gotchas

- The ignore's rationale was stale: it cited the 0.44.x
  `wasm_bridge.rs:903` plugin panic (upstream #4960) as the pin reason,
  but the freeze was later diagnosed as local load scaling and the pin
  already moved to a 0.44.3 debug source build (#299). zjstatus was
  frozen at 0.22.0 for no live reason.
- No `automerge` is configured, so this does **not** risk a silent bump
  past the current 0.44.3 bake — Renovate will open reviewable PRs
  gated by the 3-day `minimumReleaseAge`. Decide each zellij/zjstatus
  bump on its own merits when it lands.

## Verification

- `pre-commit run --files renovate.json` — `renovate-config-validator`
  and `check json` pass.

Clears the last live leftover from #167; the rest of that issue was
overtaken by events (pin off 0.43.1 via #299, resurrection loop via
#168, zellaude fork tried and reverted via #216).