### PR TITLE
Deny reads of ~/.claude.json in Claude settings

### DIFF
--- a/dot_claude/modify_private_settings.json.tmpl
+++ b/dot_claude/modify_private_settings.json.tmpl
@@ -132,15 +132,19 @@ jq --slurp '(.[0] // {}) + {
       "Bash(zellij:*)"
     ],
     "deny": [
+      "Bash(cat*.claude.json*)",
       "Bash(cat*.credentials.json*)",
       "Bash(cat*.gnupg/*)",
       "Bash(cat*.ssh/*)",
+      "Bash(head*.claude.json*)",
       "Bash(head*.credentials.json*)",
       "Bash(head*.gnupg/*)",
       "Bash(head*.ssh/*)",
+      "Bash(less*.claude.json*)",
       "Bash(less*.credentials.json*)",
       "Bash(less*.gnupg/*)",
       "Bash(less*.ssh/*)",
+      "Bash(tail*.claude.json*)",
       "Bash(tail*.credentials.json*)",
       "Bash(tail*.gnupg/*)",
       "Bash(tail*.ssh/*)",
@@ -149,6 +153,7 @@ jq --slurp '(.[0] // {}) + {
       "Bash(git push -f*)",
       "Bash(git push* -f*)",
       "Bash(git push*main*)",
+      "Read({{ .chezmoi.homeDir }}/.claude.json)",
       "Read({{ .chezmoi.homeDir }}/.claude/.credentials.json)",
       "Read({{ .chezmoi.homeDir }}/.gnupg/**)",
       "Read({{ .chezmoi.homeDir }}/.ssh/**)"


### PR DESCRIPTION
## Summary

`~/.claude.json` holds live MCP bearer tokens in plaintext, and a routine inspection leaked three into conversation context (#201). This deny-lists it alongside `.credentials.json`/`.gnupg`/`.ssh`. Closes acceptance criterion #3 only.

## Gotchas

- Recurrence guard, not a boundary: blocks the Read tool + `cat`/`head`/`tail`/`less`, but not `jq` (left allowed for legitimate config inspection) or code running as the user. The 0600 file stays readable inside Claude's process tree.
- Doesn't close #201. Criterion #1 (tokens out of the file) is gated on the alunduil-infrastructure#84 DFD — file→env buys no boundary against a compromised child. Criterion #2 was already satisfied. Full analysis in the issue comment.

## Verification

- Rendered the `modify_` template and merged it onto empty settings; `jq -e` confirmed valid JSON with the five new entries and `homeDir` expanded.
- Shell pre-commit hooks skip `.tmpl`; CI's `chezmoi-apply` round-trip is authoritative.

Refs #201