### PR TITLE
Drop zellij fork source-build; download upstream release

### DIFF
--- a/script/install/zellij
+++ b/script/install/zellij
@@ -10,63 +10,6 @@ ARCH="x86_64-unknown-linux-musl"
 parse_bin_dir "$@"
 
 bin="$BIN_DIR/zellij"
-
-# TEMPORARY (alunduil/alunduil-chezmoi#211): build zellij from source with
-# debug symbols so a live server freeze is debuggable with gdb -- upstream
-# ships only stripped binaries, which dead-ended the last hang autopsy (gdb
-# got 0 symbols, unwinder stalled at the syscall site). Builds the SAME tag we
-# otherwise download, adding only strip=false + debug=2 -- stock release
-# codegen (fat LTO, one codegen unit) is kept, so a reproduced freeze is the
-# same bug, not a build variant. Skipped under CI and wherever the Rust
-# toolchain / protoc are absent, falling back to the verified release download.
-# Revert this whole block once #211 is root-caused.
-ZELLIJ_FORK_URL="https://github.com/alunduil/zellij"
-if [ -z "${CI:-}" ] &&
-  command -v cargo >/dev/null 2>&1 &&
-  command -v protoc >/dev/null 2>&1 &&
-  rustup target list --installed 2>/dev/null | grep -qx wasm32-wasip1; then
-  marker="$BIN_DIR/.zellij-source-ref"
-  if [ -x "$bin" ] && [ "$(cat "$marker" 2>/dev/null)" = "$ZELLIJ_VERSION" ]; then
-    printf '==> zellij: debug build %s already installed at %s\n' "$ZELLIJ_VERSION" "$bin" >&2
-    exit 0
-  fi
-
-  src="${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-src/zellij"
-  if [ -d "$src/.git" ]; then
-    git -C "$src" fetch --quiet --tags origin
-  else
-    mkdir -p "$(dirname "$src")"
-    git clone --quiet "$ZELLIJ_FORK_URL" "$src"
-  fi
-  # The release build regenerates the checked-in wasm plugin assets
-  # (zellij-utils embeds them at compile time), leaving the tree dirty. Only
-  # switch refs when the pinned tag changed -- discarding those assets first,
-  # since a dirty tree aborts the checkout. When already on the tag, leave the
-  # tree alone so the cargo target cache and the regenerated assets carry
-  # forward instead of forcing a fat-LTO relink every apply.
-  target_commit="$(git -C "$src" rev-parse --verify "${ZELLIJ_VERSION}^{commit}")"
-  if [ "$(git -C "$src" rev-parse HEAD)" != "$target_commit" ]; then
-    git -C "$src" checkout --quiet -- .
-    git -C "$src" -c advice.detachedHead=false checkout --quiet "$ZELLIJ_VERSION"
-  fi
-
-  printf '==> zellij: building %s from source with debug symbols (slow)\n' "$ZELLIJ_VERSION" >&2
-  # debuginfo=2 atop the release profile's fat LTO peaks ~10-14 GiB in one
-  # rustc process; a wedged zellij server holds ~8 GiB, so kill it first or
-  # this OOMs. `xtask build --release` carries the release profile's fat LTO.
-  (
-    cd "$src"
-    CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=true \
-      cargo xtask build --release
-  )
-
-  mkdir -p "$BIN_DIR"
-  install -m 0755 "$src/target/release/zellij" "$bin"
-  printf '%s' "$ZELLIJ_VERSION" >"$marker"
-  exit 0
-fi
-
-# Default (and CI): verified upstream release download.
 if installed_version_matches "$bin" "$ZELLIJ_VERSION"; then
   printf '==> zellij: %s already installed at %s\n' "$ZELLIJ_VERSION" "$bin" >&2
   exit 0


### PR DESCRIPTION
## Summary

zellij installs from the verified upstream `zellij-org/zellij` release
on every host again. The temporary source-build from `alunduil/zellij`
(added for debug symbols the #211 hang autopsy needed) is gone now that
#211 is closed, so `ZELLIJ_VERSION` is once more the single source of
truth for both Renovate bumps and installs.

## Gotchas

- The fork path wasn't just dead weight, it was a latent break: it
  checks out `$ZELLIJ_VERSION` as a git tag against `alunduil/zellij`,
  which carries no tags today. The next Renovate bump would fail
  `git rev-parse <tag>^{commit}` under `set -e` and abort the whole
  apply, and a fresh apply on a clean cache would already fail at the
  current pin. Removing it is the actual fix, not just cleanup.
- Hosts that ran the source build still have an orphaned
  `~/.local/bin/.zellij-source-ref` marker. The download path never
  reads it, so it's inert; delete it if you want the dir tidy.

## Verification

- `shellcheck -x script/install/zellij` clean; the remaining body is
  byte-identical to the pre-workaround version that passed CI.