### PR TITLE
Drop session_serialization workaround; verified #4165 gone

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -8,13 +8,6 @@
 // anyway. The pair layout adds a zjstatus line for PR-aware status; default
 // stays minimal.
 
-// Sessions never serialize. Before Rust 1.87, std::fs::Metadata::created()
-// returns "creation time is not available" on Linux even on filesystems
-// that store btime — zellij's resurrection scan logs the error twice a
-// second per saved session and eventually saturates the screen/plugin
-// threads (zellij-org/zellij#4165, PR #5057). Empty cache → empty loop.
-session_serialization false
-
 plugins {
     zellaude location="https://github.com/ishefi/zellaude/releases/download/v0.5.0/zellaude.wasm"
     zjstatus location="https://github.com/dj95/zjstatus/releases/download/v0.22.0/zjstatus.wasm"


### PR DESCRIPTION
## Summary

Removes `session_serialization false` from `dot_config/zellij/config.kdl`. The line dodged zellij-org/zellij#4165, where the resurrection scan logged `"creation time is not available"` twice a second per saved session and saturated the screen/plugin threads. That error path only fires when `std::fs::Metadata::created()` returns `Unsupported` on Linux, which needs *both* a pre-1.87 rustc build *and* a filesystem without btime. Neither holds anymore, so the workaround was earning nothing.

## Gotchas

- Sessions now serialize (zellij's default `true`) and **resurrect across reboots**. Confirmed acceptable in the issue thread — after a reboot zellij offers to bring back pair/worktree sessions, and panes whose worktree was deleted fail gracefully. If this ever gets noisy, that's a config choice to revisit, not a regression.
- Re-pin trigger for a future reviewer: if zellij is later bumped to a binary built with **rustc < 1.87**, this workaround becomes load-bearing again. Kept out of the config comment deliberately (forward-looking, belongs here/in the issue, not at HEAD).

## Verification

- v0.44.3 musl binary is built with rustc 1.92.0 (`strings` → `rustc version 1.92.0 (ded5c06cf 2025-12-08)`); `$HOME` is btrfs with `Birth:` populated via statx — both original trigger axes resolved.
- Ran an isolated session with `session_serialization true`, wrote content, let it serialize to `contract_version_1/session_info/`, confirmed `list-sessions` rendered "Created 0s ago" (requires a successful `created()`), then killed it to drive the resurrection/exited-session scan. Zero `"creation time is not available"` entries in the log — across the experiment and 2.8M of prior real usage.
- `script/checks/zellij-config` and `pre-commit run --files dot_config/zellij/config.kdl` pass.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)