### PR TITLE
adr: renumber per-workflow-CI ADR to 0004 off the 0002 collision

### DIFF
--- a/docs/adr/0004-keep-per-workflow-ci.md
+++ b/docs/adr/0004-keep-per-workflow-ci.md
@@ -1,4 +1,4 @@
-# 2. Keep one workflow per sensor
+# 4. Keep one workflow per sensor
 
 ## Status
 


### PR DESCRIPTION
# adr: renumber per-workflow-CI ADR to 0004 off the 0002 collision

## Summary

`docs/adr/` had two files numbered `0002`: both `0002-port-git-worktree-poi-to-rust.md` and `0002-keep-per-workflow-ci.md`. ADR numbers must be unique. This PR renumbers the per-workflow-CI ADR to `0004` (since `0003` is already taken by the bash-installers ADR), leaving the `0002` number with the git-worktree Rust port — that ADR is paired to `0001` through its `Supersedes`/`Superseded by` links and must not move.

## Changes

- Rename `docs/adr/0002-keep-per-workflow-ci.md` → `docs/adr/0004-keep-per-workflow-ci.md`.
- Update the heading inside that file from `# 2. Keep one workflow per sensor` to `# 4. Keep one workflow per sensor`.

No other file in the repo references the old `0002-keep-per-workflow-ci.md` path or its `# 2.` number: grepping the whole tree (Markdown, YAML, TOML, JSON, templates, scripts, the `adr` Claude skill, and the README) finds no cross-references to update. The other `0002` ADR's link from `0001` points at `0002-port-git-worktree-poi-to-rust.md`, which is unchanged.

After the change `docs/adr/` numbers are `0000`, `0001`, `0002`, `0003`, `0004` — unique, with no duplicates.

Fixes #405

## Testing

The change is a documentation rename plus a single heading-digit edit; no build, test, or code surface is touched.

Verification performed outside the sandbox (repo-local inspection only, no untrusted build commands run on this machine):

- `ls docs/adr/` confirms the directory now lists `0000`, `0001`, `0002-port-git-worktree-poi-to-rust.md`, `0003`, `0004-keep-per-workflow-ci.md` with no remaining `0002-keep-per-workflow-ci.md`.
- `ls docs/adr/ | grep -oE "^[0-9]{4}" | sort | uniq -d` returns no duplicates after the change.
- Repo-wide `grep -rn "keep-per-workflow\|per-workflow-ci\|0002-keep-per-workflow"` finds the only remaining mention of the phrase inside the renamed file's own body prose ("the per-workflow layout") — no links to update.
- The `0002-port-git-worktree-poi-to-rust.md` ADR keeps its `Supersedes [0001]` link, and `0001` keeps its `Superseded by [0002]` link, both pointing at unchanged paths.

Markdownlint could not be re-run in the sandbox (no network in the contained environment to fetch `markdownlint-cli`), but the only structural edit is a single digit in an existing H1, so document structure is unchanged from the already-linted source.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
