### PR TITLE
Install Temurin 21 JDK for Firebase emulators

### DIFF
--- a/.chezmoiscripts/run_once_before_01-install-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_01-install-system-packages.sh.tmpl
@@ -82,11 +82,26 @@ if [ ! -f /usr/share/keyrings/1password-archive-keyring.gpg ]; then
     sudo gpg --dearmor -o /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
 fi
 
+# ------------------------------------------------------------ adoptium (java)
+# temurin-21-jdk backs the JVM-based Firebase emulators that genshin's
+# `pnpm dev` starts when that project is developed on the host rather than in
+# its devcontainer. Debian bookworm ships no openjdk-21 in main, security, or
+# backports, so Adoptium is where a 21 comes from; it is also what the
+# devcontainers `java:1` feature installs, keeping both paths on one runtime.
+if [ ! -f /usr/share/keyrings/adoptium-archive-keyring.gpg ]; then
+  log "adoptium: adding apt repository"
+  curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public |
+    sudo gpg --dearmor -o /usr/share/keyrings/adoptium-archive-keyring.gpg
+  printf 'deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb %s main\n' \
+    "$(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
+fi
+
 # -------------------------------------------------------------------- apt pkgs
 APT_PACKAGES=(
   gh zsh ripgrep fd-find fzf jq unzip age terraform libnotify-bin 1password-cli
   build-essential libffi-dev libgmp-dev libncurses-dev zlib1g-dev
   protobuf-compiler
+  temurin-21-jdk
   golang-petname
   keybase signal-desktop calibre
   nethack-console

--- a/docs/tutorials/bootstrap.md
+++ b/docs/tutorials/bootstrap.md
@@ -33,6 +33,7 @@ uv --version                               # Python-CLI installer (astral-sh/uv)
 pre-commit --version                       # git hook runner (uv tool install)
 ghc --version && cabal --version           # ghcup-managed Haskell toolchain
 pnpm --version                             # pnpm package manager (npm global)
+java --version                             # Temurin 21 JDK (Firebase emulators)
 command -v cargo-cache                     # cargo registry GC helper (needs cargo)
 golang-petname                             # repo-picker worktree namer
 command -v nethack                         # roguelike (nethack-console)


### PR DESCRIPTION
## Summary

`java` now lands on the host, so genshin.dungeon.studio's `pnpm dev` can start its JVM-based Firebase emulators when that project is developed on penguin rather than in its devcontainer. Debian bookworm has no openjdk-21 anywhere, so the JDK comes from Adoptium's apt repo.

Closes #365.

## Gotchas

- **Neither acceptance criterion is verified yet.** `java -version` and `pnpm dev` can only be checked after this merges and the apply clone pulls it — script 01 is `run_once`, and its content hash changing is what re-fires it on the next `chezmoi apply`. Worth confirming on penguin before this leaves draft.
- **Fourth-party apt repo.** Adoptium joins hashicorp/github-cli/docker/1password in script 01. Chosen over a pinned `script/install/temurin` tarball because a JDK is a ~300MB tree rather than the single binary that pattern installs, and apt then owns security updates with no version pin to maintain.
- **`pnpm dev` also needs the firebase CLI**, covered separately by dungeon-studio/genshin.dungeon.studio#866. This PR only supplies the JVM.
- **Every workstation gets the JDK**, not just penguin. The `role` axis from #417 is workstation/ha-terminal, so there's no per-machine gate short of inventing one; ha-terminal is already excluded because it ignores `.chezmoiscripts/**`.

## Verification

- `just check` green (pre-commit, bats, python, zellij, chezmoi apply round-trip, chezmoi templates, settings-permissions, observability, systemd).
- Confirmed bookworm has no `openjdk-21` in main, security, or `bookworm-backports` (fetched the backports package index directly); `temurin-21-jdk` 21.0.12 is present in Adoptium's bookworm index.
- Imported the key at the `signed-by=` URL into a scratch GNUPGHOME and verified it produces a good signature over Adoptium's bookworm `Release` — the apt source will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBB4PAQ4bEmJQZpbDU4Krh