### PR TITLE
Exempt digest and pin updates from minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
     "minimumReleaseAge": "0 days"
   },
   "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["digest", "pin"],
+      "minimumReleaseAge": "0 days"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
Renovate digest/pin updates never merge on their own. `config:best-practices` pins action SHAs, so action bumps arrive as `digest` updates — which `minimumReleaseAge` [can't age](https://docs.renovatebot.com/key-concepts/minimum-release-age/) (no release timestamp; Renovate 42+ treats that as "not old enough yet"). With `internalChecksFilter: "strict"` the PR parks behind a `renovate/stability-days` check that never resolves. This adds a `packageRules` carve-out zeroing the gate for `digest`/`pin` updates.

## Gotchas
- Takes effect only once merged to `main` — Renovate reads config from the default branch. On its next run it re-evaluates the stuck open PRs (#279, #386, #387) and flips their stale checks green; no rebase/recreate needed.
- Automerge stays off by config, so those three still need a manual merge click once green.
- Zero-day gate on digests loses no supply-chain protection: the SHA is already pinned to a tag that went through its own `minimumReleaseAge` bake at version-bump time.

## Verification
- `python3 -m json.tool renovate.json` — valid
- `pre-commit run check-json --files renovate.json` — passed
- Diagnosed against live state: #279/#386/#387 all pending on `renovate/stability-days`; version updates (#402/#403) merged normally — the contrast confirms the gate only traps digests.

Skill-level follow-up (the renovate skill teaches this same config without the carve-out): #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qeLwSf1f3Qcer8MCQDG2q