### PR TITLE
Version the chezmoi age encryption config

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,6 +1,5 @@
-# Renders to ~/.config/chezmoi/chezmoi.toml on `chezmoi init`; edit here, not the
-# deployed copy. recipient is the public half of the age key, safe to commit; the
-# private half stays in key.txt. encryption must sit above [age].
+# recipient is the public half of the age key (private half lives in key.txt,
+# uncommitted), so exposing it here leaks nothing.
 encryption = "age"
 
 [age]

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,6 +1,6 @@
-# Rendered to ~/.config/chezmoi/chezmoi.toml on `chezmoi init`; edit this source,
-# not the deployed copy. recipient is a public age key (its private half stays in
-# ~/.config/chezmoi/key.txt, never committed). encryption must precede [age].
+# Renders to ~/.config/chezmoi/chezmoi.toml on `chezmoi init`; edit here, not the
+# deployed copy. recipient is the public half of the age key, safe to commit; the
+# private half stays in key.txt. encryption must sit above [age].
 encryption = "age"
 
 [age]

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,8 @@
+# Rendered to ~/.config/chezmoi/chezmoi.toml on `chezmoi init`; edit this source,
+# not the deployed copy. recipient is a public age key (its private half stays in
+# ~/.config/chezmoi/key.txt, never committed). encryption must precede [age].
+encryption = "age"
+
+[age]
+	identity = "~/.config/chezmoi/key.txt"
+	recipient = "age13vgd4mk5a74fazamw09xqaq8yughtmlhepuqsdy2t300j4vldg9quf77j5"

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -45,7 +45,7 @@ Tool versions live in `script/install/*` (one script per tool, each pinning its 
 
 The source tree stores long-lived secrets as age-encrypted blobs that unlock at `apply` time:
 
-- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs.
+- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs. The encryption config that tells chezmoi to *use* age (and for which recipient) is rendered to `~/.config/chezmoi/chezmoi.toml` from `.chezmoi.toml.tmpl` on `chezmoi init`, so pasting the key is the only manual config step. The recipient in that template is a public key; only `key.txt`'s private half is out-of-band.
 - **GPG** signs commits. The secret key ships as an age-encrypted blob in `private_dot_gnupg/`; trust chain is *age key + GPG passphrase*.
 - **SSH** keys (`~/.ssh/{id_rsa,config}`) ship the same way under `private_dot_ssh/`; trust chain is just the age key. This is what makes `chezmoi init --apply` over HTTPS bootstrap straight into a working SSH-to-GitHub state.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -45,7 +45,7 @@ Tool versions live in `script/install/*` (one script per tool, each pinning its 
 
 The source tree stores long-lived secrets as age-encrypted blobs that unlock at `apply` time:
 
-- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs. On `chezmoi init`, chezmoi renders `.chezmoi.toml.tmpl` into `~/.config/chezmoi/chezmoi.toml`, the config that tells it to *use* age and for which recipient, so pasting the key is the only manual config step. The recipient in that template is a public key; only `key.txt`'s private half is out-of-band.
+- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs: `chezmoi init` renders `.chezmoi.toml.tmpl` into `~/.config/chezmoi/chezmoi.toml` to point chezmoi at age and its recipient, so pasting the key is the only manual step. That recipient is a public key, not a second secret.
 - **GPG** signs commits. The secret key ships as an age-encrypted blob in `private_dot_gnupg/`; trust chain is *age key + GPG passphrase*.
 - **SSH** keys (`~/.ssh/{id_rsa,config}`) ship the same way under `private_dot_ssh/`; trust chain is just the age key. This is what makes `chezmoi init --apply` over HTTPS bootstrap straight into a working SSH-to-GitHub state.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -45,7 +45,7 @@ Tool versions live in `script/install/*` (one script per tool, each pinning its 
 
 The source tree stores long-lived secrets as age-encrypted blobs that unlock at `apply` time:
 
-- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs. The encryption config that tells chezmoi to *use* age (and for which recipient) is rendered to `~/.config/chezmoi/chezmoi.toml` from `.chezmoi.toml.tmpl` on `chezmoi init`, so pasting the key is the only manual config step. The recipient in that template is a public key; only `key.txt`'s private half is out-of-band.
+- **age key** lives at `~/.config/chezmoi/key.txt`, and a password manager restores it on a fresh host. It's the one out-of-band secret the bootstrap needs. On `chezmoi init`, chezmoi renders `.chezmoi.toml.tmpl` into `~/.config/chezmoi/chezmoi.toml`, the config that tells it to *use* age and for which recipient, so pasting the key is the only manual config step. The recipient in that template is a public key; only `key.txt`'s private half is out-of-band.
 - **GPG** signs commits. The secret key ships as an age-encrypted blob in `private_dot_gnupg/`; trust chain is *age key + GPG passphrase*.
 - **SSH** keys (`~/.ssh/{id_rsa,config}`) ship the same way under `private_dot_ssh/`; trust chain is just the age key. This is what makes `chezmoi init --apply` over HTTPS bootstrap straight into a working SSH-to-GitHub state.
 


### PR DESCRIPTION
## Summary

age-encrypted secrets now decrypt on a fresh host straight from `chezmoi init --apply`. The `encryption = "age"` setting plus the recipient/identity previously lived only in a hand-created `~/.config/chezmoi/chezmoi.toml`, captured nowhere in the repo, so the documented one-command bootstrap would fail at the first `encrypted_*.age` file — `init` had no way to know it should invoke age. A new `.chezmoi.toml.tmpl` renders that config on `init`, making the bootstrap reproducible from the repo plus the age key.

## Gotchas

- The recipient is committed in `.chezmoi.toml.tmpl` — it's a **public** age key (encrypt-only); the private half stays in uncommitted `key.txt`, so committing it adds no exposure. Worth a glance to confirm you're comfortable with it in the tree.
- Hardcoded the recipient rather than a `promptStringOnce`, since this is a single-recipient personal repo. Switch to a prompt if hosts ever need different recipients.

## Verification

- `chezmoi execute-template` output is byte-identical to the live `~/.config/chezmoi/chezmoi.toml`, so re-running `init` on an existing host is a no-op.
- pre-commit passed on both changed files; `check-toml` skips it (`.tmpl` suffix) and the `chezmoi-template` sensor's glob (`run_*.tmpl`) doesn't match it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQVkWZXB3ieZCWW5JYfd7s