### PR TITLE
Annotate version pins, collapse Renovate managers

### DIFF
--- a/.chezmoiscripts/run_once_before_03-install-node-ecosystem.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_03-install-node-ecosystem.sh.tmpl
@@ -11,6 +11,7 @@ log() { printf '==> %s\n' "$*" >&2; }
 # Mirror nvm's own install-location logic: $XDG_CONFIG_HOME/nvm if XDG is set,
 # else $HOME/.nvm. Set PROFILE=/dev/null so the installer does NOT append to
 # any rc file -- the managed .bashrc sources nvm itself.
+# renovate: datasource=github-releases depName=nvm-sh/nvm
 NVM_VERSION="v0.40.5"
 export NVM_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvm"
 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
@@ -27,6 +28,7 @@ fi
 # this once-script when the pin changes, so a bump applies on apply. Match by
 # explicit version rather than `command -v node`, which could find a system
 # /usr/bin/node and skip installation, leaving nvm with zero versions.
+# renovate: datasource=node-version depName=node versioning=node
 NODE_VERSION="24.16.0"
 if ! nvm ls "$NODE_VERSION" >/dev/null 2>&1; then
   log "node: installing $NODE_VERSION via nvm"
@@ -57,6 +59,7 @@ fi
 # take effect. `npm ls -g` is the local query, no network round-trip. It
 # exits 1 when the package is absent (e.g. fresh prefix after a node bump),
 # so `|| true` keeps set -e from killing the run before the install branch.
+# renovate: datasource=npm depName=@readwise/cli
 READWISE_CLI_VERSION="0.5.9"
 installed="$(npm ls -g --depth=0 --parseable=false @readwise/cli 2>/dev/null |
   sed -n 's,.*@readwise/cli@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"
@@ -75,6 +78,7 @@ fi
 # Same pin-enforced replace as readwise-cli above. Backs the global guide's
 # devcontainer-exec helper; nvm owns the runtime so this is the only copy on
 # PATH.
+# renovate: datasource=npm depName=@devcontainers/cli
 DEVCONTAINER_CLI_VERSION="0.87.0"
 installed="$(npm ls -g --depth=0 --parseable=false @devcontainers/cli 2>/dev/null |
   sed -n 's,.*@devcontainers/cli@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"
@@ -92,6 +96,7 @@ fi
 # ---------------------------------------------------------------------- pnpm
 # Backs dev-cache-gc's `pnpm store prune`. Same pin-enforced replace as the
 # CLIs above; nvm owns the runtime so this is the only pnpm on PATH.
+# renovate: datasource=npm depName=pnpm
 PNPM_VERSION="11.8.0"
 installed="$(npm ls -g --depth=0 --parseable=false pnpm 2>/dev/null |
   sed -n 's,.*pnpm@\([0-9][0-9.]*\).*,\1,p' | head -1 || true)"

--- a/.chezmoiscripts/run_once_before_05-install-standalone-tools.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_05-install-standalone-tools.sh.tmpl
@@ -24,6 +24,7 @@ fi
 # `git branch --merged` can't see them. `gh poi` requires `gh` (apt,
 # script 01). Pin enforced: if a different version is already
 # installed, replace it so renovate-tracked bumps actually take effect.
+# renovate: datasource=github-releases depName=seachicken/gh-poi
 GH_POI_VERSION="v0.17.2"
 installed="$(gh extension list 2>/dev/null | awk -F'\t' '$2 == "seachicken/gh-poi" {print $3; exit}')"
 if [ "$installed" != "$GH_POI_VERSION" ]; then

--- a/.chezmoiscripts/run_once_before_09-install-rust-ecosystem.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_09-install-rust-ecosystem.sh.tmpl
@@ -19,6 +19,7 @@ fi
 # download-and-verify pattern; `cargo install` is the canonical path. Pin
 # enforced (Renovate-tracked, crate datasource): if a different version is
 # installed, --force replaces it so bumps actually take effect.
+# renovate: datasource=crate depName=cargo-cache
 CARGO_CACHE_VERSION="0.8.3"
 installed="$(cargo cache --version 2>/dev/null | awk '{print $2}' || true)"
 if [ "$installed" != "$CARGO_CACHE_VERSION" ]; then

--- a/.chezmoiscripts/run_onchange_before_02-install-binary-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_02-install-binary-tools.sh.tmpl
@@ -42,6 +42,7 @@ INSTALL_DIR="{{ .chezmoi.sourceDir }}/script/install"
 # overwrites a pre-existing pip-installed pre-commit on the PATH; the guard
 # keys off `uv tool list` rather than `pre-commit --version`, which can't tell
 # a uv-managed install from the legacy pip one at the same version.
+# renovate: datasource=pypi depName=pre-commit
 PRE_COMMIT_VERSION="4.6.0"
 if "$HOME/.local/bin/uv" tool list 2>/dev/null | grep -qx "pre-commit v$PRE_COMMIT_VERSION"; then
   printf '==> pre-commit: %s already installed via uv\n' "$PRE_COMMIT_VERSION" >&2

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -17,19 +17,25 @@ jobs:
   run:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # Versions stay aligned with script/install/bats-libs (the local path);
+    # Renovate bumps both together. The action takes them without the tag's
+    # leading `v`, hence extractVersion.
+    env:
+      # renovate: datasource=github-releases depName=bats-core/bats-support extractVersion=^v(?<version>.+)$
+      BATS_SUPPORT_VERSION: "0.3.0"
+      # renovate: datasource=github-releases depName=bats-core/bats-assert extractVersion=^v(?<version>.+)$
+      BATS_ASSERT_VERSION: "2.2.4"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         id: setup-bats
         with:
-          # Versions stay aligned with script/install/bats-libs (the local
-          # path); Renovate bumps both together. assert defaults to 2.1.0, so
-          # pin it explicitly. detik/file stay unused.
+          # assert defaults to 2.1.0, so pin it explicitly. detik/file stay unused.
           support-install: true
-          support-version: "0.3.0"
+          support-version: ${{ env.BATS_SUPPORT_VERSION }}
           assert-install: true
-          assert-version: "2.2.4"
+          assert-version: ${{ env.BATS_ASSERT_VERSION }}
           detik-install: false
           file-install: false
           # bats-action curls api.github.com; auth raises the anonymous rate limit.

--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Install chezmoi
         env:
+          # renovate: datasource=github-releases depName=twpayne/chezmoi
           CHEZMOI_VERSION: "v2.70.5"
         run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin -t "$CHEZMOI_VERSION"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,13 @@ repos:
   # out-of-band (#359).
   - repo: local
     hooks:
+      - id: renovate-pins
+        name: renovate-pins
+        entry: script/checks/renovate-pins
+        language: system
+        pass_filenames: false
+        files: ^(script/install/|\.chezmoiscripts/.*\.tmpl$|\.github/workflows/)
+
       - id: lychee
         name: lychee
         entry: lychee --config lychee.toml --no-progress --offline --include-fragments=full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,13 @@ effect on `apply` until committed and pulled into the apply clone. Use
   Bump in one place. Zellij *plugins*
   (`zellaude`, `zjstatus`) are pinned separately as alias tags in
   `dot_config/zellij/config.kdl`.
+- Every `*_VERSION` pin carries a `# renovate: datasource=… depName=…`
+  line directly above it (order: datasource, depName, packageName,
+  versioning, extractVersion). One generic manager in `renovate.json`
+  reads them all — a new pinned tool needs no Renovate config change.
+  An unannotated pin is invisible to Renovate rather than an error, so
+  `script/checks/renovate-pins` (a pre-commit hook) fails the build on
+  one.
 - `gh` extensions install in script 05 alongside other bespoke
   installers, not script 02 — they're managed by `gh extension`, not
   the `script/install/` download-and-verify pattern. Version pin lives

--- a/dot_claude/skills/renovate/SKILL.md
+++ b/dot_claude/skills/renovate/SKILL.md
@@ -8,55 +8,74 @@ description: Audit, write, or revise renovate.json. Use when adding Renovate, tr
 ```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:weekly"],
-  "baseBranchPatterns": ["<default-branch>"],
-  "reviewers": ["<owner>"],
+  "extends": [
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "customManagers:githubActionsVersions"
+  ],
+  "timezone": "Europe/London",
+  "reviewers": ["alunduil"],
   "pre-commit": { "enabled": true }
 }
 ```
 
-- `config:best-practices` — adds `helpers:pinGitHubActionDigests` (action SHA pinning) and OpenSSF scorecard alerts on top of `config:recommended`.
-- `schedule:weekly` — batches routine update PRs into one weekly run ("before 4am on Monday", UTC). Security updates are exempt — see Supply-chain hardening.
-- `baseBranchPatterns` — set explicitly to the repo's default branch (`main`, `master`, `trunk`, …); auto-detected otherwise, but explicit travels better across forks.
-- `reviewers` — without it, Renovate PRs land silent. Use `assignees` instead if you only want a creation-time ping (no rebase notifications).
+- This block is identical in every repo and is a standing candidate for a shared preset (`github>alunduil/renovate-config`, a `default.json`); Renovate also checks `<owner>/renovate-config` when onboarding a new repo. Until that repo exists, keep the block inline and change it everywhere at once.
+- Omit `baseBranchPatterns`. It is auto-detected, and hard-coding it is the one field that differs per repo (`main` vs `master`) — the thing that would block sharing.
+- Omit `schedule` unless a repo wants batching. With a bake period the PR is already delayed, and Renovate's default `prHourlyLimit` of 2 rate-limits the rest.
+- `packageRules` and `customManagers` are `mergeable: true`, so preset arrays concatenate with a repo's own rather than replacing them. `labels` and `reviewers` are not mergeable — setting them in a repo replaces the inherited value.
+- `reviewers` — without it, Renovate PRs land silent. Use `assignees` instead for a creation-time ping with no rebase notifications.
 - `pre-commit: { enabled: true }` — opt-in manager; enable unconditionally. No-op without `.pre-commit-config.yaml`; replaces pre-commit.ci where the file exists.
+- `config:best-practices` = `config:recommended` + `docker:pinDigests` + `helpers:pinGitHubActionDigests` + `:configMigration` + `:pinDevDependencies` + `abandonments:recommended` + `security:minimumReleaseAgeNpm` + `:maintainLockFilesWeekly`. It does *not* include OpenSSF scorecard; that is `security:openssf-scorecard`, which adds a badge column to PR bodies.
 
 ## Supply-chain hardening
 
-`config:best-practices` pins action SHAs and surfaces scorecard alerts but does not delay releases. Add a bake period so malicious versions get yanked before Renovate opens a PR:
+`config:best-practices` bakes npm releases for 3 days (`security:minimumReleaseAgeNpm`) but nothing else. Widen it to every datasource:
 
 ```json
 {
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
-  "vulnerabilityAlerts": { "minimumReleaseAge": "0 days" },
-  "osvVulnerabilityAlerts": true
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance",
+                           "lockfileUpdate", "rollback", "bump", "replacement"],
+      "minimumReleaseAge": null
+    }
+  ]
 }
 ```
 
-- `minimumReleaseAge` — days between publication and PR. 3-7 is the sweet spot; catches the common attack shape (publish → community flags → upstream yanks within a day or two).
-- `internalChecksFilter: "strict"` — PRs wait during the bake. Without it Renovate opens the PR immediately and labels it "pending", defeating the purpose.
-- `vulnerabilityAlerts.minimumReleaseAge: "0 days"` — load-bearing carve-out so known CVEs bypass the delay. Without it, the bake delays security fixes.
-- `osvVulnerabilityAlerts: true` — widens alert source beyond GitHub's advisory database to OSV.
-- Security updates bypass `schedule:weekly` (Defaults) automatically: `vulnerabilityAlerts` defaults to `schedule: []` (any time), which the `minimumReleaseAge` object merges onto, not over — so an explicit `"schedule": []` carve-out is redundant.
+- `minimumReleaseAge` — 3-7 days catches the common attack shape (publish → community flags → upstream yanks within a day or two).
+- The carve-out is the load-bearing half. `minimumReleaseAgeBehaviour` defaults to `timestamp-required` (Renovate 42), so a release with no timestamp is treated as never stable, and `internalChecksFilter` defaults to `strict`, so no branch is ever cut. These eight update types cannot carry a timestamp, so without the carve-out they stall on a pending `renovate/stability-days` check forever — silently, since no PR appears. `config:best-practices` pulls in `:maintainLockFilesWeekly` and both digest-pinning presets, so `lockFileMaintenance`, `digest`, and `pinDigest` are always in scope.
+- `osvVulnerabilityAlerts: true` — widens alerts beyond GitHub's advisory database to OSV. Defaults to `false`.
+- Do *not* write `internalChecksFilter: "strict"` or `vulnerabilityAlerts: { "minimumReleaseAge": "0 days" }`. Both are already the defaults (`lib/config/options/index.ts`: `internalChecksFilter` default `strict`; the `vulnerabilityAlerts` default object contains `minimumReleaseAge: null`, force-applied over the top-level bake).
+- `minimumReleaseAge: "0 days"` is identical to `null` as of Renovate 42.19.5. Prefer `null`.
 
-## Custom regex managers
+## Version pins in scripts
 
-For version pins inside scripts, KDL, etc.:
+Annotate the pin; do not write a manager per pin. One generic manager reads them all, and a new pin needs no config change:
+
+```bash
+# renovate: datasource=github-releases depName=mikefarah/yq
+YQ_VERSION="v4.53.2"
+```
 
 ```json
 {
   "customType": "regex",
-  "managerFilePatterns": ["/^script/install/<tool>$/"],
-  "matchStrings": ["<TOOL>_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-  "depNameTemplate": "<owner>/<tool>",
-  "datasourceTemplate": "github-releases"
+  "managerFilePatterns": ["script/install/*", ".chezmoiscripts/*.tmpl"],
+  "matchStrings": [
+    "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=\"(?<currentValue>.+?)\""
+  ]
 }
 ```
 
-- `managerFilePatterns` (renamed from `fileMatch`): wrap regex in `/.../`; bare strings are globs.
-- For URL-embedded versions, capture both `depName` and `currentValue` in `matchStrings` — no `depNameTemplate` needed.
-- One manager per `*_VERSION=` pattern; group only when the file shape is identical.
+- Annotation field order is fixed by the regex: datasource, depName, packageName, versioning, extractVersion, registryUrl. `datasource`, `versioning`, `extractVersion` and `registryUrl` are recognised capture-group names — no `*Template` fields needed.
+- For workflow YAML (`X_VERSION: "v1"` under `env:`) extend `customManagers:githubActionsVersions` instead of writing this yourself. Hoist versions buried in `with:` inputs up to `env:` so the preset reaches them; add `extractVersion=^v(?<version>.+)$` when the consumer wants the tag without its leading `v`.
+- Upstream ships equivalents for Dockerfiles, Makefiles, `*.tfvars`, `pom.xml`, and several CI formats — check `customManagers:*` before writing a regex.
+- Keep a bespoke manager only where an annotation cannot go: a version embedded in a URL (capture `depName` and `currentValue` from the URL itself), or a snippet in user-facing docs where a `# renovate:` line would be copy-pasted by a reader.
+- `managerFilePatterns` (renamed from `fileMatch`): bare strings are globs; wrap in `/.../` for a regex. Prefer the glob.
+- Validate a new `matchStrings` against the real files before committing — the regex is ECMAScript/RE2 (no lookahead, no backreferences), and a silently non-matching manager looks exactly like a dependency with no updates.
 
 ## Validation
 
@@ -72,6 +91,7 @@ Wire `renovate-config-validator` as a pre-commit hook so schema typos, deprecate
 
 - `--strict` — fail on configs that need migration (e.g. `fileMatch` → `managerFilePatterns`), not only on outright errors. Neither flag is upstream default; both go in `args`.
 - `--no-global` — treat the file as repo-level config. Without it the validator interprets it as global self-hosted config and misreports repo-only fields.
+- The validator does not resolve remote presets, so it cannot tell you an `extends` target is missing or that a shared preset changed under you.
 - Upstream docs: <https://docs.renovatebot.com/config-validation/>.
 
 ## Dashboard reading
@@ -79,14 +99,15 @@ Wire `renovate-config-validator` as a pre-commit hook so schema typos, deprecate
 Renovate opens a "Dependency Dashboard" issue. Read it before assuming a bug:
 
 - **Detected Dependencies** without `[Updates: ...]` = already current. Not a bug.
+- **Pending Status Checks** — the bake period holding an update back. Permanent residents here mean a missing no-timestamp carve-out.
 - **Repository Problems** — investigate. "Base branch does not exist" usually means a stale config reference or a transient mid-run state.
 - **Config Migration Needed** — Renovate offers an automated PR for field renames (e.g. `fileMatch` → `managerFilePatterns`, `baseBranches` → `baseBranchPatterns`). Tick the checkbox or hand-migrate.
 - **Open** — pending PRs; the per-row checkboxes force a rebase/retry.
 
 ## Procedure
 
-1. Confirm any field name you plan to write against current docs at `https://docs.renovatebot.com/configuration-options/<field>/` before editing. Renames slip in regularly (`fileMatch` → `managerFilePatterns`, `baseBranches` → `baseBranchPatterns`); memory and prior commits are not authoritative.
-2. Read `renovate.json` if present. Note the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` or the GitHub setting).
-3. **Greenfield** — write the Defaults block and the Supply-chain hardening block; fill `<owner>` and `<default-branch>`. Add custom regex managers for shell-script `*_VERSION=` pins or hard-coded release URLs. Add the `renovate-config-validator` pre-commit hook (see Validation).
-4. **Audit existing** — walk the Defaults, Supply-chain hardening, and custom-managers conventions; flag drift (still on `config:recommended`, missing `reviewers`, hard-coded `baseBranchPatterns` not matching the actual default, leftover deprecated fields like `fileMatch` or `baseBranches`, ungoverned `*_VERSION=` pins, missing `renovate-config-validator` pre-commit hook, missing `minimumReleaseAge` bake period or `vulnerabilityAlerts` carve-out, missing `schedule:weekly`).
+1. Confirm any field name, default, or preset body you plan to rely on against the source, not memory: defaults in `lib/config/options/index.ts`, preset bodies in `lib/config/presets/internal/*.preset.ts`. Docs summaries and prior commits drift — several fields once worth writing are now defaults.
+2. Read `renovate.json` if present, and any preset it extends.
+3. **Greenfield** — write the Defaults and Supply-chain hardening blocks. Add `customManagers` only for pins the annotation convention cannot reach. Add the `renovate-config-validator` pre-commit hook (see Validation).
+4. **Audit existing** — flag drift: fields that merely restate a default (`internalChecksFilter`, `vulnerabilityAlerts.minimumReleaseAge`, `baseBranchPatterns`), a no-timestamp carve-out that is missing or narrower than the eight update types, one manager per pin where an annotation would do, unannotated `*_VERSION=` pins (invisible to Renovate, so they look up-to-date forever), deprecated `fileMatch`/`baseBranches`, missing validator hook.
 5. Surface findings before editing. Apply only after scope is agreed.

--- a/renovate.json
+++ b/renovate.json
@@ -1,247 +1,55 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:weekly"],
-  "baseBranchPatterns": [
-    "main"
+  "extends": [
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "customManagers:githubActionsVersions"
   ],
+  "timezone": "Europe/London",
   "reviewers": ["alunduil"],
   "pre-commit": {
     "enabled": true
   },
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
-  "vulnerabilityAlerts": {
-    "minimumReleaseAge": "0 days"
-  },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "matchUpdateTypes": ["digest", "pin"],
-      "minimumReleaseAge": "0 days"
+      "description": "Update types with no release timestamp can never satisfy the bake, and internalChecksFilter defaults to strict, so without this they stall on a pending renovate/stability-days check forever",
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "minimumReleaseAge": null
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^script/install/bats-libs$/"],
-      "matchStrings": ["BATS_SUPPORT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "bats-core/bats-support",
+      "description": "Annotated *_VERSION pins in the install scripts and bootstrap passes",
+      "managerFilePatterns": ["script/install/*", ".chezmoiscripts/*.tmpl"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=\"(?<currentValue>.+?)\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Zellij plugins, pinned as release-asset URLs rather than a version assignment",
+      "managerFilePatterns": ["dot_config/zellij/config.kdl"],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"
+      ],
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^script/install/bats-libs$/"],
-      "matchStrings": ["BATS_ASSERT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "bats-core/bats-assert",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/bats\\.yml$/"],
-      "matchStrings": ["support-version: \"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "bats-core/bats-support",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/bats\\.yml$/"],
-      "matchStrings": ["assert-version: \"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "bats-core/bats-assert",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/zellij$/"],
-      "matchStrings": ["ZELLIJ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "zellij-org/zellij",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_.*\\.sh\\.tmpl$/"],
-      "matchStrings": ["NVM_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "nvm-sh/nvm",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/lazygit$/"],
-      "matchStrings": ["LAZYGIT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "jesseduffield/lazygit",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/act$/"],
-      "matchStrings": ["ACT_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "nektos/act",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/gcx$/"],
-      "matchStrings": ["GCX_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "grafana/gcx",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/lychee$/"],
-      "matchStrings": ["LYCHEE_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "lycheeverse/lychee",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^lychee-(?<version>v[\\d.]+)$"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/signal-cli$/"],
-      "matchStrings": ["SIGNAL_CLI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "AsamK/signal-cli",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/yq$/"],
-      "matchStrings": ["YQ_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "mikefarah/yq",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/truenas-mcp$/"],
-      "matchStrings": ["TRUENAS_MCP_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "truenas/truenas-mcp",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/vale$/"],
-      "matchStrings": ["VALE_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "vale-cli/vale",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/trivy$/"],
-      "matchStrings": ["TRIVY_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "aquasecurity/trivy",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/just$/"],
-      "matchStrings": ["JUST_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "casey/just",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/uv$/"],
-      "matchStrings": ["UV_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "astral-sh/uv",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_onchange_before_02-install-binary-tools\\.sh\\.tmpl$/"],
-      "matchStrings": ["PRE_COMMIT_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "pre-commit",
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/alloy$/"],
-      "matchStrings": ["ALLOY_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "grafana/alloy",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/prometheus$/"],
-      "matchStrings": ["PROMETHEUS_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "prometheus/prometheus",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/loki$/"],
-      "matchStrings": ["LOKI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "grafana/loki",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/tempo$/"],
-      "matchStrings": ["TEMPO_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "grafana/tempo",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^script/install/grafana$/"],
-      "matchStrings": ["GRAFANA_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "grafana/grafana",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_05-install-standalone-tools\\.sh\\.tmpl$/"],
-      "matchStrings": ["GH_POI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "seachicken/gh-poi",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
-      "matchStrings": ["NODE_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node-version",
-      "versioningTemplate": "node"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
-      "matchStrings": ["READWISE_CLI_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "@readwise/cli",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
-      "matchStrings": ["DEVCONTAINER_CLI_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "@devcontainers/cli",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_03-install-node-ecosystem\\.sh\\.tmpl$/"],
-      "matchStrings": ["PNPM_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "pnpm",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.chezmoiscripts/run_once_before_09-install-rust-ecosystem\\.sh\\.tmpl$/"],
-      "matchStrings": ["CARGO_CACHE_VERSION=\"(?<currentValue>[\\d.]+)\""],
-      "depNameTemplate": "cargo-cache",
-      "datasourceTemplate": "crate"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/dot_config/zellij/config\\.kdl$/"],
-      "matchStrings": ["https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>v[\\d.]+)/"],
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/chezmoi\\.yml$/"],
-      "matchStrings": ["CHEZMOI_VERSION: \"(?<currentValue>v[\\d.]+)\""],
-      "depNameTemplate": "twpayne/chezmoi",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^docs/tutorials/bootstrap\\.md$/"],
+      "description": "chezmoi pin in the bootstrap tutorial; annotating it would leak Renovate syntax into a copy-pasted snippet",
+      "managerFilePatterns": ["docs/tutorials/bootstrap.md"],
       "matchStrings": ["CHEZMOI_VERSION=\"(?<currentValue>v[\\d.]+)\""],
       "depNameTemplate": "twpayne/chezmoi",
       "datasourceTemplate": "github-releases"

--- a/script/checks/renovate-pins
+++ b/script/checks/renovate-pins
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Every pinned *_VERSION carries a `# renovate:` line above it, which is what
+# renovate.json's generic managers match on. A pin without one is not a
+# Renovate error -- it is simply never extracted, so it reads as permanently
+# up to date and silently rots. Nothing else notices, hence this check.
+
+set -euo pipefail
+
+SOURCE_DIR="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$SOURCE_DIR"
+
+fail=0
+while IFS= read -r file; do
+  awk -v f="$file" '
+    /^[[:space:]]*[A-Za-z0-9_]+_VERSION[=:][[:space:]]*"/ {
+      if (prev !~ /# renovate:/) {
+        printf "%s:%d:%s\n", f, NR, $0
+        rc = 1
+      }
+    }
+    { prev = $0 }
+    END { exit rc }
+  ' "$file" || fail=1
+done < <(git ls-files 'script/install/*' '.chezmoiscripts/*.tmpl' '.github/workflows/*.yml')
+
+if [ "$fail" -ne 0 ]; then
+  printf '%s: pins above lack a `# renovate: datasource=... depName=...` line\n' \
+    "${0##*/}" >&2
+  exit 1
+fi

--- a/script/install/act
+++ b/script/install/act
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=nektos/act
 ACT_VERSION="v0.2.89"
 ARCH="Linux_x86_64"
 

--- a/script/install/alloy
+++ b/script/install/alloy
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=grafana/alloy
 ALLOY_VERSION="v1.16.2"
 ARCH="linux-amd64"
 

--- a/script/install/bats-libs
+++ b/script/install/bats-libs
@@ -9,8 +9,10 @@ set -euo pipefail
 # *_VERSION lines; the matching *_SHA256 has no automated source, so a version
 # bump trips the sha check in CI until the hash is refreshed by hand (the
 # deliberate supply-chain checkpoint on every upgrade).
+# renovate: datasource=github-releases depName=bats-core/bats-support
 BATS_SUPPORT_VERSION="v0.3.0"
 BATS_SUPPORT_SHA256="7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f"
+# renovate: datasource=github-releases depName=bats-core/bats-assert
 BATS_ASSERT_VERSION="v2.2.4"
 BATS_ASSERT_SHA256="e305df20c4c36cba4570e10f1cd824efb1ae71d88b5ef474550781ebee04192f"
 

--- a/script/install/gcx
+++ b/script/install/gcx
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=grafana/gcx
 GCX_VERSION="v0.4.0"
 ARCH="linux_amd64"
 

--- a/script/install/grafana
+++ b/script/install/grafana
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=grafana/grafana
 GRAFANA_VERSION="v13.0.1"
 ARCH="linux-amd64"
 

--- a/script/install/just
+++ b/script/install/just
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # casey/just tags have no `v` prefix (unlike zellij/lazygit/act), so the
 # version variable and Renovate matcher both use bare semver.
+# renovate: datasource=github-releases depName=casey/just
 JUST_VERSION="1.51.0"
 ARCH="x86_64-unknown-linux-musl"
 

--- a/script/install/lazygit
+++ b/script/install/lazygit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=jesseduffield/lazygit
 LAZYGIT_VERSION="v0.62.2"
 ARCH="linux_x86_64"
 

--- a/script/install/loki
+++ b/script/install/loki
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=grafana/loki
 LOKI_VERSION="v3.7.2"
 ARCH="linux-amd64"
 

--- a/script/install/lychee
+++ b/script/install/lychee
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-(?<version>v[\d.]+)$
 LYCHEE_VERSION="v0.24.2"
 ARCH="x86_64-unknown-linux-musl"
 

--- a/script/install/prometheus
+++ b/script/install/prometheus
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=prometheus/prometheus
 PROMETHEUS_VERSION="v3.12.0"
 ARCH="linux-amd64"
 

--- a/script/install/signal-cli
+++ b/script/install/signal-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=AsamK/signal-cli
 SIGNAL_CLI_VERSION="v0.14.6"
 ARCH="Linux-native"
 

--- a/script/install/tempo
+++ b/script/install/tempo
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=grafana/tempo
 TEMPO_VERSION="v3.0.0"
 ARCH="linux_amd64"
 

--- a/script/install/trivy
+++ b/script/install/trivy
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=aquasecurity/trivy
 TRIVY_VERSION="v0.71.1"
 ARCH="Linux-64bit"
 

--- a/script/install/truenas-mcp
+++ b/script/install/truenas-mcp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=truenas/truenas-mcp
 TRUENAS_MCP_VERSION="v0.0.4"
 ARCH="linux-amd64"
 

--- a/script/install/uv
+++ b/script/install/uv
@@ -5,6 +5,7 @@ set -euo pipefail
 # variable and Renovate matcher both use bare semver. uv is the host's
 # Python-CLI installer: `uv tool install` gives pre-commit a reproducible,
 # pinned home without a system `pip --user` (blocked here under PEP 668).
+# renovate: datasource=github-releases depName=astral-sh/uv
 UV_VERSION="0.11.29"
 ARCH="x86_64-unknown-linux-musl"
 

--- a/script/install/vale
+++ b/script/install/vale
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=vale-cli/vale
 VALE_VERSION="v3.14.2"
 ARCH="Linux_64-bit"
 

--- a/script/install/yq
+++ b/script/install/yq
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION="v4.53.2"
 ARCH="linux_amd64"
 

--- a/script/install/zellij
+++ b/script/install/zellij
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=zellij-org/zellij
 ZELLIJ_VERSION="v0.44.3"
 ARCH="x86_64-unknown-linux-musl"
 


### PR DESCRIPTION
## Summary

`renovate.json` drops from 250 lines to 29 and no longer needs an edit per pinned tool: the metadata now sits as a `# renovate:` comment beside each pin, where three generic managers read it. Also fixes a live trap — the no-timestamp carve-out covered only `digest` and `pin`, but `config:best-practices` pulls in `:maintainLockFilesWeekly` and both digest-pinning presets, so `lockFileMaintenance` and `pinDigest` updates would park on a `renovate/stability-days` check that can never resolve, without ever opening a PR.

Closes #406

## Gotchas

- The carve-out uses `minimumReleaseAge: null`, not the `"0 days"` #406 suggested. Identical since Renovate 42.19.5, and `null` is what upstream's own `security:minimumReleaseAgeNpm` preset writes.
- Three deletions are no-ops, not policy changes: `internalChecksFilter: "strict"` and `vulnerabilityAlerts.minimumReleaseAge` restate Renovate's defaults verbatim (`lib/config/options/index.ts`), and `baseBranchPatterns` is auto-detected.
- `schedule:weekly` is gone, reversing #342. Updates now arrive as each three-day bake expires, rate-limited by the default `prHourlyLimit` of 2, rather than batched into Monday.
- `bats.yml`'s two action inputs moved to job-level `env:` so the upstream `customManagers:githubActionsVersions` preset reaches them; `extractVersion` strips the tag's leading `v`, which the action's inputs require.
- This config block is identical across all seven repos and belongs in a shared preset — alunduil/alunduil-infrastructure#311 stands up `renovate-config`; collapsing this block to a one-line `extends` is the follow-up.

## Verification

- Simulated the three repo managers plus the upstream preset regex over the working tree: 33 dependencies extracted, the same 33 the old config covered, with identical `depName`, `datasource` and `currentValue`.
- `script/checks/renovate-pins` passes on the clean tree and fails with `file:line` when an annotation is removed (checked by stripping `yq`'s, then restoring).
- `just check` green, including `actionlint` on both edited workflows.